### PR TITLE
Updates to macro usage and documentation updates

### DIFF
--- a/docs/components.md
+++ b/docs/components.md
@@ -17,33 +17,37 @@ These components are available on all operating systems (Windows, macOS, Linux).
 | **`virtual_clock`** | timing   | Native       | Alias to `real_clock` since time is a construct of our consciousness                                         |
 | **`current_rss`**   | memory   | Native       | The total size of the pages of memory allocated excluding swap                                               |
 | **`peak_rss`**      | memory   | Native       | The peak amount of utilized memory (resident-set size) at that point of execution ("high-water" memory mark) |
+| **`trip_count`**    | counting | Native       | Recording the number of trips through a section of code                                                      |
 
-## POSIX Components
+## System-Dependent Components
 
 > Namespace: `tim::component`
 
-These components are only available on POSIX systems. The components in the "resource usage" category are provided by POSIX `rusage` (`man getrusage`).
+These components are only available on certain operating systems. In general, all of these components are available for POSIX systems.
+The components in the "resource usage" category are provided by POSIX `rusage` (`man getrusage`).
 
-| Component Name                 | Category       | Dependencies | Description                                                                                                                                              |
-| ------------------------------ | -------------- | ------------ | -------------------------------------------------------------------------------------------------------------------------------------------------------- |
-| **`process_cpu_clock`**        | timing         | POSIX        | CPU timer that tracks the amount of CPU (in user- or kernel-mode) used by the calling process (excludes child processes)                                 |
-| **`thread_cpu_clock`**         | timing         | POSIX        | CPU timer that tracks the amount of CPU (in user- or kernel-mode) used by the calling thread (excludes sibling/child threads)                            |
-| **`process_cpu_util`**         | timing         | POSIX        | Percentage of process CPU time (`process_cpu_clock`) vs. wall-clock time                                                                                 |
-| **`thread_cpu_util`**          | timing         | POSIX        | Percentage of thread CPU time (`thread_cpu_clock`) vs. `wall_clock`                                                                                      |
-| **`monotonic_clock`**          | timing         | POSIX        | Real-clock timer that increments monotonically, unaffected by frequency or time adjustments, that increments while system is asleep                      |
-| **`monotonic_raw_clock`**      | timing         | POSIX        | Real-clock timer that increments monotonically, unaffected by frequency or time adjustments                                                              |
-| **`data_rss`**                 | memory         | POSIX        | Unshared memory residing the data segment of a process                                                                                                   |
-| **`stack_rss`**                | resource usage | POSIX        | Integral value of the amount of unshared memory residing in the stack segment of a process                                                               |
-| **`num_io_in`**                | resource usage | POSIX        | Number of times the file system had to perform input                                                                                                     |
-| **`num_io_out`**               | resource usage | POSIX        | Number of times the file system had to perform output                                                                                                    |
-| **`num_major_page_faults`**    | resource usage | POSIX        | Number of page faults serviced that required I/O activity                                                                                                |
-| **`num_minor_page_faults`**    | resource usage | POSIX        | Number of page faults serviced without any I/O activity<sup>[[1]](#fn1)</sup>                                                                            |
-| **`num_msg_recv`**             | resource usage | POSIX        | Number of IPC messages received                                                                                                                          |
-| **`num_msg_sent`**             | resource usage | POSIX        | Number of IPC messages sent                                                                                                                              |
-| **`num_signals`**              | resource usage | POSIX        | Number of signals delivered                                                                                                                              |
-| **`num_swap`**                 | resource_usage | POSIX        | Number of swaps out of main memory                                                                                                                       |
-| **`priority_context_switch`**  | resource usage | POSIX        | Number of times a context switch resulted due to a higher priority process becoming runnable or bc the current process exceeded its time slice.          |
-| **`voluntary_context_switch`** | resource usage | POSIX        | Number of times a context switch resulted due to a process voluntarily giving up the processor before its time slice was completed<sup>[[2]](#fn2)</sup> |
+| Component Name                 | Category       | Dependencies | Description                                                                                                                                                                                    |
+| ------------------------------ | -------------- | ------------ | ---------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`read_bytes`**               | I/O            | Linux/macOS  | Attempt to count the number of bytes which this process really did cause to be fetched from the storage layer. Done at the submit_bio() level, so it is accurate for block-backed filesystems. |
+| **`written_bytes`**            | I/O            | Linux/macOS  | Attempt to count the number of bytes which this process caused to be sent to the storage layer. This is done at page-dirtying time.                                                            |
+| **`process_cpu_clock`**        | timing         | POSIX        | CPU timer that tracks the amount of CPU (in user- or kernel-mode) used by the calling process (excludes child processes)                                                                       |
+| **`thread_cpu_clock`**         | timing         | POSIX        | CPU timer that tracks the amount of CPU (in user- or kernel-mode) used by the calling thread (excludes sibling/child threads)                                                                  |
+| **`process_cpu_util`**         | timing         | POSIX        | Percentage of process CPU time (`process_cpu_clock`) vs. wall-clock time                                                                                                                       |
+| **`thread_cpu_util`**          | timing         | POSIX        | Percentage of thread CPU time (`thread_cpu_clock`) vs. `wall_clock`                                                                                                                            |
+| **`monotonic_clock`**          | timing         | POSIX        | Real-clock timer that increments monotonically, unaffected by frequency or time adjustments, that increments while system is asleep                                                            |
+| **`monotonic_raw_clock`**      | timing         | POSIX        | Real-clock timer that increments monotonically, unaffected by frequency or time adjustments                                                                                                    |
+| **`data_rss`**                 | resource usage | POSIX        | Unshared memory residing the data segment of a process                                                                                                                                         |
+| **`stack_rss`**                | resource usage | POSIX        | Integral value of the amount of unshared memory residing in the stack segment of a process                                                                                                     |
+| **`num_io_in`**                | resource usage | POSIX        | Number of times the file system had to perform input                                                                                                                                           |
+| **`num_io_out`**               | resource usage | POSIX        | Number of times the file system had to perform output                                                                                                                                          |
+| **`num_major_page_faults`**    | resource usage | POSIX        | Number of page faults serviced that required I/O activity                                                                                                                                      |
+| **`num_minor_page_faults`**    | resource usage | POSIX        | Number of page faults serviced without any I/O activity<sup>[[1]](#fn1)</sup>                                                                                                                  |
+| **`num_msg_recv`**             | resource usage | POSIX        | Number of IPC messages received                                                                                                                                                                |
+| **`num_msg_sent`**             | resource usage | POSIX        | Number of IPC messages sent                                                                                                                                                                    |
+| **`num_signals`**              | resource usage | POSIX        | Number of signals delivered                                                                                                                                                                    |
+| **`num_swap`**                 | resource_usage | POSIX        | Number of swaps out of main memory                                                                                                                                                             |
+| **`priority_context_switch`**  | resource usage | POSIX        | Number of times a context switch resulted due to a higher priority process becoming runnable or bc the current process exceeded its time slice.                                                |
+| **`voluntary_context_switch`** | resource usage | POSIX        | Number of times a context switch resulted due to a process voluntarily giving up the processor before its time slice was completed<sup>[[2]](#fn2)</sup>                                       |
 
 <a name="fn1">[1]</a>: Here I/O activity is avoided by reclaiming a page frame from the list of pages awaiting reallocation
 
@@ -53,9 +57,10 @@ These components are only available on POSIX systems. The components in the "res
 
 > Namespace: `tim::component`
 
-| Component Name | Category | Dependencies | Description                                      |
-| -------------- | -------- | ------------ | ------------------------------------------------ |
-| **`cuda_event`** | timing   | CUDA runtime | Elapsed time between two points in a CUDA stream |
+| Component Name    | Category      | Dependencies | Description                                                                 |
+| ----------------- | ------------- | ------------ | --------------------------------------------------------------------------- |
+| **`cuda_event`**  | timing        | CUDA runtime | Elapsed time between two points in a CUDA stream                            |
+| **`nvtx_marker`** | external tool | CUDA runtime | Inserts CUDA NVTX markers into the code for `nvprof` and/or `NsightSystems` |
 
 ## Hardware Counter Components
 
@@ -116,43 +121,231 @@ All the components listed above can be used directly but it is recommended to us
 The variadic wrapper types provide bulk operations on all the specified types, e.g. `start()` member function
 that calls `start()` on all the specified types.
 
-| Type                       | Description                                                                                        |
-| -------------------------- | -------------------------------------------------------------------------------------------------- |
-| **`component_tuple<...>`** |                                                                                                    |
-| **`component_list<...>`**  | Specified types are wrapped into pointers and initially null. Operations applied to non-null types |
-| **`auto_tuple<...>`**      | `component_tuple<...>` + auto start/stop via scope                                                 |
-| **`auto_list<...>`**       | `component_list<...>` + auto start/stop via scope                                                  |
+| Type                               | Description                                                                                                                                                                                                                |
+| ---------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| **`component_tuple<...>`**         |                                                                                                                                                                                                                            |
+| **`component_list<...>`**          | Specified types are wrapped into pointers and initially null. Operations applied to non-null types.                                                                                                                        |
+| **`component_hybrid<Tuple,List>`** | Provides static (compile-time enabled) reporting for components specified in `Tuple` (`tim::component_tuple<...>`) and dynamic (runtime-enabled) reporting for components specified in `List` (`tim::component_list<...>`) |
+| **`auto_tuple<...>`**              | `component_tuple<...>` + auto start/stop via scope                                                                                                                                                                         |
+| **`auto_list<...>`**               | `component_list<...>` + auto start/stop via scope                                                                                                                                                                          |
+| **`auto_hybrid<Tuple,List>`**      | `component_hybrid<Tuple, List>` + auto start/stop via scope                                                                                                                                                                |
 
 ### Example
 
 ```cpp
+
 #include <timemory/timemory.hpp>
-#include <thread>
-#include <chrono>
+
+#include <cstdint>
+#include <cstdio>
+
+//--------------------------------------------------------------------------------------//
+//
+//      TiMemory specifications
+//
+//--------------------------------------------------------------------------------------//
 
 using namespace tim::component;
-using auto_tuple_t = tim::auto_tuple<real_clock, cpu_clock, cpu_util, peak_rss>;
-using auto_list_t  = tim::auto_list<real_clock, cpu_clock, cpu_util, peak_rss>;
 
-void some_func()
+// specify a component_tuple and it's auto type
+using tuple_t      = tim::component_tuple<real_clock, cpu_clock>;
+using auto_tuple_t = typename tuple_t::auto_type;
+
+using list_t      = tim::component_list<cpu_util, peak_rss>;
+using auto_list_t = typename list_t::auto_type;
+
+// specify hybrid of: a tuple (always-on) and a list (optional) and the auto type
+using hybrid_t      = tim::component_hybrid<tuple_t, list_t>;
+using auto_hybrid_t = typename hybrid_t::auto_type;
+
+//--------------------------------------------------------------------------------------//
+//
+//      Pre-declarations of implementation details
+//
+//--------------------------------------------------------------------------------------//
+
+void do_alloc(uint64_t);
+void do_sleep(uint64_t);
+void do_work(uint64_t);
+
+//--------------------------------------------------------------------------------------//
+//
+//      Measurement functions
+//
+//--------------------------------------------------------------------------------------//
+
+void
+tuple_func()
 {
-    auto_tuple_t at("some_func");
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    auto_tuple_t at("tuple_func");
+    do_alloc(100 * tim::units::get_page_size());
+    do_sleep(750);
+    do_work(250);
 }
 
-void another_func()
+void
+list_func()
 {
-    auto_list_t al("another_func");
-    std::this_thread::sleep_for(std::chrono::seconds(1));
+    auto_list_t al("list_func");
+    do_alloc(250 * tim::units::get_page_size());
+    do_sleep(250);
+    do_work(750);
 }
 
-int main()
+void
+hybrid_func()
 {
-    // runtime customization of auto_list_t
-    auto_list_t::get_initializer() = [](auto_list_t& al)
-    { al.initialize<real_clock, cpu_clock, cpu_util, peak_rss>(); };
-
-    some_func();
-    another_func();
+    auto_hybrid_t ah("hybrid_func");
+    do_alloc(500 * tim::units::get_page_size());
+    do_sleep(500);
+    do_work(500);
 }
+
+//--------------------------------------------------------------------------------------//
+//
+//      Main
+//
+//--------------------------------------------------------------------------------------//
+
+int
+main()
+{
+    auto_hybrid_t ah(__FUNCTION__);
+    tuple_func();
+    list_func();
+    hybrid_func();
+}
+
+//--------------------------------------------------------------------------------------//
+//
+//      Implementation details
+//
+//--------------------------------------------------------------------------------------//
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <random>
+#include <thread>
+
+template <typename _Tp>
+size_t
+random_entry(const std::vector<_Tp>& v)
+{
+    // this function is provided to make sure memory allocation is not optimized away
+    std::mt19937 rng;
+    rng.seed(std::random_device()());
+    std::uniform_int_distribution<std::mt19937::result_type> dist(0, v.size() - 1);
+    return v.at(dist(rng));
+}
+
+uint64_t
+fibonacci(uint64_t n)
+{
+    // this function is provided to make sure memory allocation is not optimized away
+    return (n < 2) ? n : (fibonacci(n - 1) + fibonacci(n - 2));
+}
+
+void
+do_alloc(uint64_t nsize)
+{
+    // this function allocates approximately nsize bytes of memory
+    std::vector<uint64_t> v(nsize, 15);
+    uint64_t              nfib = random_entry(v);
+    auto                  ret  = fibonacci(nfib);
+    printf("fibonacci(%li) = %li\n", (uint64_t) nfib, ret);
+}
+
+void
+do_sleep(uint64_t n)
+{
+    // this function does approximately "n" milliseconds of real time
+    std::this_thread::sleep_for(std::chrono::milliseconds(n));
+}
+
+void
+do_work(uint64_t n)
+{
+    // this function does approximately "n" milliseconds of cpu time
+    using mutex_t   = std::mutex;
+    using lock_t    = std::unique_lock<mutex_t>;
+    using condvar_t = std::condition_variable;
+    mutex_t mutex;
+    lock_t  hold_lk(mutex);
+    lock_t  try_lk(mutex, std::defer_lock);
+    auto    now   = std::chrono::system_clock::now();
+    auto    until = now + std::chrono::milliseconds(n);
+    while(std::chrono::system_clock::now() < until)
+        try_lk.try_lock();
+}
+```
+
+#### Compile
+
+```console
+g++ -O3 -std=c++11 -I/opt/timemory/include test_example.cpp -o test_example
+```
+
+#### Standard Execution (no `cpu_util` or `peak_rss`)
+
+```console
+./test_example
+```
+
+#### Standard Output (no `cpu_util` or `peak_rss`)
+
+```console
+fibonacci(15) = 610
+fibonacci(15) = 610
+fibonacci(15) = 610
+
+[real]> Outputting 'timemory_output/real.txt'... Done
+
+> [cxx] main          :    3.021 sec real, 1 laps, depth 0 (exclusive:  33.4%)
+> [cxx] |_tuple_func  :    1.003 sec real, 1 laps, depth 1
+> [cxx] |_hybrid_func :    1.010 sec real, 1 laps, depth 1
+
+[cpu]> Outputting 'timemory_output/cpu.txt'... Done
+
+> [cxx] main          :    1.500 sec cpu, 1 laps, depth 0 (exclusive:  50.0%)
+> [cxx] |_tuple_func  :    0.250 sec cpu, 1 laps, depth 1
+> [cxx] |_hybrid_func :    0.500 sec cpu, 1 laps, depth 1
+```
+
+#### Enabling `cpu_util` and `peak_rss` at Runtime
+
+```console
+TIMEMORY_COMPONENT_LIST_INIT="cpu_util,peak_rss" ./test_example
+```
+
+#### Enabling `cpu_util` and `peak_rss` at Runtime Output
+
+```console
+fibonacci(15) = 610
+fibonacci(15) = 610
+fibonacci(15) = 610
+
+[peak_rss]> Outputting 'timemory_output/peak_rss.txt'... Done
+
+> [cxx] main          :  27.9 MB peak_rss, 1 laps, depth 0 (exclusive:  11.9%)
+> [cxx] |_list_func   :   8.2 MB peak_rss, 1 laps, depth 1
+> [cxx] |_hybrid_func :  16.4 MB peak_rss, 1 laps, depth 1
+
+[cpu_util]> Outputting 'timemory_output/cpu_util.txt'... Done
+
+> [cxx] main          :   49.7 % cpu_util, 1 laps, depth 0
+> [cxx] |_list_func   :   74.6 % cpu_util, 1 laps, depth 1
+> [cxx] |_hybrid_func :   49.6 % cpu_util, 1 laps, depth 1
+
+[real]> Outputting 'timemory_output/real.txt'... Done
+
+> [cxx] main          :    3.016 sec real, 1 laps, depth 0 (exclusive:  33.3%)
+> [cxx] |_tuple_func  :    1.002 sec real, 1 laps, depth 1
+> [cxx] |_hybrid_func :    1.009 sec real, 1 laps, depth 1
+
+[cpu]> Outputting 'timemory_output/cpu.txt'... Done
+
+> [cxx] main          :    1.500 sec cpu, 1 laps, depth 0 (exclusive:  50.0%)
+> [cxx] |_tuple_func  :    0.250 sec cpu, 1 laps, depth 1
+> [cxx] |_hybrid_func :    0.500 sec cpu, 1 laps, depth 1
 ```

--- a/docs/features.md
+++ b/docs/features.md
@@ -33,7 +33,7 @@ using auto_tuple_t = tim::auto_tuple<real_clock, system_clock, cpu_clock, cpu_ut
 
 void some_function()
 {
-    TIMEMORY_AUTO_TUPLE(auto_tuple_t, "");
+    TIMEMORY_OBJECT(auto_tuple_t, "");
     // ...
 }
 ```

--- a/docs/getting_started/basics.md
+++ b/docs/getting_started/basics.md
@@ -15,7 +15,7 @@ In C++ and Python, TiMemory can be added in one line of code (once the type is d
 using auto_tuple_t = tim::auto_tuple<real_clock, cpu_clock, peak_rss>;
 void some_function()
 {
-    TIMEMORY_AUTO_TUPLE(auto_tuple_t, "");
+    TIMEMORY_OBJECT(auto_tuple_t, "");
     // ...
 }
 ```
@@ -26,7 +26,7 @@ void some_function()
 using auto_tuple_t = tim::auto_tuple<real_clock, cpu_clock, peak_rss, cuda_event>;
 void some_function()
 {
-    TIMEMORY_AUTO_TUPLE(auto_tuple_t, "");
+    TIMEMORY_OBJECT(auto_tuple_t, "");
     // ...
 }
 ```
@@ -42,10 +42,11 @@ def some_function():
 ### C
 
 In C, TiMemory requires only two lines of code
+
 ```c
-void* timer = TIMEMORY_AUTO_TUPLE("", WALL_CLOCK, SYS_CLOCK, USER_CLOCK, PEAK_RSS, CUDA_EVENT);
+void* timer = TIMEMORY_OBJECT("", WALL_CLOCK, SYS_CLOCK, USER_CLOCK, PEAK_RSS, CUDA_EVENT);
 // ...
-FREE_TIMEMORY_AUTO_TUPLE(timer);
+FREE_TIMEMORY_OBJECT(timer);
 ```
 
 When the application terminates, output to text and JSON is automated or controlled via
@@ -97,7 +98,7 @@ using comp_tuple_t = typename auto_tuple_t::component_type;
 intmax_t
 fibonacci(intmax_t n)
 {
-    TIMEMORY_BASIC_AUTO_TUPLE(real_tuple_t, "");
+    TIMEMORY_BASIC_OBJECT(real_tuple_t, "");
     return (n < 2) ? n : fibonacci(n - 1) + fibonacci(n - 2);
 }
 
@@ -120,7 +121,7 @@ main(int argc, char** argv)
     for(auto n : { 10, 11, 12 })
     {
         // create a caliper handle to an auto_tuple_t and have it report when destroyed
-        TIMEMORY_BLANK_AUTO_TUPLE_CALIPER(fib, auto_tuple_t, "fibonacci(", n, ")");
+        TIMEMORY_BLANK_CALIPER(fib, auto_tuple_t, "fibonacci(", n, ")");
         TIMEMORY_CALIPER_APPLY(fib, report_at_exit, true);
         // run calculation
         auto ret = fibonacci(n);

--- a/docs/getting_started/custom_components.md
+++ b/docs/getting_started/custom_components.md
@@ -50,11 +50,26 @@ provide data via the POSIX rusage struct on Windows.
 
 > Namespace: `tim::trait`
 
-| Type Trait                        | Description                                                                                                                                  | Default Setting   |
-| --------------------------------- | -------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `tim::trait::record_max`          | Specify that arithmetic operations should use comparisions                                                                                   | `std::false_type` |
-| `tim::trait::is_available`        | Specify the availablity of the component's implementation                                                                                    | `std::true_type`  |
-| `tim::trait::array_serialization` | Specify the component stores data as an array and invoke `_array` variants of `label`, `descript`, `display_unit`, and `unit` function calls | `std::false_type` |
+
+| Type Trait                     | Description                                                                            | Default Setting   |
+| ------------------------------ | -------------------------------------------------------------------------------------- | ----------------- |
+| **`record_max`**               | Specify that arithmetic operations should use comparisions                             | `std::false_type` |
+| **`array_serialization`**      | Specify the component stores data as an array                                          | `std::false_type` |
+| **`is_available`**             | Specify the availablity of the component's implementation                              | `std::true_type`  |
+| **`external_output_handling`** | Specify the component handles it's own output (if any)                                 | `std::false_type` |
+| **`requires_prefix`**          | Specify the component requires a `prefix` member variable to be set before `start()`   | `std::false_type` |
+| **`custom_label_printing`**    | Specify the component provides its own labeling for output (typically multiple labels) | `std::false_type` |
+| **`custom_unit_printing`**     | Specify the component provides its own units for output (typically multiple units)     | `std::false_type` |
+| **`custom_laps_printing`**     | Specify the component provides its own "lap" printing for output                       | `std::false_type` |
+| **`start_priority`**           | Specify the component should be started before non-prioritized components              | `std::false_type` |
+| **`stop_priority`**            | Specify the component should be stopped before non-prioritized components              | `std::false_type` |
+| **`is_timing_category`**       | Designates the width and precision should apply environment-specified timing settings  | `std::false_type` |
+| **`is_memory_category`**       | Designates the width and precision should apply environment-specified memory settings  | `std::false_type` |
+| **`uses_timing_units`**        | Designates the width and precision should apply environment-specified timing units     | `std::false_type` |
+| **`uses_memory_units`**        | Designates the width and precision should apply environment-specified memory units     | `std::false_type` |
+| **`requires_json`**            | Specify the component should always output the JSON file format                        | `std::false_type` |
+
+> `tim::trait::array_serialization` trait causes invocation of `_array` variants of `label`, `descript`, `display_unit`, and `unit` function calls, e.g. `label_array()`
 
 ### Type Traits Example
 
@@ -93,13 +108,13 @@ and their inclusion requires the definition of an associated static member funct
 
 > Namespace: `tim::policy`
 
-| Policy                         | Associated Static Member Function                     | Invocation Context                             |
-| ------------------------------ | ----------------------------------------------------- | ---------------------------------------------- |
-| `tim::policy::global_init`     | `void invoke_global_init()`                           | Initial creation of component within a process |
-| `tim::policy::global_finalize` | `void invoke_global_finalize()`                       | Termination of process (application cleanup)   |
-| `tim::policy::thread_init`     | `void invoke_thread_init()`                           | Initial creation of component within a thread  |
-| `tim::policy::thread_finalize` | `void invoke_thread_finalize()`                       | Termination of thread (thread cleanup)         |
-| `tim::policy::serialization`   | `template <typename Archive> void invoke_serialize()` | Serialization to JSON                          |
+| Policy                             | Associated Static Member Function                     | Invocation Context                             |
+| ---------------------------------- | ----------------------------------------------------- | ---------------------------------------------- |
+| **`tim::policy::global_init`**     | `void invoke_global_init()`                           | Initial creation of component within a process |
+| **`tim::policy::global_finalize`** | `void invoke_global_finalize()`                       | Termination of process (application cleanup)   |
+| **`tim::policy::thread_init`**     | `void invoke_thread_init()`                           | Initial creation of component within a thread  |
+| **`tim::policy::thread_finalize`** | `void invoke_thread_finalize()`                       | Termination of thread (thread cleanup)         |
+| **`tim::policy::serialization`**   | `template <typename Archive> void invoke_serialize()` | Serialization to JSON                          |
 
 In general, the `global_init` policy is used to define an operation that occur prior to recording any component of this
 type, e.g. parse environment of any relevant settings; the `global_finalize` policy is used to define an operation that
@@ -112,22 +127,22 @@ adding the peak data to a roofline component.
 
 ## Custom Component Example
 
-| Required                  | Type                      | Description                                                             |
-| ------------------------- | ------------------------- | ----------------------------------------------------------------------- |
-| `value_type`              | Alias/typedef             | Data type used for storage                                              |
-| `base_type`               | Alias/typedef             | Base type specification                                                 |
-| `precision`               | Constant integer          | Default output precision                                                |
-| `width`                   | Constant integer          | Default output width                                                    |
-| `format_flags`            | `std::ios_base::fmtflags` | Bitset of formatting flags                                              |
-| `unit()`                  | numerical value           | Units of data type                                                      |
-| `label()`                 | string                    | Short-hand description without spaces                                   |
-| `descript()`              | string                    | Full description of component                                           |
-| `display_unit()`          | string                    | String representation of `unit()`                                       |
-| `record()`                | static function           | How to measure/record data type of component (must return `value_type`) |
-| `get() const`             | const member function     | Returns the current measurement                                         |
-| `compute_display() const` | const member function     | Returns the current measurement in for desired for reporting            |
-| `start()`                 | member function           | Defines operation when component recording is started                   |
-| `stop()`                  | member function           | Defines operation when component recording is stopped                   |
+| Required              | Type                      | Description                                                             |
+| --------------------- | ------------------------- | ----------------------------------------------------------------------- |
+| `value_type`          | Alias/typedef             | Data type used for storage                                              |
+| `base_type`           | Alias/typedef             | Base type specification                                                 |
+| `precision`           | Constant integer          | Default output precision                                                |
+| `width`               | Constant integer          | Default output width                                                    |
+| `format_flags`        | `std::ios_base::fmtflags` | Bitset of formatting flags                                              |
+| `unit()`              | numerical value           | Units of data type                                                      |
+| `label()`             | string                    | Short-hand description without spaces                                   |
+| `descript()`          | string                    | Full description of component                                           |
+| `display_unit()`      | string                    | String representation of `unit()`                                       |
+| `record()`            | static function           | How to measure/record data type of component (must return `value_type`) |
+| `get() const`         | const member function     | Returns the current measurement                                         |
+| `get_display() const` | const member function     | Returns the current measurement in format desired for reporting         |
+| `start()`             | member function           | Defines operation when component recording is started                   |
+| `stop()`              | member function           | Defines operation when component recording is stopped                   |
 
 ```cpp
 struct real_clock : public base<real_clock, int64_t>

--- a/docs/getting_started/integrating.md
+++ b/docs/getting_started/integrating.md
@@ -120,7 +120,9 @@ The following table provides the relevant translation for projects that use Make
 ## Optional TiMemory Usage
 
 If you want to make TiMemory optional (i.e. a soft dependency), this can be easily done with a _very_
-minimal amount of code intrusion and without numerous `#ifdef` blocks.
+minimal amount of code intrusion and without numerous `#ifdef` blocks. If you include timemory in
+your source tree, this can be accomplished by defining `DISABLE_TIMEMORY` during compilation or
+before `#include <timemory/timemory.hpp>` (C++ language) or `#include <timemory/ctimemory.h>` (C language).
 
 In general, there are two steps and an optional third if you want to use the preload interface.
 
@@ -131,6 +133,8 @@ In general, there are two steps and an optional third if you want to use the pre
 3. (Optional) Declare the extern "C" interface functions in the header file
 
 ### Header file
+
+#### Language: C++
 
 > Reference: `examples/ex-optional/test_optional.hpp`
 
@@ -143,24 +147,99 @@ In general, there are two steps and an optional third if you want to use the pre
 
 #else
 
+#    include <ostream>
 #    include <string>
-#    define TIMEMORY_AUTO_TUPLE(...)
-#    define TIMEMORY_BASIC_AUTO_TUPLE(...)
-#    define TIMEMORY_BLANK_AUTO_TUPLE(...)
-#    define TIMEMORY_AUTO_TUPLE_CALIPER(...)
-#    define TIMEMORY_BASIC_AUTO_TUPLE_CALIPER(...)
-#    define TIMEMORY_BLANK_AUTO_TUPLE_CALIPER(...)
-#    define TIMEMORY_CALIPER_APPLY(...)
 
 namespace tim
 {
-void print_env() {}
-void timemory_init(int, char**, const std::string& = "", const std::string& = "") {}
-void timemory_init(const std::string&, const std::string& = "", const std::string& = "")
-{}
-}
+void                              print_env() {}
+template <typename... _Args> void timemory_init(_Args...) {}
+void                              timemory_finalize() {}
+
+/// this provides "functionality" for *_INSTANCE macros
+/// and can be omitted if these macros are not utilized
+struct dummy
+{
+    template <typename... _Args> dummy(_Args&&...) {}
+    ~dummy()            = default;
+    dummy(const dummy&) = default;
+    dummy(dummy&&)      = default;
+    dummy& operator=(const dummy&) = default;
+    dummy& operator=(dummy&&) = default;
+
+    void                              start() {}
+    void                              stop() {}
+    void                              conditional_start() {}
+    void                              conditional_stop() {}
+    void                              report_at_exit(bool) {}
+    template <typename... _Args> void mark_begin(_Args&&...) {}
+    template <typename... _Args> void mark_end(_Args&&...) {}
+    friend std::ostream& operator<<(std::ostream& os, const dummy&) { return os; }
+};
+}  // namespace tim
+
+// creates a label
+#    define TIMEMORY_BASIC_LABEL(...) std::string("")
+#    define TIMEMORY_LABEL(...) std::string("")
+
+// define an object
+#    define TIMEMORY_BLANK_OBJECT(...)
+#    define TIMEMORY_BASIC_OBJECT(...)
+#    define TIMEMORY_OBJECT(...)
+
+// define an object with a caliper reference
+#    define TIMEMORY_BLANK_CALIPER(...)
+#    define TIMEMORY_BASIC_CALIPER(...)
+#    define TIMEMORY_CALIPER(...)
+#    define TIMEMORY_CALIPER_APPLY(...)
+#    define TIMEMORY_CALIPER_TYPE_APPLY(...)
+
+// define an object
+#    define TIMEMORY_BLANK_INSTANCE(...) tim::dummy()
+#    define TIMEMORY_BASIC_INSTANCE(...) tim::dummy()
+#    define TIMEMORY_INSTANCE(...) tim::dummy()
+
+// debug only
+#    define TIMEMORY_DEBUG_BASIC_OBJECT(...)
+#    define TIMEMORY_DEBUG_OBJECT(...)
+#    define TIMEMORY_DEBUG_BASIC_OBJECT(...)
+#    define TIMEMORY_DEBUG_OBJECT(...)
+
+// for CUDA
+#    define TIMEMORY_CALIPER_MARK_STREAM_BEGIN(...)
+#    define TIMEMORY_CALIPER_MARK_STREAM_END(...)
 
 #endif
+```
+
+#### Language: C
+
+```c
+#pragma once
+
+#if defined(USE_TIMEMORY)
+
+#    include <timemory/ctimemory.h>
+
+#else
+
+#    define TIMEMORY_SETTINGS_INIT { }
+#    define TIMEMORY_INIT(...)
+
+// legacy
+#    define TIMEMORY_BLANK_AUTO_TIMER(...) NULL
+#    define TIMEMORY_BASIC_AUTO_TIMER(...) NULL
+#    define TIMEMORY_AUTO_TIMER(...) NULL
+#    define FREE_TIMEMORY_AUTO_TIMER(...)
+
+// modern
+#    define TIMEMORY_BASIC_OBJECT(...) NULL
+#    define TIMEMORY_BLANK_OBJECT(...) NULL
+#    define TIMEMORY_OBJECT(...) NULL
+#    define FREE_TIMEMORY_OBJECT(...)
+
+#endif
+
 ```
 
 ## TiMemory Preload Interface

--- a/docs/getting_started/roofline.md
+++ b/docs/getting_started/roofline.md
@@ -60,6 +60,7 @@ python -m timemory.roofline -- ./test_cxx_roofline
 | `-d`, `--display`     | bool       | Open a window with the plot                            |
 | `-o`, `--output-file` | bool       | Output filename of roofline plot                       |
 | `-D`, `--output-dir`  | bool       | Output directory for plot                              |
+| `-n`, `--num-threads` | integer    | Number of threads for the peak roofline calculation    |
 | `--format`            | bool       | Image format to render                                 |
 
 ## Customizing the calculation of the "roof" for the Roofline
@@ -84,13 +85,13 @@ cpu_roofline_dp_flops::get_finalize_threads_function() = []() { return 1; };
 
 ## Full Customization of the Roofline Model
 
-Full customization of the roofline model can be accomplished by changing the `get_finalize_function()` of
+Full customization of the roofline model can be accomplished by changing the `get_finalizer()` of
 the roofline component. See documentation on [exec_params](#execution-parameters) and [operation_counter](#operation-counter)
 for more detail about these types.
 
 ```cpp
     // overload the finalization function that runs ERT calculations
-    tim::component::cpu_roofline_dp_flops::get_finalize_function() = [=]() {
+    tim::component::cpu_roofline_dp_flops::get_finalizer() = [=]() {
 
         // these are the kernel functions we want to calculate the peaks with
         auto store_func = [](double& a, const double& b) { a = b; };

--- a/docs/overhead.md
+++ b/docs/overhead.md
@@ -1,116 +1,332 @@
 # Overhead
 
-Analysis on a fibonacci calculation determined that one TiMemory "component" adds an average overhead of 3 microseconds (`0.000003 s`) when the component is being inserted into call-graph for the first time. Once a component exists in
-the call-graph, the overhead is approximately 1.25 microseconds. For example, in the following:
+Analysis on a fibonacci calculation determined that one TiMemory "component" adds an average overhead of 1 microsecond (`0.000001 s`) when the component
+is being inserted into call-graph for the first time.
+Once a component exists in the call-graph, the overhead is approximately 0.85 microseconds (`0.00000085 s`).
+However, this is for a **_VERY_** large number of measurements, when the number of measurements are kept within a reasonable range (approximately <= 10,000 - 15,000)
+and number of unique measurements is kept to a minimum, depending on cache re-use, timemory can have **_ZERO_** overhead.
 
-```c++
+| Unique Measurements | Total Measurements | No Measurements (sec) | Using Measurements (sec) | Difference (sec) | Avg. Overhead (sec) |
+| :-----------------: | :----------------: | :-------------------: | :----------------------: | :--------------: | :-----------------: |
+|       16,720        |       16,720       |       1.352e+00       |        1.350e+00         |    -2.421e-03    |     -1.440e-07      |
+|         16          |       27,056       |       1.365e+00       |        1.353e+00         |    -1.199e-02    |     -4.430e-07      |
+|      2,056,912      |     2,056,912      |       1.367e+00       |        3.425e+00         |    2.059e+00     |      1.000e-06      |
+|         27          |     2,056,912      |       1.365e+00       |        3.103e+00         |    1.738e+00     |      8.450e-07      |
+
+> The exact performance is specific to the machine and the overhead for a particular machine can be calculated by running/modifying the `test_cxx_overhead` example
+> in `examples/ex-cxx-overhead`.
+
+## Test Problem
+
+The following pair of fibonacci functions provide an almost direct measurment of the overhead of timemory.
+Aside from the creation, starting, stopping, storing, and accumulation of the timemory components, the fibonacci calculation is a simple
+but highly scalable calculation that just adds a large number of integers together.
+
+```cpp
+int64_t fibonacci(int64_t n) { return (n < 2) ? n : (fibonacci(n - 1) + fibonacci(n - 2)); }
+
 int64_t
 fibonacci(int64_t n, int64_t cutoff)
 {
+    using auto_tuple_t = tim::auto_tuple<real_clock, system_clock, user_clock, trip_count>;
     if(n > cutoff)
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(tim::auto_tuple<real_clock>, "[", n, "]");
-        return (n < 2) ? n : (fibonacci(n - 2, cutoff) + fibonacci(n - 1, cutoff));
+        nlaps += auto_tuple_t::size();
+        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[", n, "]");
+        return (n < 2) ? n : (fibonacci(n - 1, cutoff) + fibonacci(n - 2, cutoff));
     }
-    return fibonacci(n); // standard fibonacci (no timers)
+    return fibonacci(n);
 }
 ```
 
-every single instance is unique and the overhead fibonacci(43, 16) produces 514191 unique timers:
+In order to re-use measurements (reduce unique measurements), we make the following modification:
 
-```shell
-> [cxx] run [with timing = false]@'test_cxx_overhead.cpp':110             : 1.667e+00 sec real, 1 laps
-> [cxx] run [with timing =  true]@'test_cxx_overhead.cpp':110             : 2.782e+00 sec real, 1 laps
-> [cxx] fibonacci[43]                                                     : 2.782e+00 sec real, 1 laps
-> [cxx] |_fibonacci[41]                                                   : 1.033e+00 sec real, 1 laps
-> [cxx]   |_fibonacci[39]                                                 : 3.868e-01 sec real, 1 laps
-> [cxx]     |_fibonacci[37]                                               : 1.467e-01 sec real, 1 laps
-> [cxx]       |_fibonacci[35]                                             : 5.519e-02 sec real, 1 laps
-> [cxx]         |_fibonacci[33]                                           : 2.151e-02 sec real, 1 laps
-> [cxx]           |_fibonacci[31]                                         : 8.197e-03 sec real, 1 laps
-> [cxx]             |_fibonacci[29]                                       : 3.063e-03 sec real, 1 laps
-> [cxx]               |_fibonacci[27]                                     : 1.148e-03 sec real, 1 laps
-> [cxx]                 |_fibonacci[25]                                   : 4.421e-04 sec real, 1 laps
-> [cxx]                   |_fibonacci[23]                                 : 1.718e-04 sec real, 1 laps
-> [cxx]                     |_fibonacci[21]                               : 6.159e-05 sec real, 1 laps
-> [cxx]                       |_fibonacci[19]                             : 2.116e-05 sec real, 1 laps
-> [cxx]                         |_fibonacci[17]                           : 6.281e-06 sec real, 1 laps
-> [cxx]                         |_fibonacci[18]                           : 1.172e-05 sec real, 1 laps
-> [cxx]                           |_fibonacci[17]                         : 6.146e-06 sec real, 1 laps
-> [cxx]                       |_fibonacci[20]                             : 3.766e-05 sec real, 1 laps
-> [cxx]                         |_fibonacci[18]                           : 1.156e-05 sec real, 1 laps
-> [cxx]                           |_fibonacci[17]                         : 6.183e-06 sec real, 1 laps
-> [cxx]                         |_fibonacci[19]                           : 2.318e-05 sec real, 1 laps
-> [cxx]                           |_fibonacci[17]                         : 6.166e-06 sec real, 1 laps
-> [cxx]                           |_fibonacci[18]                         : 1.319e-05 sec real, 1 laps
-> [cxx]                             |_fibonacci[17]                       : 6.180e-06 sec real, 1 laps
-> [cxx]                     |_fibonacci[22]                               : 1.072e-04 sec real, 1 laps
+```cpp
+int64_t
+fibonacci(int64_t n, int64_t cutoff)
+{
+    using auto_tuple_t = tim::auto_tuple<real_clock, system_clock, user_clock, trip_count>;
+    if(n > cutoff)
+    {
+        nlaps += auto_tuple_t::size();
+        // TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[", n, "]");
+        TIMEMORY_BLANK_AUTO_TUPLE(auto_tuple_t, __FUNCTION__);
+        return (n < 2) ? n : (fibonacci(n - 1, cutoff) + fibonacci(n - 2, cutoff));
+    }
+    return fibonacci(n);
+}
+```
 
+## Measuring Overhead of 16,720 unique measurements
+
+Every single instance is unique and `fibonacci(43, 26)` produces:
+
+The difference between the two measurements (i.e. negative overhead per measurement) is due to minute differences in the cache and CPU frequency.
+
+```console
+Report from 16720 total measurements:
+	> [cxx] run [with timing = false]@'test_cxx_overhead.cpp':86 : 1.352e+00 sec real [laps: 1]
+	> [cxx] run [with timing =  true]@'test_cxx_overhead.cpp':86 : 1.350e+00 sec real [laps: 1]
+	> [cxx] timing difference                                    : -2.421e-03 sec real
+	> [cxx] average overhead per timer                           : -1.440e-07 sec real
+
+> [cxx] main[./test_cxx_overhead]@'test_cxx_overhead.cpp':132 : 2.690e+00 sec user, 1 laps, depth  0 (exclusive:  50.2%)
+> [cxx] |_fibonacci[43]                                       : 1.340e+00 sec user, 1 laps, depth  1 (exclusive:   0.0%)
+> [cxx]   |_fibonacci[42]                                     : 8.300e-01 sec user, 1 laps, depth  2 (exclusive:   0.0%)
+> [cxx]     |_fibonacci[41]                                   : 5.100e-01 sec user, 1 laps, depth  3 (exclusive:   0.0%)
+> [cxx]       |_fibonacci[40]                                 : 3.200e-01 sec user, 1 laps, depth  4 (exclusive:   0.0%)
+> [cxx]         |_fibonacci[39]                               : 2.000e-01 sec user, 1 laps, depth  5 (exclusive:   0.0%)
+> [cxx]           |_fibonacci[38]                             : 1.200e-01 sec user, 1 laps, depth  6 (exclusive:   0.0%)
+> [cxx]             |_fibonacci[37]                           : 8.000e-02 sec user, 1 laps, depth  7 (exclusive:   0.0%)
+> [cxx]               |_fibonacci[36]                         : 5.000e-02 sec user, 1 laps, depth  8 (exclusive:   0.0%)
+> [cxx]                 |_fibonacci[35]                       : 3.000e-02 sec user, 1 laps, depth  9 (exclusive:   0.0%)
+> [cxx]                   |_fibonacci[34]                     : 2.000e-02 sec user, 1 laps, depth 10 (exclusive:   0.0%)
+> [cxx]                     |_fibonacci[33]                   : 1.000e-02 sec user, 1 laps, depth 11 (exclusive:   0.0%)
+> [cxx]                       |_fibonacci[32]                 : 1.000e-02 sec user, 1 laps, depth 12 (exclusive:   0.0%)
+> [cxx]                         |_fibonacci[31]               : 0.000e+00 sec user, 1 laps, depth 13 (exclusive:   0.0%)
+> [cxx]                           |_fibonacci[30]             : 0.000e+00 sec user, 1 laps, depth 14 (exclusive:   0.0%)
+> [cxx]                             |_fibonacci[29]           : 0.000e+00 sec user, 1 laps, depth 15 (exclusive:   0.0%)
+> [cxx]                               |_fibonacci[28]         : 0.000e+00 sec user, 1 laps, depth 16 (exclusive:   0.0%)
+> [cxx]                                 |_fibonacci[27]       : 0.000e+00 sec user, 1 laps, depth 17
+> [cxx]                               |_fibonacci[27]         : 0.000e+00 sec user, 1 laps, depth 16
+> [cxx]                             |_fibonacci[28]           : 0.000e+00 sec user, 1 laps, depth 15 (exclusive:   0.0%)
+> [cxx]                               |_fibonacci[27]         : 0.000e+00 sec user, 1 laps, depth 16
+> [cxx]                           |_fibonacci[29]             : 0.000e+00 sec user, 1 laps, depth 14 (exclusive:   0.0%)
+> [cxx]                             |_fibonacci[28]           : 0.000e+00 sec user, 1 laps, depth 15 (exclusive:   0.0%)
+> [cxx]                               |_fibonacci[27]         : 0.000e+00 sec user, 1 laps, depth 16
+> [cxx]                             |_fibonacci[27]           : 0.000e+00 sec user, 1 laps, depth 15
+> [cxx]                         |_fibonacci[30]               : 1.000e-02 sec user, 1 laps, depth 13 (exclusive:   0.0%)
+> [cxx]                           |_fibonacci[29]             : 1.000e-02 sec user, 1 laps, depth 14 (exclusive:   0.0%)
+...
+```
+
+> Output is truncated and/or not shown for all components (`real_clock`, `system_clock`, `user_clock`, and `trip_count`)
+
+## Measuring Overhead of 16 unique measurements and 27,056 total measurements
+
+By reducing the number of unique measurements, we can increase the total number of measurements and produce the same effect as above (approx. **_zero overhead_**).
+`fibonacci(43, 25)` increases the total number of measurements from 16,720 to 27,056 but reduces the number of unique measurments to 16.
+
+```console
+Report from 27056 total measurements:
+	> [cxx] run [with timing = false]@'test_cxx_overhead.cpp':86 : 1.365e+00 sec real [laps: 1]
+	> [cxx] run [with timing =  true]@'test_cxx_overhead.cpp':86 : 1.353e+00 sec real [laps: 1]
+	> [cxx] timing difference                                    : -1.199e-02 sec real
+	> [cxx] average overhead per timer                           : -4.430e-07 sec real
+
+> [cxx] main[./test_cxx_overhead]@'test_cxx_overhead.cpp':132  : 2.718e+00 sec real,    1 laps, depth  0 (exclusive:   0.0%)
+> [cxx] |_run [with timing = false]@'test_cxx_overhead.cpp':86 : 1.365e+00 sec real,    1 laps, depth  1
+> [cxx] |_run [with timing =  true]@'test_cxx_overhead.cpp':86 : 1.353e+00 sec real,    1 laps, depth  1 (exclusive:   0.0%)
+> [cxx]   |_fibonacci                                          : 1.353e+00 sec real,    1 laps, depth  2 (exclusive:   0.0%)
+> [cxx]     |_fibonacci                                        : 1.353e+00 sec real,    2 laps, depth  3 (exclusive:   0.0%)
+> [cxx]       |_fibonacci                                      : 1.353e+00 sec real,    4 laps, depth  4 (exclusive:   0.0%)
+> [cxx]         |_fibonacci                                    : 1.353e+00 sec real,    8 laps, depth  5 (exclusive:   0.0%)
+> [cxx]           |_fibonacci                                  : 1.353e+00 sec real,   16 laps, depth  6 (exclusive:   0.0%)
+> [cxx]             |_fibonacci                                : 1.353e+00 sec real,   32 laps, depth  7 (exclusive:   0.0%)
+> [cxx]               |_fibonacci                              : 1.353e+00 sec real,   64 laps, depth  8 (exclusive:   0.0%)
+> [cxx]                 |_fibonacci                            : 1.352e+00 sec real,  128 laps, depth  9 (exclusive:   0.1%)
+> [cxx]                   |_fibonacci                          : 1.352e+00 sec real,  256 laps, depth 10 (exclusive:   0.1%)
+> [cxx]                     |_fibonacci                        : 1.350e+00 sec real,  511 laps, depth 11 (exclusive:   1.1%)
+> [cxx]                       |_fibonacci                      : 1.336e+00 sec real,  968 laps, depth 12 (exclusive:   7.3%)
+> [cxx]                         |_fibonacci                    : 1.238e+00 sec real, 1486 laps, depth 13 (exclusive:  22.9%)
+> [cxx]                           |_fibonacci                  : 9.547e-01 sec real, 1586 laps, depth 14 (exclusive:  43.3%)
+> [cxx]                             |_fibonacci                : 5.414e-01 sec real, 1093 laps, depth 15 (exclusive:  61.8%)
+> [cxx]                               |_fibonacci              : 2.068e-01 sec real,  470 laps, depth 16 (exclusive:  76.1%)
+> [cxx]                                 |_fibonacci            : 4.935e-02 sec real,  121 laps, depth 17 (exclusive:  86.7%)
+> [cxx]                                   |_fibonacci          : 6.587e-03 sec real,   17 laps, depth 18 (exclusive:  94.3%)
+> [cxx]                                     |_fibonacci        : 3.742e-04 sec real,    1 laps, depth 19
+```
+
+> Output is truncated and/or not shown for all components (`real_clock`, `system_clock`, `user_clock`, and `trip_count`)
+
+The difference between the two measurements (i.e. negative overhead per measurement) is due to minute differences in the cache and CPU frequency.
+
+## Measuring Overhead of 2,056,912 unique measurements
+
+Every single instance is unique and `fibonacci(43, 16)` produces:
+
+```console
+Report from 2056912 total measurements:
+	> [cxx] run [with timing = false]@'test_cxx_overhead.cpp':86 : 1.367e+00 sec real [laps: 1]
+	> [cxx] run [with timing =  true]@'test_cxx_overhead.cpp':86 : 3.425e+00 sec real [laps: 1]
+	> [cxx] timing difference                                    : 2.059e+00 sec real
+	> [cxx] average overhead per timer                           : 1.000e-06 sec real
+
+> [cxx] main[./test_cxx_overhead]@'test_cxx_overhead.cpp':132                 : 5.388e+00 sec real, 1 laps, depth  0 (exclusive:   0.0%)
+> [cxx] |_run [with timing = false]@'test_cxx_overhead.cpp':86                : 1.370e+00 sec real, 1 laps, depth  1
+> [cxx] |_run [with timing =  true]@'test_cxx_overhead.cpp':86                : 4.018e+00 sec real, 1 laps, depth  1 (exclusive:   0.0%)
+> [cxx]   |_fibonacci[43]                                                     : 4.018e+00 sec real, 1 laps, depth  2 (exclusive:   0.0%)
+> [cxx]     |_fibonacci[42]                                                   : 2.486e+00 sec real, 1 laps, depth  3 (exclusive:   0.0%)
+> [cxx]       |_fibonacci[41]                                                 : 1.537e+00 sec real, 1 laps, depth  4 (exclusive:   0.0%)
+> [cxx]         |_fibonacci[40]                                               : 9.509e-01 sec real, 1 laps, depth  5 (exclusive:   0.0%)
+> [cxx]           |_fibonacci[39]                                             : 5.880e-01 sec real, 1 laps, depth  6 (exclusive:   0.0%)
+> [cxx]             |_fibonacci[38]                                           : 3.638e-01 sec real, 1 laps, depth  7 (exclusive:   0.0%)
+> [cxx]               |_fibonacci[37]                                         : 2.250e-01 sec real, 1 laps, depth  8 (exclusive:   0.0%)
+> [cxx]                 |_fibonacci[36]                                       : 1.392e-01 sec real, 1 laps, depth  9 (exclusive:   0.0%)
+> [cxx]                   |_fibonacci[35]                                     : 8.607e-02 sec real, 1 laps, depth 10 (exclusive:   0.0%)
+> [cxx]                     |_fibonacci[34]                                   : 5.325e-02 sec real, 1 laps, depth 11 (exclusive:   0.0%)
+> [cxx]                       |_fibonacci[33]                                 : 3.293e-02 sec real, 1 laps, depth 12 (exclusive:   0.0%)
+> [cxx]                         |_fibonacci[32]                               : 2.037e-02 sec real, 1 laps, depth 13 (exclusive:   0.0%)
+> [cxx]                           |_fibonacci[31]                             : 1.260e-02 sec real, 1 laps, depth 14 (exclusive:   0.1%)
+> [cxx]                             |_fibonacci[30]                           : 7.802e-03 sec real, 1 laps, depth 15 (exclusive:   0.1%)
+> [cxx]                               |_fibonacci[29]                         : 4.827e-03 sec real, 1 laps, depth 16 (exclusive:   0.2%)
+> [cxx]                                 |_fibonacci[28]                       : 2.992e-03 sec real, 1 laps, depth 17 (exclusive:   0.3%)
+> [cxx]                                   |_fibonacci[27]                     : 1.857e-03 sec real, 1 laps, depth 18 (exclusive:   0.5%)
+> [cxx]                                     |_fibonacci[26]                   : 1.152e-03 sec real, 1 laps, depth 19 (exclusive:   0.8%)
+> [cxx]                                       |_fibonacci[25]                 : 7.149e-04 sec real, 1 laps, depth 20 (exclusive:   1.3%)
+> [cxx]                                         |_fibonacci[24]               : 4.468e-04 sec real, 1 laps, depth 21 (exclusive:   1.9%)
+> [cxx]                                           |_fibonacci[23]             : 2.829e-04 sec real, 1 laps, depth 22 (exclusive:   5.1%)
+> [cxx]                                             |_fibonacci[22]           : 1.706e-04 sec real, 1 laps, depth 23 (exclusive:   6.8%)
+> [cxx]                                               |_fibonacci[21]         : 1.041e-04 sec real, 1 laps, depth 24 (exclusive:   8.3%)
+> [cxx]                                                 |_fibonacci[20]       : 6.541e-05 sec real, 1 laps, depth 25 (exclusive:  14.9%)
+> [cxx]                                                   |_fibonacci[19]     : 4.105e-05 sec real, 1 laps, depth 26 (exclusive:  28.4%)
+> [cxx]                                                     |_fibonacci[18]   : 2.300e-05 sec real, 1 laps, depth 27 (exclusive:  61.1%)
+> [cxx]                                                       |_fibonacci[17] : 8.943e-06 sec real, 1 laps, depth 28
+> [cxx]                                                     |_fibonacci[17]   : 6.383e-06 sec real, 1 laps, depth 27
+> [cxx]                                                   |_fibonacci[18]     : 1.458e-05 sec real, 1 laps, depth 26 (exclusive:  57.3%)
+> [cxx]                                                     |_fibonacci[17]   : 6.233e-06 sec real, 1 laps, depth 27
+> [cxx]                                                 |_fibonacci[19]       : 3.009e-05 sec real, 1 laps, depth 25 (exclusive:  28.1%)
+> [cxx]                                                   |_fibonacci[18]     : 1.544e-05 sec real, 1 laps, depth 26 (exclusive:  59.6%)
+> [cxx]                                                     |_fibonacci[17]   : 6.231e-06 sec real, 1 laps, depth 27
+> [cxx]                                                   |_fibonacci[17]     : 6.182e-06 sec real, 1 laps, depth 26
+> [cxx]                                               |_fibonacci[20]         : 5.493e-05 sec real, 1 laps, depth 24 (exclusive:  17.7%)
+> [cxx]                                                 |_fibonacci[19]       : 3.117e-05 sec real, 1 laps, depth 25 (exclusive:  35.3%)
+> [cxx]                                                   |_fibonacci[18]     : 1.394e-05 sec real, 1 laps, depth 26 (exclusive:  55.9%)
+> [cxx]                                                     |_fibonacci[17]   : 6.140e-06 sec real, 1 laps, depth 27
+> [cxx]                                                   |_fibonacci[17]     : 6.227e-06 sec real, 1 laps, depth 26
+> [cxx]                                                 |_fibonacci[18]       : 1.406e-05 sec real, 1 laps, depth 25 (exclusive:  56.4%)
 ...
 
-> [cxx] run [with timing = false]@'test_cxx_overhead.cpp':110 : 1.667e+00 sec real [laps: 1]
-> [cxx] run [with timing =  true]@'test_cxx_overhead.cpp':110 : 2.782e+00 sec real [laps: 1]
-> [cxx] timing difference                                     : 1.115e+00 sec real
-> [cxx] average overhead per timer                            : 2.168e-06 sec real
+> [cxx] main[./test_cxx_overhead]@'test_cxx_overhead.cpp':132               : 4.170e+00 sec user, 1 laps, depth  0 (exclusive:  31.9%)
+> [cxx] |_fibonacci[43]                                                     : 2.840e+00 sec user, 1 laps, depth  1
+> [cxx]   |_fibonacci[42]                                                   : 1.760e+00 sec user, 1 laps, depth  2 (exclusive:   0.0%)
+> [cxx]     |_fibonacci[41]                                                 : 1.110e+00 sec user, 1 laps, depth  3 (exclusive:   0.0%)
+> [cxx]       |_fibonacci[40]                                               : 7.000e-01 sec user, 1 laps, depth  4
+> [cxx]         |_fibonacci[39]                                             : 4.300e-01 sec user, 1 laps, depth  5 (exclusive:   0.0%)
+> [cxx]           |_fibonacci[38]                                           : 2.700e-01 sec user, 1 laps, depth  6 (exclusive:   0.0%)
+> [cxx]             |_fibonacci[37]                                         : 1.700e-01 sec user, 1 laps, depth  7 (exclusive:   0.0%)
+> [cxx]               |_fibonacci[36]                                       : 1.100e-01 sec user, 1 laps, depth  8 (exclusive:   0.0%)
+> [cxx]                 |_fibonacci[35]                                     : 7.000e-02 sec user, 1 laps, depth  9 (exclusive:   0.0%)
+> [cxx]                   |_fibonacci[34]                                   : 4.000e-02 sec user, 1 laps, depth 10 (exclusive:   0.0%)
+> [cxx]                     |_fibonacci[33]                                 : 3.000e-02 sec user, 1 laps, depth 11 (exclusive:   0.0%)
+> [cxx]                       |_fibonacci[32]                               : 2.000e-02 sec user, 1 laps, depth 12 (exclusive:   0.0%)
+> [cxx]                         |_fibonacci[31]                             : 1.000e-02 sec user, 1 laps, depth 13 (exclusive:   0.0%)
+> [cxx]                           |_fibonacci[30]                           : 1.000e-02 sec user, 1 laps, depth 14 (exclusive:   0.0%)
+> [cxx]                             |_fibonacci[29]                         : 1.000e-02 sec user, 1 laps, depth 15 (exclusive:   0.0%)
+> [cxx]                               |_fibonacci[28]                       : 1.000e-02 sec user, 1 laps, depth 16 (exclusive:   0.0%)
+> [cxx]                                 |_fibonacci[27]                     : 1.000e-02 sec user, 1 laps, depth 17 (exclusive:   0.0%)
+> [cxx]                                   |_fibonacci[26]                   : 1.000e-02 sec user, 1 laps, depth 18 (exclusive:   0.0%)
+> [cxx]                                     |_fibonacci[25]                 : 1.000e-02 sec user, 1 laps, depth 19 (exclusive:   0.0%)
+> [cxx]                                       |_fibonacci[24]               : 0.000e+00 sec user, 1 laps, depth 20 (exclusive:   0.0%)
+> [cxx]                                         |_fibonacci[23]             : 0.000e+00 sec user, 1 laps, depth 21 (exclusive:   0.0%)
+> [cxx]                                           |_fibonacci[22]           : 0.000e+00 sec user, 1 laps, depth 22 (exclusive:   0.0%)
+> [cxx]                                             |_fibonacci[21]         : 0.000e+00 sec user, 1 laps, depth 23 (exclusive:   0.0%)
+> [cxx]                                               |_fibonacci[20]       : 0.000e+00 sec user, 1 laps, depth 24 (exclusive:   0.0%)
+> [cxx]                                                 |_fibonacci[19]     : 0.000e+00 sec user, 1 laps, depth 25 (exclusive:   0.0%)
+> [cxx]                                                   |_fibonacci[18]   : 0.000e+00 sec user, 1 laps, depth 26 (exclusive:   0.0%)
+> [cxx]                                                     |_fibonacci[17] : 0.000e+00 sec user, 1 laps, depth 27
+> [cxx]                                                   |_fibonacci[17]   : 0.000e+00 sec user, 1 laps, depth 26
+> [cxx]                                                 |_fibonacci[18]     : 0.000e+00 sec user, 1 laps, depth 25 (exclusive:   0.0%)
+> [cxx]                                                   |_fibonacci[17]   : 0.000e+00 sec user, 1 laps, depth 26
+> [cxx]                                               |_fibonacci[19]       : 0.000e+00 sec user, 1 laps, depth 24 (exclusive:   0.0%)
+> [cxx]                                                 |_fibonacci[18]     : 0.000e+00 sec user, 1 laps, depth 25 (exclusive:   0.0%)
+> [cxx]                                                   |_fibonacci[17]   : 0.000e+00 sec user, 1 laps, depth 26
+> [cxx]                                                 |_fibonacci[17]     : 0.000e+00 sec user, 1 laps, depth 25
+> [cxx]                                             |_fibonacci[20]         : 0.000e+00 sec user, 1 laps, depth 23 (exclusive:   0.0%)
+> [cxx]                                               |_fibonacci[19]       : 0.000e+00 sec user, 1 laps, depth 24 (exclusive:   0.0%)
+> [cxx]                                                 |_fibonacci[18]     : 0.000e+00 sec user, 1 laps, depth 25 (exclusive:   0.0%)
+> [cxx]                                                   |_fibonacci[17]   : 0.000e+00 sec user, 1 laps, depth 26
+> [cxx]                                                 |_fibonacci[17]     : 0.000e+00 sec user, 1 laps, depth 25
+> [cxx]                                               |_fibonacci[18]       : 0.000e+00 sec user, 1 laps, depth 24 (exclusive:   0.0%)
+> [cxx]                                                 |_fibonacci[17]     : 0.000e+00 sec user, 1 laps, depth 25
+> [cxx]                                           |_fibonacci[21]           : 0.000e+00 sec user, 1 laps, depth 22 (exclusive:   0.0%)
+> [cxx]                                             |_fibonacci[20]         : 0.000e+00 sec user, 1 laps, depth 23 (exclusive:   0.0%)
+> [cxx]                                               |_fibonacci[19]       : 0.000e+00 sec user, 1 laps, depth 24 (exclusive:   0.0%)
+> [cxx]                                                 |_fibonacci[18]     : 0.000e+00 sec user, 1 laps, depth 25 (exclusive:   0.0%)
+...
 ```
 
-However, the following produces only 27 unique timers:
+> Output is truncated and/or not shown for all components (`real_clock`, `system_clock`, `user_clock`, and `trip_count`)
 
-```c++
-int64_t
-fibonacci(int64_t n, int64_t cutoff)
-{
-    if(n > cutoff)
-    {
-        TIMEMORY_BASIC_AUTO_TUPLE(tim::auto_tuple<real_clock>, "");
-        return (n < 2) ? n : (fibonacci(n - 2, cutoff) + fibonacci(n - 1, cutoff));
-    }
-    return fibonacci(n); // standard fibonacci (no timers)
-}
-```
+## Measuring Overhead of 27 unique measurements with 2,056,912 measurements
 
-and the overhead is much smaller:
+After making the modifications to re-use measurements, `fibonacci(43, 16)` produces only 27 unique measurements and the overhead is reduced by ~15%:
 
 ```shell
-> [cxx] run [with timing = false]@'test_cxx_overhead.cpp':110         : 2.220e+00 sec real, 1 laps
-> [cxx] run [with timing =  true]@'test_cxx_overhead.cpp':110         : 2.832e+00 sec real, 1 laps
-> [cxx] fibonacci                                                     : 2.832e+00 sec real, 1 laps
-> [cxx] |_fibonacci                                                   : 2.832e+00 sec real, 2 laps
-> [cxx]   |_fibonacci                                                 : 2.832e+00 sec real, 4 laps
-> [cxx]     |_fibonacci                                               : 2.832e+00 sec real, 8 laps
-> [cxx]       |_fibonacci                                             : 2.832e+00 sec real, 16 laps
-> [cxx]         |_fibonacci                                           : 2.832e+00 sec real, 32 laps
-> [cxx]           |_fibonacci                                         : 2.832e+00 sec real, 64 laps
-> [cxx]             |_fibonacci                                       : 2.832e+00 sec real, 128 laps
-> [cxx]               |_fibonacci                                     : 2.831e+00 sec real, 256 laps
-> [cxx]                 |_fibonacci                                   : 2.831e+00 sec real, 512 laps
-> [cxx]                   |_fibonacci                                 : 2.830e+00 sec real, 1024 laps
-> [cxx]                     |_fibonacci                               : 2.828e+00 sec real, 2048 laps
-> [cxx]                       |_fibonacci                             : 2.824e+00 sec real, 4096 laps
-> [cxx]                         |_fibonacci                           : 2.815e+00 sec real, 8192 laps
-> [cxx]                           |_fibonacci                         : 2.798e+00 sec real, 16369 laps
-> [cxx]                             |_fibonacci                       : 2.761e+00 sec real, 32192 laps
-> [cxx]                               |_fibonacci                     : 2.660e+00 sec real, 58651 laps
-> [cxx]                                 |_fibonacci                   : 2.425e+00 sec real, 89846 laps
-> [cxx]                                   |_fibonacci                 : 1.977e+00 sec real, 106762 laps
-> [cxx]                                     |_fibonacci               : 1.355e+00 sec real, 94184 laps
-> [cxx]                                       |_fibonacci             : 7.419e-01 sec real, 60460 laps
-> [cxx]                                         |_fibonacci           : 3.124e-01 sec real, 27896 laps
-> [cxx]                                           |_fibonacci         : 9.630e-02 sec real, 9109 laps
-> [cxx]                                             |_fibonacci       : 2.064e-02 sec real, 2048 laps
-> [cxx]                                               |_fibonacci     : 2.952e-03 sec real, 301 laps
-> [cxx]                                                 |_fibonacci   : 2.318e-04 sec real, 26 laps
-> [cxx]                                                   |_fibonacci : 8.503e-06 sec real, 1 laps
+Report from 2056912 total measurements:
+	> [cxx] run [with timing = false]@'test_cxx_overhead.cpp':86 : 1.365e+00 sec real [laps: 1]
+	> [cxx] run [with timing =  true]@'test_cxx_overhead.cpp':86 : 3.103e+00 sec real [laps: 1]
+	> [cxx] timing difference                                    : 1.738e+00 sec real
+	> [cxx] average overhead per timer                           : 8.450e-07 sec real
 
-> [cxx] run [with timing = false]@'test_cxx_overhead.cpp':110 : 2.220e+00 sec real [laps: 1]
-> [cxx] run [with timing =  true]@'test_cxx_overhead.cpp':110 : 2.832e+00 sec real [laps: 1]
-> [cxx] timing difference                                     : 6.116e-01 sec real
-> [cxx] average overhead per timer                            : 1.189e-06 sec real
+> [cxx] main[./test_cxx_overhead]@'test_cxx_overhead.cpp':132             : 4.841e+00 sec real,      1 laps, depth  0 (exclusive:   0.0%)
+> [cxx] |_run [with timing = false]@'test_cxx_overhead.cpp':86            : 1.338e+00 sec real,      1 laps, depth  1
+> [cxx] |_run [with timing =  true]@'test_cxx_overhead.cpp':86            : 3.503e+00 sec real,      1 laps, depth  1 (exclusive:   0.0%)
+> [cxx]   |_fibonacci                                                     : 3.502e+00 sec real,      1 laps, depth  2 (exclusive:   0.0%)
+> [cxx]     |_fibonacci                                                   : 3.502e+00 sec real,      2 laps, depth  3 (exclusive:   0.0%)
+> [cxx]       |_fibonacci                                                 : 3.502e+00 sec real,      4 laps, depth  4 (exclusive:   0.0%)
+> [cxx]         |_fibonacci                                               : 3.502e+00 sec real,      8 laps, depth  5 (exclusive:   0.0%)
+> [cxx]           |_fibonacci                                             : 3.502e+00 sec real,     16 laps, depth  6 (exclusive:   0.0%)
+> [cxx]             |_fibonacci                                           : 3.502e+00 sec real,     32 laps, depth  7 (exclusive:   0.0%)
+> [cxx]               |_fibonacci                                         : 3.502e+00 sec real,     64 laps, depth  8 (exclusive:   0.0%)
+> [cxx]                 |_fibonacci                                       : 3.501e+00 sec real,    128 laps, depth  9 (exclusive:   0.0%)
+> [cxx]                   |_fibonacci                                     : 3.500e+00 sec real,    256 laps, depth 10 (exclusive:   0.1%)
+> [cxx]                     |_fibonacci                                   : 3.498e+00 sec real,    512 laps, depth 11 (exclusive:   0.1%)
+> [cxx]                       |_fibonacci                                 : 3.495e+00 sec real,   1024 laps, depth 12 (exclusive:   0.2%)
+> [cxx]                         |_fibonacci                               : 3.487e+00 sec real,   2048 laps, depth 13 (exclusive:   0.4%)
+> [cxx]                           |_fibonacci                             : 3.472e+00 sec real,   4096 laps, depth 14 (exclusive:   0.9%)
+> [cxx]                             |_fibonacci                           : 3.442e+00 sec real,   8192 laps, depth 15 (exclusive:   1.7%)
+> [cxx]                               |_fibonacci                         : 3.384e+00 sec real,  16369 laps, depth 16 (exclusive:   3.5%)
+> [cxx]                                 |_fibonacci                       : 3.266e+00 sec real,  32192 laps, depth 17 (exclusive:   7.0%)
+> [cxx]                                   |_fibonacci                     : 3.036e+00 sec real,  58651 laps, depth 18 (exclusive:  13.7%)
+> [cxx]                                     |_fibonacci                   : 2.622e+00 sec real,  89846 laps, depth 19 (exclusive:  23.8%)
+> [cxx]                                       |_fibonacci                 : 1.999e+00 sec real, 106762 laps, depth 20 (exclusive:  36.3%)
+> [cxx]                                         |_fibonacci               : 1.273e+00 sec real,  94184 laps, depth 21 (exclusive:  49.2%)
+> [cxx]                                           |_fibonacci             : 6.464e-01 sec real,  60460 laps, depth 22 (exclusive:  61.1%)
+> [cxx]                                             |_fibonacci           : 2.516e-01 sec real,  27896 laps, depth 23 (exclusive:  71.1%)
+> [cxx]                                               |_fibonacci         : 7.263e-02 sec real,   9109 laps, depth 24 (exclusive:  79.5%)
+> [cxx]                                                 |_fibonacci       : 1.488e-02 sec real,   2048 laps, depth 25 (exclusive:  86.2%)
+> [cxx]                                                   |_fibonacci     : 2.052e-03 sec real,    301 laps, depth 26 (exclusive:  91.4%)
+> [cxx]                                                     |_fibonacci   : 1.774e-04 sec real,     26 laps, depth 27 (exclusive:  95.2%)
+> [cxx]                                                       |_fibonacci : 8.580e-06 sec real,      1 laps, depth 28
+
+> [cxx] main[./test_cxx_overhead]@'test_cxx_overhead.cpp':132           : 4.070e+00 sec user,      1 laps, depth  0 (exclusive:  33.7%)
+> [cxx] |_fibonacci                                                     : 2.700e+00 sec user,      1 laps, depth  1 (exclusive:   0.0%)
+> [cxx]   |_fibonacci                                                   : 2.700e+00 sec user,      2 laps, depth  2 (exclusive:   0.0%)
+> [cxx]     |_fibonacci                                                 : 2.700e+00 sec user,      4 laps, depth  3 (exclusive:   0.0%)
+> [cxx]       |_fibonacci                                               : 2.700e+00 sec user,      8 laps, depth  4 (exclusive:   0.0%)
+> [cxx]         |_fibonacci                                             : 2.700e+00 sec user,     16 laps, depth  5 (exclusive:   0.0%)
+> [cxx]           |_fibonacci                                           : 2.700e+00 sec user,     32 laps, depth  6 (exclusive:   0.0%)
+> [cxx]             |_fibonacci                                         : 2.700e+00 sec user,     64 laps, depth  7 (exclusive:   0.0%)
+> [cxx]               |_fibonacci                                       : 2.700e+00 sec user,    128 laps, depth  8 (exclusive:   0.0%)
+> [cxx]                 |_fibonacci                                     : 2.700e+00 sec user,    256 laps, depth  9 (exclusive:   0.4%)
+> [cxx]                   |_fibonacci                                   : 2.690e+00 sec user,    512 laps, depth 10 (exclusive:   0.0%)
+> [cxx]                     |_fibonacci                                 : 2.690e+00 sec user,   1024 laps, depth 11 (exclusive:   0.4%)
+> [cxx]                       |_fibonacci                               : 2.680e+00 sec user,   2048 laps, depth 12 (exclusive:   0.0%)
+> [cxx]                         |_fibonacci                             : 2.680e+00 sec user,   4096 laps, depth 13 (exclusive:   0.7%)
+> [cxx]                           |_fibonacci                           : 2.660e+00 sec user,   8192 laps, depth 14 (exclusive:   1.1%)
+> [cxx]                             |_fibonacci                         : 2.630e+00 sec user,  16369 laps, depth 15 (exclusive:   1.5%)
+> [cxx]                               |_fibonacci                       : 2.590e+00 sec user,  32192 laps, depth 16 (exclusive:   5.4%)
+> [cxx]                                 |_fibonacci                     : 2.450e+00 sec user,  58651 laps, depth 17 (exclusive:  11.8%)
+> [cxx]                                   |_fibonacci                   : 2.160e+00 sec user,  89846 laps, depth 18 (exclusive:  22.7%)
+> [cxx]                                     |_fibonacci                 : 1.670e+00 sec user, 106762 laps, depth 19 (exclusive:  35.9%)
+> [cxx]                                       |_fibonacci               : 1.070e+00 sec user,  94184 laps, depth 20 (exclusive:  45.8%)
+> [cxx]                                         |_fibonacci             : 5.800e-01 sec user,  60460 laps, depth 21 (exclusive:  50.0%)
+> [cxx]                                           |_fibonacci           : 2.900e-01 sec user,  27896 laps, depth 22 (exclusive:  75.9%)
+> [cxx]                                             |_fibonacci         : 7.000e-02 sec user,   9109 laps, depth 23 (exclusive:  85.7%)
+> [cxx]                                               |_fibonacci       : 1.000e-02 sec user,   2048 laps, depth 24 (exclusive: 100.0%)
+> [cxx]                                                 |_fibonacci     : 0.000e+00 sec user,    301 laps, depth 25 (exclusive:   0.0%)
+> [cxx]                                                   |_fibonacci   : 0.000e+00 sec user,     26 laps, depth 26 (exclusive:   0.0%)
+> [cxx]                                                     |_fibonacci : 0.000e+00 sec user,      1 laps, depth 27
 ```
 
-The exact performance is specific to the machine and the overhead for a particular machine can be calculated by running the `test_cxx_overhead` example.
+> Output is truncated and/or not shown for all components (`real_clock`, `system_clock`, `user_clock`, and `trip_count`)
+
+## Conclusion
 
 Since TiMemory only records information of the functions explicitly specified, you can safely assume that unless
 TiMemory is inserted into a function called `> 100,000` times, it won't be adding more than a second of runtime
-to the function. Therefore, there is a simple rule of thumb: **don't insert a TiMemory auto-tuple into very simple functions
-that get called very frequently**.
+to the function and **judicious use will probably have zero overhead**.
+
+Therefore, there is a simple rule of thumb:
+**do not insert a TiMemory components into simple functions that get invoked extremely frequently**.

--- a/examples/ex-c/test_c_timing.c
+++ b/examples/ex-c/test_c_timing.c
@@ -13,9 +13,9 @@ get_timer(const char* func, int use_tuple)
 {
     if(use_tuple > 0)
     {
-        return TIMEMORY_AUTO_TUPLE(
-            func, WALL_CLOCK, SYS_CLOCK, USER_CLOCK, CPU_CLOCK, CPU_UTIL, CURRENT_RSS,
-            PEAK_RSS, PRIORITY_CONTEXT_SWITCH, VOLUNTARY_CONTEXT_SWITCH, CALIPER);
+        return TIMEMORY_OBJECT(func, WALL_CLOCK, SYS_CLOCK, USER_CLOCK, CPU_CLOCK,
+                               CPU_UTIL, CURRENT_RSS, PEAK_RSS, PRIORITY_CONTEXT_SWITCH,
+                               VOLUNTARY_CONTEXT_SWITCH, CALIPER);
     }
     else
     {
@@ -30,7 +30,7 @@ free_timer(void* timer, int use_tuple)
 {
     if(use_tuple > 0)
     {
-        FREE_TIMEMORY_AUTO_TUPLE(timer);
+        FREE_TIMEMORY_OBJECT(timer);
     }
     else
     {
@@ -47,7 +47,7 @@ get_fibonacci_timer(const char* func, int use_tuple)
     sprintf(buffer, "%s[using_tuple=%i]", func, use_tuple);
     if(use_tuple > 0)
     {
-        return TIMEMORY_BLANK_AUTO_TUPLE(buffer, WALL_CLOCK, SYS_CLOCK, USER_CLOCK);
+        return TIMEMORY_BLANK_OBJECT(buffer, WALL_CLOCK, SYS_CLOCK, USER_CLOCK);
     }
     else
     {

--- a/examples/ex-caliper/test_caliper.cpp
+++ b/examples/ex-caliper/test_caliper.cpp
@@ -116,7 +116,7 @@ fibonacci(intmax_t n)
 intmax_t
 time_fibonacci(intmax_t n, const std::string& scope_tag, const std::string& type_tag)
 {
-    TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[", scope_tag, "-", type_tag, "]");
+    TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[", scope_tag, "-", type_tag, "]");
     return fibonacci(n);
 }
 
@@ -144,7 +144,7 @@ test_caliper(intmax_t nfib, const std::string& scope_tag)
 {
     std::atomic<int64_t> ret;
     // accumulate metrics on full run
-    TIMEMORY_BASIC_AUTO_TUPLE_CALIPER(tot, auto_tuple_t, "[total-", scope_tag, "-scope]");
+    TIMEMORY_BASIC_CALIPER(tot, auto_tuple_t, "[total-", scope_tag, "-scope]");
 
     // run a fibonacci calculation and accumulate metric
     auto run_fibonacci = [&](long n, const std::string& type_tag) {
@@ -152,14 +152,14 @@ test_caliper(intmax_t nfib, const std::string& scope_tag)
     };
 
     // run longer fibonacci calculations on two threads
-    TIMEMORY_BASIC_AUTO_TUPLE_CALIPER(worker_thread, auto_tuple_t, "[worker-thread-",
-                                      scope_tag, "-scope]");
+    TIMEMORY_BASIC_CALIPER(worker_thread, auto_tuple_t, "[worker-thread-", scope_tag,
+                           "-scope]");
     std::thread t(run_fibonacci, nfib, "worker");
     TIMEMORY_CALIPER_APPLY(worker_thread, stop);
 
     // run shorter fibonacci calculation on main thread
-    TIMEMORY_BASIC_AUTO_TUPLE_CALIPER(master_thread, auto_tuple_t, "[master-thread-",
-                                      scope_tag, "-scope]");
+    TIMEMORY_BASIC_CALIPER(master_thread, auto_tuple_t, "[master-thread-", scope_tag,
+                           "-scope]");
     run_fibonacci(nfib - 1, "master");
     TIMEMORY_CALIPER_APPLY(master_thread, stop);
 

--- a/examples/ex-cpu-roofline/test_cpu_roofline.cpp
+++ b/examples/ex-cpu-roofline/test_cpu_roofline.cpp
@@ -102,7 +102,7 @@ main(int argc, char** argv)
     // execute fibonacci in a thread
     //
     auto exec_fibonacci = [&](int64_t n) {
-        TIMEMORY_BLANK_AUTO_TUPLE_CALIPER(0, auto_tuple_t, "fibonacci(", n, ")");
+        TIMEMORY_BLANK_CALIPER(0, auto_tuple_t, "fibonacci(", n, ")");
         auto ret = fibonacci(n);
         TIMEMORY_CALIPER_APPLY(0, stop);
         printf("fibonacci(%li) = %.1f\n", static_cast<long>(n), ret);
@@ -112,7 +112,7 @@ main(int argc, char** argv)
     // execute random_fibonacci in a thread
     //
     auto exec_random_fibonacci = [&](int64_t n) {
-        TIMEMORY_BLANK_AUTO_TUPLE_CALIPER(1, auto_tuple_t, "random_fibonacci(", n, ")");
+        TIMEMORY_BLANK_CALIPER(1, auto_tuple_t, "random_fibonacci(", n, ")");
         auto ret = random_fibonacci(n);
         TIMEMORY_CALIPER_APPLY(1, stop);
         printf("random_fibonacci(%li) = %.1f\n", static_cast<long>(n), ret);
@@ -121,7 +121,7 @@ main(int argc, char** argv)
     //
     // overall timing
     //
-    auto _main = TIMEMORY_BLANK_AUTO_TUPLE_INSTANCE(auto_tuple_t, "overall_timer");
+    auto _main = TIMEMORY_BLANK_INSTANCE(auto_tuple_t, "overall_timer");
     _main.report_at_exit(true);
     real_clock total;
     total.start();

--- a/examples/ex-cuda-event/test_cuda_event.cu
+++ b/examples/ex-cuda-event/test_cuda_event.cu
@@ -256,7 +256,7 @@ test_1_saxpy()
 {
     print_info(__FUNCTION__);
     warmup();
-    TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "");
+    TIMEMORY_BASIC_OBJECT(auto_tuple_t, "");
 
     comp_tuple_t _clock("Runtime");
     _clock.start();
@@ -273,20 +273,20 @@ test_1_saxpy()
     cuda_event* evt      = nullptr;
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[cpu_malloc]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[cpu_malloc]");
         x = tim::device::cpu::alloc<float>(N);
         y = tim::device::cpu::alloc<float>(N);
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[gpu_malloc]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[gpu_malloc]");
         d_x = tim::cuda::malloc<float>(N);
         d_y = tim::cuda::malloc<float>(N);
         CUDA_CHECK_LAST_ERROR();
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[assign]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[assign]");
         for(int i = 0; i < N; i++)
         {
             x[i] = 1.0f;
@@ -295,12 +295,12 @@ test_1_saxpy()
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[create_event]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[create_event]");
         evt = new cuda_event();
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[H2D]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[H2D]");
         evt->mark_begin();
         tim::cuda::memcpy(d_x, x, N, tim::cuda::host_to_device_v);
         tim::cuda::memcpy(d_y, y, N, tim::cuda::host_to_device_v);
@@ -310,7 +310,7 @@ test_1_saxpy()
 
     for(int i = 0; i < 1; ++i)
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[", i, "]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[", i, "]");
         // Perform SAXPY on 1M elements
         evt->mark_begin();
         saxpy<<<ngrid, block>>>(N, 1.0f, d_x, d_y);
@@ -318,7 +318,7 @@ test_1_saxpy()
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[D2H]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[D2H]");
         evt->mark_begin();
         cudaMemcpy(y, d_y, N * sizeof(float), cudaMemcpyDeviceToHost);
         evt->mark_end();
@@ -327,7 +327,7 @@ test_1_saxpy()
     tim::cuda::device_sync();
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[check]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[check]");
         for(int64_t i = 0; i < N; i++)
         {
             maxError = std::max(maxError, std::abs(y[i] - 2.0f));
@@ -339,7 +339,7 @@ test_1_saxpy()
     nseconds += evt->get();
     _clock.stop();
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[output]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[output]");
         std::cout << "Event: " << *evt << std::endl;
         std::cout << _clock << std::endl;
         printf("Max error: %8.4e\n", maxError);
@@ -367,7 +367,7 @@ test_2_saxpy_async()
 {
     print_info(__FUNCTION__);
     warmup();
-    TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "");
+    TIMEMORY_BASIC_OBJECT(auto_tuple_t, "");
 
     comp_tuple_t _clock("Runtime");
     _clock.start();
@@ -390,19 +390,19 @@ test_2_saxpy_async()
     };
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[cpu_malloc]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[cpu_malloc]");
         x = tim::device::cpu::alloc<float>(N);
         y = tim::device::cpu::alloc<float>(N);
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[gpu_malloc]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[gpu_malloc]");
         d_x = tim::cuda::malloc<float>(N);
         d_y = tim::cuda::malloc<float>(N);
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[assign]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[assign]");
         for(int i = 0; i < N; i++)
         {
             x[i] = 1.0f;
@@ -411,7 +411,7 @@ test_2_saxpy_async()
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[create]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[create]");
         for(int i = 0; i < nitr; ++i)
         {
             tim::cuda::stream_create(stream[i]);
@@ -421,7 +421,7 @@ test_2_saxpy_async()
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[H2D]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[H2D]");
         for(int i = 0; i < nitr; ++i)
         {
             auto   offset = Nsub * i;
@@ -438,7 +438,7 @@ test_2_saxpy_async()
 
     for(int i = 0; i < nitr; ++i)
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[", i, "]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[", i, "]");
 
         auto   offset = Nsub * i;
         float* _dx    = d_x + offset;
@@ -451,7 +451,7 @@ test_2_saxpy_async()
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[D2H]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[D2H]");
         for(int i = 0; i < nitr; ++i)
         {
             auto   offset = Nsub * i;
@@ -466,7 +466,7 @@ test_2_saxpy_async()
     _sync();
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[check]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[check]");
         for(int64_t i = 0; i < N; i++)
         {
             maxError = std::max(maxError, std::abs(y[i] - 2.0f));
@@ -476,7 +476,7 @@ test_2_saxpy_async()
 
     _clock.stop();
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[output]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[output]");
         cuda_event _evt = **evt;
         for(int i = 1; i < nitr; ++i)
         {
@@ -512,7 +512,7 @@ test_3_saxpy_pinned()
 {
     print_info(__FUNCTION__);
     warmup();
-    TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "");
+    TIMEMORY_BASIC_OBJECT(auto_tuple_t, "");
 
     comp_tuple_t _clock("Runtime");
     _clock.start();
@@ -529,19 +529,19 @@ test_3_saxpy_pinned()
     cuda_event* evt      = nullptr;
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[cpu_malloc]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[cpu_malloc]");
         x = tim::cuda::malloc_host<float>(N);
         y = tim::cuda::malloc_host<float>(N);
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[gpu_malloc]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[gpu_malloc]");
         d_x = tim::cuda::malloc<float>(N);
         d_y = tim::cuda::malloc<float>(N);
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[assign]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[assign]");
         for(int i = 0; i < N; i++)
         {
             x[i] = 1.0f;
@@ -550,13 +550,13 @@ test_3_saxpy_pinned()
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[create_event]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[create_event]");
         evt = new cuda_event();
         evt->start();
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[H2D]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[H2D]");
         evt->mark_begin();
         tim::cuda::memcpy(d_x, x, N, tim::cuda::host_to_device_v);
         tim::cuda::memcpy(d_y, y, N, tim::cuda::host_to_device_v);
@@ -565,7 +565,7 @@ test_3_saxpy_pinned()
 
     for(int i = 0; i < 1; ++i)
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[", i, "]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[", i, "]");
         evt->mark_begin();
         // Perform SAXPY on 1M elements
         saxpy<<<ngrid, block>>>(N, 1.0f, d_x, d_y);
@@ -573,7 +573,7 @@ test_3_saxpy_pinned()
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[D2H]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[D2H]");
         evt->mark_begin();
         tim::cuda::memcpy(y, d_y, N, tim::cuda::device_to_host_v);
         evt->mark_end();
@@ -582,7 +582,7 @@ test_3_saxpy_pinned()
     tim::cuda::device_sync();
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[check]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[check]");
         for(int64_t i = 0; i < N; i++)
         {
             maxError = std::max(maxError, std::abs(y[i] - 2.0f));
@@ -594,7 +594,7 @@ test_3_saxpy_pinned()
     evt->stop();
     nseconds += evt->get();
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[output]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[output]");
         std::cout << "Event: " << *evt << std::endl;
         std::cout << _clock << std::endl;
         printf("Max error: %8.4e\n", maxError);
@@ -622,7 +622,7 @@ test_4_saxpy_async_pinned()
 {
     print_info(__FUNCTION__);
     warmup();
-    TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "");
+    TIMEMORY_BASIC_OBJECT(auto_tuple_t, "");
 
     comp_tuple_t _clock("Runtime");
     _clock.start();
@@ -645,19 +645,19 @@ test_4_saxpy_async_pinned()
     };
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[cpu_malloc]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[cpu_malloc]");
         x = tim::cuda::malloc_host<float>(N);
         y = tim::cuda::malloc_host<float>(N);
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[gpu_malloc]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[gpu_malloc]");
         d_x = tim::cuda::malloc<float>(N);
         d_y = tim::cuda::malloc<float>(N);
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[assign]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[assign]");
         for(int i = 0; i < N; i++)
         {
             x[i] = 1.0f;
@@ -666,7 +666,7 @@ test_4_saxpy_async_pinned()
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[create]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[create]");
         for(int i = 0; i < nitr; ++i)
         {
             tim::cuda::stream_create(stream[i]);
@@ -676,7 +676,7 @@ test_4_saxpy_async_pinned()
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[H2D]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[H2D]");
         for(int i = 0; i < nitr; ++i)
         {
             auto   offset = Nsub * i;
@@ -693,7 +693,7 @@ test_4_saxpy_async_pinned()
 
     for(int i = 0; i < nitr; ++i)
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[", i, "]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[", i, "]");
 
         auto   offset = Nsub * i;
         float* _dx    = d_x + offset;
@@ -706,7 +706,7 @@ test_4_saxpy_async_pinned()
     }
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[D2H]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[D2H]");
         for(int i = 0; i < nitr; ++i)
         {
             auto   offset = Nsub * i;
@@ -721,7 +721,7 @@ test_4_saxpy_async_pinned()
     _sync();
 
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[check]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[check]");
         for(int64_t i = 0; i < N; i++)
         {
             maxError = std::max(maxError, std::abs(y[i] - 2.0f));
@@ -731,7 +731,7 @@ test_4_saxpy_async_pinned()
 
     _clock.stop();
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[output]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[output]");
         cuda_event _evt = **evt;
         for(int i = 1; i < nitr; ++i)
         {
@@ -771,7 +771,7 @@ test_5_mt_saxpy_async()
 {
     print_info(__FUNCTION__);
     warmup();
-    TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "");
+    TIMEMORY_BASIC_OBJECT(auto_tuple_t, "");
     auto lambda_op = tim::str::join("", "::", __TIMEMORY_FUNCTION__);
 
     comp_tuple_t _clock("Runtime");
@@ -797,22 +797,22 @@ test_5_mt_saxpy_async()
         cuda_event evt(stream);
         evt.start();
 
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, lambda_op, "[run_thread]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, lambda_op, "[run_thread]");
 
         {
-            TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, lambda_op, "[cpu_malloc]");
+            TIMEMORY_BASIC_OBJECT(auto_tuple_t, lambda_op, "[cpu_malloc]");
             x = tim::device::cpu::alloc<float>(Nsub);
             y = tim::device::cpu::alloc<float>(Nsub);
         }
 
         {
-            TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, lambda_op, "[gpu_malloc]");
+            TIMEMORY_BASIC_OBJECT(auto_tuple_t, lambda_op, "[gpu_malloc]");
             d_x = tim::cuda::malloc<float>(Nsub);
             d_y = tim::cuda::malloc<float>(Nsub);
         }
 
         {
-            TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, lambda_op, "[assign]");
+            TIMEMORY_BASIC_OBJECT(auto_tuple_t, lambda_op, "[assign]");
             for(int i = 0; i < Nsub; i++)
             {
                 x[i] = 1.0f;
@@ -821,7 +821,7 @@ test_5_mt_saxpy_async()
         }
 
         {
-            TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, lambda_op, "[H2D]");
+            TIMEMORY_BASIC_OBJECT(auto_tuple_t, lambda_op, "[H2D]");
             evt.mark_begin();
             tim::cuda::memcpy(d_x, x, Nsub, tim::cuda::host_to_device_v, stream);
             tim::cuda::memcpy(d_y, y, Nsub, tim::cuda::host_to_device_v, stream);
@@ -829,7 +829,7 @@ test_5_mt_saxpy_async()
         }
 
         {
-            TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, lambda_op, "[", i, "]");
+            TIMEMORY_BASIC_OBJECT(auto_tuple_t, lambda_op, "[", i, "]");
             // Perform SAXPY on 1M elements
             evt.mark_begin();
             saxpy<<<ngrid, block, 0, stream>>>(Nsub, 1.0f, d_x, d_y);
@@ -837,7 +837,7 @@ test_5_mt_saxpy_async()
         }
 
         {
-            TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, lambda_op, "[D2H]");
+            TIMEMORY_BASIC_OBJECT(auto_tuple_t, lambda_op, "[D2H]");
             evt.mark_begin();
             tim::cuda::memcpy(y, d_y, Nsub, tim::cuda::device_to_host_v);
             evt.mark_end();
@@ -847,7 +847,7 @@ test_5_mt_saxpy_async()
         tim::cuda::stream_destroy(stream);
 
         {
-            TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, lambda_op, "[check]");
+            TIMEMORY_BASIC_OBJECT(auto_tuple_t, lambda_op, "[check]");
             for(int64_t i = 0; i < Nsub; i++)
             {
                 maxError = std::max(maxError, std::abs(y[i] - 2.0f));
@@ -887,7 +887,7 @@ test_5_mt_saxpy_async()
 
     _clock.stop();
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[output]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[output]");
         std::cout << "Event: " << evt << std::endl;
         std::cout << _clock << std::endl;
         printf("Max error: %8.4e\n", maxError);
@@ -908,7 +908,7 @@ test_6_mt_saxpy_async_pinned()
 {
     print_info(__FUNCTION__);
     warmup();
-    TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "");
+    TIMEMORY_BASIC_OBJECT(auto_tuple_t, "");
     auto lambda_op = tim::str::join("", "::", __TIMEMORY_FUNCTION__);
 
     comp_tuple_t _clock("Runtime");
@@ -934,22 +934,22 @@ test_6_mt_saxpy_async_pinned()
         cuda_event* evt = new cuda_event(stream);
         evt->start();
 
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, lambda_op, "[run_thread]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, lambda_op, "[run_thread]");
 
         {
-            TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, lambda_op, "[cpu_malloc]");
+            TIMEMORY_BASIC_OBJECT(auto_tuple_t, lambda_op, "[cpu_malloc]");
             x = tim::cuda::malloc_host<float>(Nsub);
             y = tim::cuda::malloc_host<float>(Nsub);
         }
 
         {
-            TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, lambda_op, "[gpu_malloc]");
+            TIMEMORY_BASIC_OBJECT(auto_tuple_t, lambda_op, "[gpu_malloc]");
             d_x = tim::cuda::malloc_host<float>(Nsub);
             d_y = tim::cuda::malloc_host<float>(Nsub);
         }
 
         {
-            TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, lambda_op, "[assign]");
+            TIMEMORY_BASIC_OBJECT(auto_tuple_t, lambda_op, "[assign]");
             for(int i = 0; i < Nsub; i++)
             {
                 x[i] = 1.0f;
@@ -958,7 +958,7 @@ test_6_mt_saxpy_async_pinned()
         }
 
         {
-            TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, lambda_op, "[H2D]");
+            TIMEMORY_BASIC_OBJECT(auto_tuple_t, lambda_op, "[H2D]");
             evt->mark_begin();
             tim::cuda::memcpy(d_x, x, Nsub, tim::cuda::host_to_device_v, stream);
             tim::cuda::memcpy(d_y, y, Nsub, tim::cuda::host_to_device_v, stream);
@@ -966,7 +966,7 @@ test_6_mt_saxpy_async_pinned()
         }
 
         {
-            TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, lambda_op, "[", i, "]");
+            TIMEMORY_BASIC_OBJECT(auto_tuple_t, lambda_op, "[", i, "]");
 
             // Perform SAXPY on 1M elements
             evt->mark_begin();
@@ -975,7 +975,7 @@ test_6_mt_saxpy_async_pinned()
         }
 
         {
-            TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, lambda_op, "[D2H]");
+            TIMEMORY_BASIC_OBJECT(auto_tuple_t, lambda_op, "[D2H]");
             evt->mark_begin();
             tim::cuda::memcpy(y, d_y, Nsub, tim::cuda::device_to_host_v, stream);
             evt->mark_end();
@@ -985,7 +985,7 @@ test_6_mt_saxpy_async_pinned()
         tim::cuda::stream_destroy(stream);
 
         {
-            TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, lambda_op, "[check]");
+            TIMEMORY_BASIC_OBJECT(auto_tuple_t, lambda_op, "[check]");
             for(int64_t i = 0; i < Nsub; i++)
             {
                 maxError = std::max(maxError, std::abs(y[i] - 2.0f));
@@ -1027,7 +1027,7 @@ test_6_mt_saxpy_async_pinned()
 
     _clock.stop();
     {
-        TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[output]");
+        TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[output]");
         std::cout << "Event: " << evt << std::endl;
         std::cout << _clock << std::endl;
         printf("Max error: %8.4e\n", maxError);

--- a/examples/ex-cxx-basic/test_cxx_basic.cpp
+++ b/examples/ex-cxx-basic/test_cxx_basic.cpp
@@ -29,10 +29,9 @@
 
 using namespace tim::component;
 
-using papi_tuple_t = papi_tuple<PAPI_TOT_CYC, PAPI_TOT_INS, PAPI_LST_INS>;
-using real_tuple_t = tim::auto_tuple<real_clock, papi_tuple_t, caliper>;
+using real_tuple_t = tim::auto_tuple<real_clock, papi_array_t, caliper>;
 using auto_tuple_t =
-    tim::auto_tuple<real_clock, cpu_clock, cpu_util, peak_rss, papi_tuple_t, caliper>;
+    tim::auto_tuple<real_clock, cpu_clock, cpu_util, peak_rss, papi_array_t, caliper>;
 using comp_tuple_t = typename auto_tuple_t::component_type;
 using auto_list_t  = tim::auto_list<real_clock, cpu_clock, cpu_util, peak_rss, caliper>;
 
@@ -48,6 +47,10 @@ fibonacci(intmax_t n);
 int
 main(int argc, char** argv)
 {
+    papi_array_t::get_initializer() = []() {
+        return std::vector<int>({ PAPI_TOT_CYC, PAPI_TOT_INS, PAPI_LST_INS });
+    };
+
     // runtime customization of auto_list_t initialization
     auto_list_t::get_initializer() = [](auto_list_t& al) {
         const std::string default_env = "real_clock,cpu_clock,cpu_util,caliper";
@@ -71,7 +74,7 @@ main(int argc, char** argv)
     for(auto n : { 15, 20, 25 })
     {
         // create a caliper handle to an auto_tuple_t and have it report when destroyed
-        TIMEMORY_BLANK_AUTO_TUPLE_CALIPER(fib, auto_tuple_t, "fibonacci(", n, ")");
+        TIMEMORY_BLANK_CALIPER(fib, auto_tuple_t, "fibonacci(", n, ")");
         TIMEMORY_CALIPER_APPLY(fib, report_at_exit, true);
         // run calculation
         auto ret = fibonacci(n);
@@ -92,7 +95,7 @@ main(int argc, char** argv)
 intmax_t
 fibonacci(intmax_t n)
 {
-    TIMEMORY_BASIC_AUTO_TUPLE(real_tuple_t, "");
+    TIMEMORY_BASIC_OBJECT(real_tuple_t, "");
     return (n < 2) ? n : fibonacci(n - 1) + fibonacci(n - 2);
 }
 

--- a/examples/ex-cxx-overhead/test_cxx_overhead.cpp
+++ b/examples/ex-cxx-overhead/test_cxx_overhead.cpp
@@ -35,15 +35,14 @@ static int64_t nlaps = 0;
 // using auto_tuple_t = tim::auto_tuple<real_clock>;
 using namespace tim::component;
 
-using auto_tuple_t =
-    tim::auto_tuple<real_clock, system_clock, user_clock, trip_count, caliper>;
+using auto_tuple_t  = tim::auto_tuple<real_clock, system_clock, user_clock, trip_count>;
 using timer_tuple_t = typename tim::auto_tuple<real_clock>::component_type;
 
 using papi_tuple_t = papi_array<8>;
 using global_tuple_t =
     tim::auto_tuple<real_clock, user_clock, system_clock, cpu_clock, cpu_util, peak_rss,
                     current_rss, priority_context_switch, voluntary_context_switch,
-                    papi_tuple_t>;
+                    caliper, papi_tuple_t>;
 
 //======================================================================================//
 
@@ -69,9 +68,9 @@ fibonacci(int64_t n, int64_t cutoff)
     if(n > cutoff)
     {
         nlaps += auto_tuple_t::size();
-        // TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "");
-        // TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "[", n, "]");
-        TIMEMORY_BLANK_AUTO_TUPLE(auto_tuple_t, __FUNCTION__);
+        // TIMEMORY_BASIC_OBJECT(auto_tuple_t, "");
+        // TIMEMORY_BASIC_OBJECT(auto_tuple_t, "[", n, "]");
+        TIMEMORY_BLANK_OBJECT(auto_tuple_t, __FUNCTION__);
         return (n < 2) ? n : (fibonacci(n - 1, cutoff) + fibonacci(n - 2, cutoff));
     }
     return fibonacci(n);
@@ -82,8 +81,8 @@ fibonacci(int64_t n, int64_t cutoff)
 timer_tuple_t
 run(int64_t n, bool with_timing, int64_t cutoff)
 {
-    auto signature = TIMEMORY_AUTO_LABEL(" [with timing = ", ((with_timing) ? " " : ""),
-                                         with_timing, "]");
+    auto signature =
+        TIMEMORY_LABEL(" [with timing = ", ((with_timing) ? " " : ""), with_timing, "]");
     timer_tuple_t timer(signature);
     int64_t       result = 0;
     {
@@ -129,7 +128,7 @@ main(int argc, char** argv)
     {
         nlaps = 0;
         bool enable_auto_timers;
-        TIMEMORY_AUTO_TUPLE(global_tuple_t, "[", argv[0], "]");
+        TIMEMORY_OBJECT(global_tuple_t, "[", argv[0], "]");
         // run without timing first
         timer_list.push_back(run(nfib, enable_auto_timers = false, nfib));
         timer_list.push_back(run(nfib, enable_auto_timers = true, cutoff));

--- a/examples/ex-cxx-tuple/test_cxx_tuple.cpp
+++ b/examples/ex-cxx-tuple/test_cxx_tuple.cpp
@@ -82,7 +82,7 @@ fibonacci(int32_t n)
 int64_t
 time_fibonacci(int32_t n)
 {
-    TIMEMORY_AUTO_TUPLE(auto_tuple_t, "");
+    TIMEMORY_OBJECT(auto_tuple_t, "");
     return fibonacci(n);
 }
 //--------------------------------------------------------------------------------------//
@@ -206,7 +206,7 @@ void
 test_1_usage()
 {
     print_info(__FUNCTION__);
-    TIMEMORY_AUTO_TUPLE(auto_tuple_t, "");
+    TIMEMORY_OBJECT(auto_tuple_t, "");
 
     full_measurement_t _use_beg("");
     full_measurement_t _use_delta("");
@@ -304,10 +304,10 @@ test_2_timing()
     std::stringstream    lambda_ss;
 
     {
-        TIMEMORY_AUTO_TUPLE(auto_tuple_t, "");
+        TIMEMORY_OBJECT(auto_tuple_t, "");
 
         auto run_fib = [&](long n) {
-            TIMEMORY_AUTO_TUPLE(auto_tuple_t, "");
+            TIMEMORY_OBJECT(auto_tuple_t, "");
             measurement_t _tm("", false);
             _tm.start();
             ret += time_fibonacci(n);
@@ -356,23 +356,23 @@ test_3_auto_tuple()
 
     std::atomic<int64_t> ret;
     // accumulate metrics on full run
-    TIMEMORY_BASIC_AUTO_TUPLE_CALIPER(tot, full_set_t, "[total]");
+    TIMEMORY_BASIC_CALIPER(tot, full_set_t, "[total]");
 
     std::this_thread::sleep_for(std::chrono::milliseconds(10));
 
     // run a fibonacci calculation and accumulate metric
     auto run_fibonacci = [&](long n) {
-        // TIMEMORY_AUTO_TUPLE(small_set_t, "[fibonacci_" + std::to_string(n) + "]");
+        // TIMEMORY_OBJECT(small_set_t, "[fibonacci_" + std::to_string(n) + "]");
         ret += time_fibonacci(n);
     };
 
     // run longer fibonacci calculations on two threads
-    TIMEMORY_BASIC_AUTO_TUPLE_CALIPER(worker_thread, full_set_t, "[worker_thread]");
+    TIMEMORY_BASIC_CALIPER(worker_thread, full_set_t, "[worker_thread]");
     std::thread t(run_fibonacci, 43);
     TIMEMORY_CALIPER_APPLY(worker_thread, stop);
 
     // run shorter fibonacci calculation on main thread
-    TIMEMORY_BASIC_AUTO_TUPLE_CALIPER(master_thread, full_set_t, "[master_thread]");
+    TIMEMORY_BASIC_CALIPER(master_thread, full_set_t, "[master_thread]");
     run_fibonacci(42);
     TIMEMORY_CALIPER_APPLY(master_thread, stop);
 
@@ -391,7 +391,7 @@ test_4_measure()
 {
     print_info(__FUNCTION__);
 
-    tim::component_tuple<current_rss, peak_rss> prss(TIMEMORY_AUTO_LABEL(""));
+    tim::component_tuple<current_rss, peak_rss> prss(TIMEMORY_LABEL(""));
     {
         TIMEMORY_VARIADIC_BASIC_AUTO_TUPLE("[init]", current_rss, peak_rss);
         // just record the peak rss
@@ -431,12 +431,12 @@ int main()
 
     {
         // uses C++ scoping for start/stop
-        TIMEMORY_AUTO_TUPLE(auto_roofline_t, "roofline_for_A");
+        TIMEMORY_OBJECT(auto_roofline_t, "roofline_for_A");
         func_A();
     }
 
     {
-        TIMEMORY_AUTO_TUPLE(auto_roofline_t, "roofline_for_B");
+        TIMEMORY_OBJECT(auto_roofline_t, "roofline_for_B");
         func_B();
     }
 

--- a/examples/ex-optional/test_optional.cpp
+++ b/examples/ex-optional/test_optional.cpp
@@ -90,13 +90,13 @@ int main(int argc, char** argv)
     //
     // create an auto tuple accessible via a caliper integer or expand to nothing
     //
-    TIMEMORY_AUTO_TUPLE_CALIPER(main, auto_tuple_t, "");
-    TIMEMORY_AUTO_TUPLE_CALIPER(0, auto_tuple_t, "[]");
+    auto main = TIMEMORY_INSTANCE(auto_tuple_t, "");
+    TIMEMORY_CALIPER(0, auto_tuple_t, "[]");
 
     //
     // call <auto_tuple_t>.report_at_exit(true) or expand to nothing
     //
-    TIMEMORY_CALIPER_APPLY(main, report_at_exit, true);
+    main.report_at_exit(true);
     TIMEMORY_CALIPER_APPLY(0, report_at_exit, true);
 
     //
@@ -121,8 +121,9 @@ int main(int argc, char** argv)
     //
     // call <auto_tuple_t>.stop() or expand to nothing
     //
-    TIMEMORY_CALIPER_APPLY(main, stop);
+    main.stop();
 
+    tim::timemory_finalize();
     status();
 }
 
@@ -139,7 +140,7 @@ long impl::fibonacci(long n)
 
 long fibonacci(long n)
 {
-    TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_t, "(", n, ")");
+    TIMEMORY_BASIC_OBJECT(auto_tuple_t, "(", n, ")");
     return impl::fibonacci(n);
 }
 

--- a/examples/ex-optional/test_optional.hpp
+++ b/examples/ex-optional/test_optional.hpp
@@ -47,21 +47,66 @@ using auto_tuple_thr = tim::auto_tuple<real_clock, thread_cpu_clock, thread_cpu_
 
 #else
 
+#    include <ostream>
 #    include <string>
-#    define TIMEMORY_AUTO_TUPLE(...)
-#    define TIMEMORY_BASIC_AUTO_TUPLE(...)
-#    define TIMEMORY_BLANK_AUTO_TUPLE(...)
-#    define TIMEMORY_AUTO_TUPLE_CALIPER(...)
-#    define TIMEMORY_BASIC_AUTO_TUPLE_CALIPER(...)
-#    define TIMEMORY_BLANK_AUTO_TUPLE_CALIPER(...)
-#    define TIMEMORY_CALIPER_APPLY(...)
 
 namespace tim
 {
-void print_env() {}
-void timemory_init(int, char**, const std::string& = "", const std::string& = "") {}
-void timemory_init(const std::string&, const std::string& = "", const std::string& = "")
-{}
-}
+void                              print_env() {}
+template <typename... _Args> void timemory_init(_Args...) {}
+void                              timemory_finalize() {}
+
+/// this provides "functionality" for *_INSTANCE macros
+/// and can be omitted if these macros are not utilized
+struct dummy
+{
+    template <typename... _Args> dummy(_Args&&...) {}
+    ~dummy()            = default;
+    dummy(const dummy&) = default;
+    dummy(dummy&&)      = default;
+    dummy& operator=(const dummy&) = default;
+    dummy& operator=(dummy&&) = default;
+
+    void                              start() {}
+    void                              stop() {}
+    void                              conditional_start() {}
+    void                              conditional_stop() {}
+    void                              report_at_exit(bool) {}
+    template <typename... _Args> void mark_begin(_Args&&...) {}
+    template <typename... _Args> void mark_end(_Args&&...) {}
+    friend std::ostream& operator<<(std::ostream& os, const dummy&) { return os; }
+};
+}  // namespace tim
+
+// creates a label
+#    define TIMEMORY_BASIC_LABEL(...) std::string("")
+#    define TIMEMORY_LABEL(...) std::string("")
+
+// define an object
+#    define TIMEMORY_BLANK_OBJECT(...)
+#    define TIMEMORY_BASIC_OBJECT(...)
+#    define TIMEMORY_OBJECT(...)
+
+// define an object with a caliper reference
+#    define TIMEMORY_BLANK_CALIPER(...)
+#    define TIMEMORY_BASIC_CALIPER(...)
+#    define TIMEMORY_CALIPER(...)
+#    define TIMEMORY_CALIPER_APPLY(...)
+#    define TIMEMORY_CALIPER_TYPE_APPLY(...)
+
+// define an object
+#    define TIMEMORY_BLANK_INSTANCE(...) tim::dummy()
+#    define TIMEMORY_BASIC_INSTANCE(...) tim::dummy()
+#    define TIMEMORY_INSTANCE(...) tim::dummy()
+
+// debug only
+#    define TIMEMORY_DEBUG_BASIC_OBJECT(...)
+#    define TIMEMORY_DEBUG_OBJECT(...)
+#    define TIMEMORY_DEBUG_BASIC_OBJECT(...)
+#    define TIMEMORY_DEBUG_OBJECT(...)
+
+// for CUDA
+#    define TIMEMORY_CALIPER_MARK_STREAM_BEGIN(...)
+#    define TIMEMORY_CALIPER_MARK_STREAM_END(...)
 
 #endif

--- a/source/python/libpytimemory.cpp
+++ b/source/python/libpytimemory.cpp
@@ -143,35 +143,38 @@ PYBIND11_MODULE(libpytimemory, tim)
     //
     //==================================================================================//
     py::module cupti = tim.def_submodule("cupti", "cupti query");
-    cupti.def("available_events",
-              [&](int device) {
+
+    auto get_available_cupti_events = [=](int device) {
 #if defined(TIMEMORY_USE_CUPTI)
-                  CUdevice cu_device;
-                  CUDA_DRIVER_API_CALL(cuInit(0));
-                  CUDA_DRIVER_API_CALL(cuDeviceGet(&cu_device, device));
-                  return tim::cupti::available_events(cu_device);
+        CUdevice cu_device;
+        CUDA_DRIVER_API_CALL(cuInit(0));
+        CUDA_DRIVER_API_CALL(cuDeviceGet(&cu_device, device));
+        return tim::cupti::available_events(cu_device);
 #else
-                  tim::consume_parameters(device);
-                  return py::list();
+        tim::consume_parameters(device);
+        return py::list();
 #endif
-              },
+    };
+
+    auto get_available_cupti_metrics = [=](int device) {
+#if defined(TIMEMORY_USE_CUPTI)
+        CUdevice cu_device;
+        CUDA_DRIVER_API_CALL(cuInit(0));
+        CUDA_DRIVER_API_CALL(cuDeviceGet(&cu_device, device));
+        auto     ret = tim::cupti::available_metrics(cu_device);
+        py::list l;
+        for(const auto& itr : ret)
+            l.append(py::cast<std::string>(itr));
+        return l;
+#else
+        tim::consume_parameters(device);
+        return py::list();
+#endif
+    };
+
+    cupti.def("available_events", get_available_cupti_events,
               "Return the available CUPTI events", py::arg("device") = 0);
-    cupti.def("available_metrics",
-              [&](int device) {
-#if defined(TIMEMORY_USE_CUPTI)
-                  CUdevice cu_device;
-                  CUDA_DRIVER_API_CALL(cuInit(0));
-                  CUDA_DRIVER_API_CALL(cuDeviceGet(&cu_device, device));
-                  auto     ret = tim::cupti::available_metrics(cu_device);
-                  py::list l;
-                  for(const auto& itr : ret)
-                      l.append(py::cast<std::string>(itr));
-                  return l;
-#else
-                  tim::consume_parameters(device);
-                  return py::list();
-#endif
-              },
+    cupti.def("available_metrics", get_available_cupti_metrics,
               "Return the available CUPTI metric", py::arg("device") = 0);
 
     //==================================================================================//
@@ -279,24 +282,31 @@ PYBIND11_MODULE(libpytimemory, tim)
             py::arg("nback") = 2, py::arg("basename_only") = true,
             py::arg("use_dirname") = false, py::arg("noquotes") = false);
     //----------------------------------------------------------------------------------//
-    tim.def("set_max_depth", [&](int32_t ndepth) { manager_t::max_depth(ndepth); },
-            "Max depth of auto-timers");
+    tim.def(
+        "set_max_depth", [&](int32_t ndepth) { manager_t::max_depth(ndepth); },
+        "Max depth of auto-timers");
     //----------------------------------------------------------------------------------//
-    tim.def("get_max_depth", [&]() { return manager_t::max_depth(); },
-            "Max depth of auto-timers");
+    tim.def(
+        "get_max_depth", [&]() { return manager_t::max_depth(); },
+        "Max depth of auto-timers");
     //----------------------------------------------------------------------------------//
-    tim.def("toggle", [&](bool timers_on) { manager_t::enable(timers_on); },
-            "Enable/disable auto-timers", py::arg("timers_on") = true);
+    tim.def(
+        "toggle", [&](bool timers_on) { manager_t::enable(timers_on); },
+        "Enable/disable auto-timers", py::arg("timers_on") = true);
     //----------------------------------------------------------------------------------//
-    tim.def("enable", [&]() { manager_t::enable(true); }, "Enable auto-timers");
+    tim.def(
+        "enable", [&]() { manager_t::enable(true); }, "Enable auto-timers");
     //----------------------------------------------------------------------------------//
-    tim.def("disable", [&]() { manager_t::enable(false); }, "Disable auto-timers");
+    tim.def(
+        "disable", [&]() { manager_t::enable(false); }, "Disable auto-timers");
     //----------------------------------------------------------------------------------//
-    tim.def("is_enabled", [&]() { return manager_t::is_enabled(); },
-            "Return if the auto-timers are enabled or disabled");
+    tim.def(
+        "is_enabled", [&]() { return manager_t::is_enabled(); },
+        "Return if the auto-timers are enabled or disabled");
     //----------------------------------------------------------------------------------//
-    tim.def("enabled", [&]() { return manager_t::is_enabled(); },
-            "Return if the auto-timers are enabled or disabled");
+    tim.def(
+        "enabled", [&]() { return manager_t::is_enabled(); },
+        "Return if the auto-timers are enabled or disabled");
     //----------------------------------------------------------------------------------//
     tim.def("enable_signal_detection", &pytim::enable_signal_detection,
             "Enable signal detection", py::arg("signal_list") = py::list());
@@ -304,8 +314,9 @@ PYBIND11_MODULE(libpytimemory, tim)
     tim.def("disable_signal_detection", &pytim::disable_signal_detection,
             "Enable signal detection");
     //----------------------------------------------------------------------------------//
-    tim.def("has_mpi_support", [&]() { return tim::mpi::is_supported(); },
-            "Return if the TiMemory library has MPI support");
+    tim.def(
+        "has_mpi_support", [&]() { return tim::mpi::is_supported(); },
+        "Return if the TiMemory library has MPI support");
     //----------------------------------------------------------------------------------//
     tim.def("set_rusage_children", set_rusage_child,
             "Set the rusage to record child processes");
@@ -313,28 +324,29 @@ PYBIND11_MODULE(libpytimemory, tim)
     tim.def("set_rusage_self", set_rusage_self,
             "Set the rusage to record child processes");
     //----------------------------------------------------------------------------------//
-    tim.def("set_exit_action",
-            [&](py::function func) {
-                auto _func              = [&](int errcode) -> void { func(errcode); };
-                using signal_function_t = std::function<void(int)>;
-                using std::placeholders::_1;
-                signal_function_t _f = std::bind<void>(_func, _1);
-                tim::signal_settings::set_exit_action(_f);
-            },
-            "Set the exit action when a signal is raised -- function must accept "
-            "integer");
+    tim.def(
+        "set_exit_action",
+        [&](py::function func) {
+            auto _func              = [&](int errcode) -> void { func(errcode); };
+            using signal_function_t = std::function<void(int)>;
+            using std::placeholders::_1;
+            signal_function_t _f = std::bind<void>(_func, _1);
+            tim::signal_settings::set_exit_action(_f);
+        },
+        "Set the exit action when a signal is raised -- function must accept "
+        "integer");
     //----------------------------------------------------------------------------------//
-    tim.def("timemory_init",
-            [&](py::list argv, std::string _prefix, std::string _suffix) {
-                if(argv.size() < 1)
-                    return;
-                char* _argv =
-                    const_cast<char*>(argv.begin()->cast<std::string>().c_str());
-                tim::timemory_init(1, &_argv, _prefix, _suffix);
-            },
-            "Parse the environment and use argv[0] to set output path",
-            py::arg("argv") = py::list(), py::arg("prefix") = "timemory-",
-            py::arg("suffix") = "-output");
+    tim.def(
+        "timemory_init",
+        [&](py::list argv, std::string _prefix, std::string _suffix) {
+            if(argv.size() < 1)
+                return;
+            char* _argv = const_cast<char*>(argv.begin()->cast<std::string>().c_str());
+            tim::timemory_init(1, &_argv, _prefix, _suffix);
+        },
+        "Parse the environment and use argv[0] to set output path",
+        py::arg("argv") = py::list(), py::arg("prefix") = "timemory-",
+        py::arg("suffix") = "-output");
 
     //==================================================================================//
     //
@@ -344,52 +356,60 @@ PYBIND11_MODULE(libpytimemory, tim)
     timer.def(py::init(&pytim::init::timer), "Initialization",
               py::return_value_policy::take_ownership, py::arg("prefix") = "");
     //----------------------------------------------------------------------------------//
-    timer.def("real_elapsed",
-              [&](py::object pytimer) {
-                  tim_timer_t& _timer = *(pytimer.cast<tim_timer_t*>());
-                  auto&        obj    = std::get<0>(_timer);
-                  return obj.get_display();
-              },
-              "Elapsed wall clock");
+    timer.def(
+        "real_elapsed",
+        [&](py::object pytimer) {
+            tim_timer_t& _timer = *(pytimer.cast<tim_timer_t*>());
+            auto&        obj    = std::get<0>(_timer);
+            return obj.get_display();
+        },
+        "Elapsed wall clock");
     //----------------------------------------------------------------------------------//
-    timer.def("sys_elapsed",
-              [&](py::object pytimer) {
-                  tim_timer_t& _timer = *(pytimer.cast<tim_timer_t*>());
-                  auto&        obj    = std::get<1>(_timer);
-                  return obj.get_display();
-              },
-              "Elapsed system clock");
+    timer.def(
+        "sys_elapsed",
+        [&](py::object pytimer) {
+            tim_timer_t& _timer = *(pytimer.cast<tim_timer_t*>());
+            auto&        obj    = std::get<1>(_timer);
+            return obj.get_display();
+        },
+        "Elapsed system clock");
     //----------------------------------------------------------------------------------//
-    timer.def("user_elapsed",
-              [&](py::object pytimer) {
-                  tim_timer_t& _timer = *(pytimer.cast<tim_timer_t*>());
-                  auto&        obj    = std::get<2>(_timer);
-                  return obj.get_display();
-              },
-              "Elapsed user time");
+    timer.def(
+        "user_elapsed",
+        [&](py::object pytimer) {
+            tim_timer_t& _timer = *(pytimer.cast<tim_timer_t*>());
+            auto&        obj    = std::get<2>(_timer);
+            return obj.get_display();
+        },
+        "Elapsed user time");
     //----------------------------------------------------------------------------------//
-    timer.def("start", [&](py::object pytimer) { pytimer.cast<tim_timer_t*>()->start(); },
-              "Start timer");
+    timer.def(
+        "start", [&](py::object pytimer) { pytimer.cast<tim_timer_t*>()->start(); },
+        "Start timer");
     //----------------------------------------------------------------------------------//
-    timer.def("stop", [&](py::object pytimer) { pytimer.cast<tim_timer_t*>()->stop(); },
-              "Stop timer");
+    timer.def(
+        "stop", [&](py::object pytimer) { pytimer.cast<tim_timer_t*>()->stop(); },
+        "Stop timer");
     //----------------------------------------------------------------------------------//
-    timer.def("report",
-              [&](py::object pytimer) {
-                  std::cout << *(pytimer.cast<tim_timer_t*>()) << std::endl;
-              },
-              "Report timer");
+    timer.def(
+        "report",
+        [&](py::object pytimer) {
+            std::cout << *(pytimer.cast<tim_timer_t*>()) << std::endl;
+        },
+        "Report timer");
     //----------------------------------------------------------------------------------//
-    timer.def("__str__",
-              [&](py::object pytimer) {
-                  std::stringstream ss;
-                  ss << *(pytimer.cast<tim_timer_t*>());
-                  return ss.str();
-              },
-              "Stringify timer");
+    timer.def(
+        "__str__",
+        [&](py::object pytimer) {
+            std::stringstream ss;
+            ss << *(pytimer.cast<tim_timer_t*>());
+            return ss.str();
+        },
+        "Stringify timer");
     //----------------------------------------------------------------------------------//
-    timer.def("reset", [&](py::object self) { self.cast<tim_timer_t*>()->reset(); },
-              "Reset the timer");
+    timer.def(
+        "reset", [&](py::object self) { self.cast<tim_timer_t*>()->reset(); },
+        "Reset the timer");
     //----------------------------------------------------------------------------------//
 
     //==================================================================================//
@@ -404,11 +424,13 @@ PYBIND11_MODULE(libpytimemory, tim)
     man.def(py::init<>(&pytim::init::manager), "Initialization",
             py::return_value_policy::take_ownership);
     //----------------------------------------------------------------------------------//
-    man.def("set_max_depth", [&](py::object, int depth) { manager_t::max_depth(depth); },
-            "Set the max depth of the timers");
+    man.def(
+        "set_max_depth", [&](py::object, int depth) { manager_t::max_depth(depth); },
+        "Set the max depth of the timers");
     //----------------------------------------------------------------------------------//
-    man.def("get_max_depth", [&](py::object) { return manager_t::max_depth(); },
-            "Get the max depth of the timers");
+    man.def(
+        "get_max_depth", [&](py::object) { return manager_t::max_depth(); },
+        "Get the max depth of the timers");
     //----------------------------------------------------------------------------------//
     man.def("write_ctest_notes", &pytim::manager::write_ctest_notes,
             "Write a CTestNotes.cmake file", py::arg("directory") = ".",
@@ -432,14 +454,15 @@ PYBIND11_MODULE(libpytimemory, tim)
                    py::arg("nback") = 1, py::arg("added_args") = false,
                    py::return_value_policy::take_ownership);
     //----------------------------------------------------------------------------------//
-    auto_timer.def("__str__",
-                   [&](py::object _pyauto_timer) {
-                       std::stringstream _ss;
-                       auto_timer_t* _auto_timer = _pyauto_timer.cast<auto_timer_t*>();
-                       _ss << _auto_timer->component_tuple();
-                       return _ss.str();
-                   },
-                   "Print the auto timer");
+    auto_timer.def(
+        "__str__",
+        [&](py::object _pyauto_timer) {
+            std::stringstream _ss;
+            auto_timer_t*     _auto_timer = _pyauto_timer.cast<auto_timer_t*>();
+            _ss << _auto_timer->get_component_type();
+            return _ss.str();
+        },
+        "Print the auto timer");
     //----------------------------------------------------------------------------------//
     timer_decorator.def(py::init(&pytim::init::timer_decorator), "Initialization",
                         py::return_value_policy::automatic);
@@ -455,41 +478,43 @@ PYBIND11_MODULE(libpytimemory, tim)
                   py::arg("report_at_exit") = false, py::arg("nback") = 1,
                   py::arg("added_args") = false, py::return_value_policy::take_ownership);
     //----------------------------------------------------------------------------------//
-    comp_list.def("start",
-                  [&](py::object pytimer) { pytimer.cast<component_list_t*>()->start(); },
-                  "Start component tuple");
+    comp_list.def(
+        "start", [&](py::object pytimer) { pytimer.cast<component_list_t*>()->start(); },
+        "Start component tuple");
     //----------------------------------------------------------------------------------//
-    comp_list.def("stop",
-                  [&](py::object pytimer) { pytimer.cast<component_list_t*>()->stop(); },
-                  "Stop component tuple");
+    comp_list.def(
+        "stop", [&](py::object pytimer) { pytimer.cast<component_list_t*>()->stop(); },
+        "Stop component tuple");
     //----------------------------------------------------------------------------------//
-    comp_list.def("report",
-                  [&](py::object pytimer) {
-                      std::cout << *(pytimer.cast<component_list_t*>()) << std::endl;
-                  },
-                  "Report component tuple");
+    comp_list.def(
+        "report",
+        [&](py::object pytimer) {
+            std::cout << *(pytimer.cast<component_list_t*>()) << std::endl;
+        },
+        "Report component tuple");
     //----------------------------------------------------------------------------------//
-    comp_list.def("__str__",
-                  [&](py::object pytimer) {
-                      std::stringstream ss;
-                      ss << *(pytimer.cast<component_list_t*>());
-                      return ss.str();
-                  },
-                  "Stringify component tuple");
+    comp_list.def(
+        "__str__",
+        [&](py::object pytimer) {
+            std::stringstream ss;
+            ss << *(pytimer.cast<component_list_t*>());
+            return ss.str();
+        },
+        "Stringify component tuple");
     //----------------------------------------------------------------------------------//
-    comp_list.def("reset",
-                  [&](py::object self) { self.cast<component_list_t*>()->reset(); },
-                  "Reset the component tuple");
+    comp_list.def(
+        "reset", [&](py::object self) { self.cast<component_list_t*>()->reset(); },
+        "Reset the component tuple");
     //----------------------------------------------------------------------------------//
-    comp_list.def("__str__",
-                  [&](py::object _pyauto_tuple) {
-                      std::stringstream _ss;
-                      component_list_t* _auto_tuple =
-                          _pyauto_tuple.cast<component_list_t*>();
-                      _ss << *_auto_tuple;
-                      return _ss.str();
-                  },
-                  "Print the component tuple");
+    comp_list.def(
+        "__str__",
+        [&](py::object _pyauto_tuple) {
+            std::stringstream _ss;
+            component_list_t* _auto_tuple = _pyauto_tuple.cast<component_list_t*>();
+            _ss << *_auto_tuple;
+            return _ss.str();
+        },
+        "Print the component tuple");
     //----------------------------------------------------------------------------------//
     comp_decorator.def(py::init(&pytim::init::component_decorator), "Initialization",
                        py::return_value_policy::automatic);
@@ -519,60 +544,66 @@ PYBIND11_MODULE(libpytimemory, tim)
                   py::return_value_policy::take_ownership, py::arg("prefix") = "",
                   py::arg("record") = false);
     //----------------------------------------------------------------------------------//
-    rss_usage.def("record", [&](py::object self) { self.cast<rss_usage_t*>()->record(); },
-                  "Record the RSS usage");
+    rss_usage.def(
+        "record", [&](py::object self) { self.cast<rss_usage_t*>()->record(); },
+        "Record the RSS usage");
     //----------------------------------------------------------------------------------//
-    rss_usage.def("__str__",
-                  [&](py::object self) {
-                      std::stringstream ss;
-                      ss << *(self.cast<rss_usage_t*>());
-                      return ss.str();
-                  },
-                  "Stringify the rss usage");
+    rss_usage.def(
+        "__str__",
+        [&](py::object self) {
+            std::stringstream ss;
+            ss << *(self.cast<rss_usage_t*>());
+            return ss.str();
+        },
+        "Stringify the rss usage");
     //----------------------------------------------------------------------------------//
-    rss_usage.def("__iadd__",
-                  [&](py::object self, py::object rhs) {
-                      *(self.cast<rss_usage_t*>()) += *(rhs.cast<rss_usage_t*>());
-                      return self;
-                  },
-                  "Add rss usage");
+    rss_usage.def(
+        "__iadd__",
+        [&](py::object self, py::object rhs) {
+            *(self.cast<rss_usage_t*>()) += *(rhs.cast<rss_usage_t*>());
+            return self;
+        },
+        "Add rss usage");
     //----------------------------------------------------------------------------------//
-    rss_usage.def("__isub__",
-                  [&](py::object self, py::object rhs) {
-                      *(self.cast<rss_usage_t*>()) -= *(rhs.cast<rss_usage_t*>());
-                      return self;
-                  },
-                  "Subtract rss usage");
+    rss_usage.def(
+        "__isub__",
+        [&](py::object self, py::object rhs) {
+            *(self.cast<rss_usage_t*>()) -= *(rhs.cast<rss_usage_t*>());
+            return self;
+        },
+        "Subtract rss usage");
     //----------------------------------------------------------------------------------//
-    rss_usage.def("__add__",
-                  [&](py::object self, py::object rhs) {
-                      rss_usage_t* _rss = new rss_usage_t(*(self.cast<rss_usage_t*>()));
-                      *_rss += *(rhs.cast<rss_usage_t*>());
-                      return _rss;
-                  },
-                  "Add rss usage", py::return_value_policy::take_ownership);
+    rss_usage.def(
+        "__add__",
+        [&](py::object self, py::object rhs) {
+            rss_usage_t* _rss = new rss_usage_t(*(self.cast<rss_usage_t*>()));
+            *_rss += *(rhs.cast<rss_usage_t*>());
+            return _rss;
+        },
+        "Add rss usage", py::return_value_policy::take_ownership);
     //----------------------------------------------------------------------------------//
-    rss_usage.def("__sub__",
-                  [&](py::object self, py::object rhs) {
-                      rss_usage_t* _rss = new rss_usage_t(*(self.cast<rss_usage_t*>()));
-                      *_rss -= *(rhs.cast<rss_usage_t*>());
-                      return _rss;
-                  },
-                  "Subtract rss usage", py::return_value_policy::take_ownership);
+    rss_usage.def(
+        "__sub__",
+        [&](py::object self, py::object rhs) {
+            rss_usage_t* _rss = new rss_usage_t(*(self.cast<rss_usage_t*>()));
+            *_rss -= *(rhs.cast<rss_usage_t*>());
+            return _rss;
+        },
+        "Subtract rss usage", py::return_value_policy::take_ownership);
     //----------------------------------------------------------------------------------//
-    rss_usage.def("current",
-                  [&](py::object self, int64_t /*_units*/) {
-                      return std::get<0>(*self.cast<rss_usage_t*>()).get_display();
-                  },
-                  "Return the current rss usage",
-                  py::arg("units") = units.attr("megabyte"));
+    rss_usage.def(
+        "current",
+        [&](py::object self, int64_t /*_units*/) {
+            return std::get<0>(*self.cast<rss_usage_t*>()).get_display();
+        },
+        "Return the current rss usage", py::arg("units") = units.attr("megabyte"));
     //----------------------------------------------------------------------------------//
-    rss_usage.def("peak",
-                  [&](py::object self, int64_t /*_units*/) {
-                      return std::get<1>(*self.cast<rss_usage_t*>()).get_display();
-                  },
-                  "Return the current rss usage",
-                  py::arg("units") = units.attr("megabyte"));
+    rss_usage.def(
+        "peak",
+        [&](py::object self, int64_t /*_units*/) {
+            return std::get<1>(*self.cast<rss_usage_t*>()).get_display();
+        },
+        "Return the current rss usage", py::arg("units") = units.attr("megabyte"));
 
     //==================================================================================//
     //
@@ -587,8 +618,9 @@ PYBIND11_MODULE(libpytimemory, tim)
     //==================================================================================//
 
     // ---------------------------------------------------------------------- //
-    opts.def("default_max_depth", [&]() { return std::numeric_limits<uint16_t>::max(); },
-             "Return the default max depth");
+    opts.def(
+        "default_max_depth", [&]() { return std::numeric_limits<uint16_t>::max(); },
+        "Return the default max depth");
     // ---------------------------------------------------------------------- //
     opts.def("safe_mkdir", &pytim::opt::safe_mkdir,
              "if [ ! -d <directory> ]; then mkdir -p <directory> ; fi");

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -32,6 +32,11 @@ endif()
 
 message(STATUS "[${PROJECT_NAME}] hybrid test components: ${HYBRID_COMPONENTS}")
 
+add_googletest(macro_tests
+    DISCOVER_TESTS
+    SOURCES         macro_tests.cpp
+    LINK_LIBRARIES  timemory-headers timemory-compile-options)
+
 add_googletest(hybrid_tests
     DISCOVER_TESTS
     SOURCES         hybrid_tests.cpp

--- a/source/tests/cuda_tests.cpp
+++ b/source/tests/cuda_tests.cpp
@@ -201,11 +201,11 @@ TEST_F(cuda_tests, saxpy_streams)
         y[i] = 2.0;
     }
 
-    TIMEMORY_BLANK_AUTO_TUPLE_CALIPER(mem, tuple_t, "memory");
+    TIMEMORY_BLANK_CALIPER(mem, tuple_t, "memory");
     auto& mem = TIMEMORY_CALIPER_REFERENCE(mem);
     mem.start();
 
-    TIMEMORY_BLANK_AUTO_TUPLE_CALIPER(dev, tuple_t, "iterations + memory");
+    TIMEMORY_BLANK_CALIPER(dev, tuple_t, "iterations + memory");
     auto& dev = TIMEMORY_CALIPER_REFERENCE(dev);
     dev.start();
 

--- a/source/tests/hybrid_tests.cpp
+++ b/source/tests/hybrid_tests.cpp
@@ -152,8 +152,9 @@ get_info(const _Tp& obj, _Func&& _func)
 template <typename _Tp, typename _Up, typename _Vp = typename _Tp::value_type,
           typename _Func = std::function<_Vp(_Vp)>>
 void
-print_info(const _Tp& obj, const _Up& expected, string_t unit,
-           _Func _func = [](const _Vp& obj) { return obj; })
+print_info(
+    const _Tp& obj, const _Up& expected, string_t unit,
+    _Func _func = [](const _Vp& obj) { return obj; })
 {
     std::cout << std::endl;
     std::cout << "[" << get_test_name() << "]>  measured : " << obj << std::endl;

--- a/source/tests/macro_tests.cpp
+++ b/source/tests/macro_tests.cpp
@@ -1,0 +1,156 @@
+// MIT License
+//
+// Copyright (c) 2019, The Regents of the University of California,
+// through Lawrence Berkeley National Laboratory (subject to receipt of any
+// required approvals from the U.S. Dept. of Energy).  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "gtest/gtest.h"
+
+#include <timemory/timemory.hpp>
+
+#include <chrono>
+#include <iostream>
+#include <mutex>
+#include <random>
+#include <thread>
+#include <vector>
+
+using namespace tim::component;
+using mutex_t   = std::mutex;
+using lock_t    = std::unique_lock<mutex_t>;
+using condvar_t = std::condition_variable;
+
+using auto_tuple_t      = tim::auto_tuple<real_clock, cpu_clock, cpu_util>;
+using component_tuple_t = typename auto_tuple_t::component_type;
+
+//--------------------------------------------------------------------------------------//
+
+namespace details
+{
+//--------------------------------------------------------------------------------------//
+//  Get the current tests name
+//
+inline std::string
+get_test_name()
+{
+    return ::testing::UnitTest::GetInstance()->current_test_info()->name();
+}
+// this function consumes approximately "n" milliseconds of real time
+void
+do_sleep(long n)
+{
+    std::this_thread::sleep_for(std::chrono::milliseconds(n));
+}
+
+// this function consumes an unknown number of cpu resources
+long
+fibonacci(long n)
+{
+    return (n < 2) ? n : (fibonacci(n - 1) + fibonacci(n - 2));
+}
+
+// this function consumes approximately "t" milliseconds of cpu time
+void
+consume(long n)
+{
+    // a mutex held by one lock
+    mutex_t mutex;
+    // acquire lock
+    lock_t hold_lk(mutex);
+    // associate but defer
+    lock_t try_lk(mutex, std::defer_lock);
+    // get current time
+    auto now = std::chrono::system_clock::now();
+    // get elapsed
+    auto until = now + std::chrono::milliseconds(n);
+    // try until time point
+    while(std::chrono::system_clock::now() < until)
+        try_lk.try_lock();
+}
+
+}  // namespace details
+
+//--------------------------------------------------------------------------------------//
+
+class macro_tests : public ::testing::Test
+{
+};
+
+//--------------------------------------------------------------------------------------//
+
+TEST_F(macro_tests, blank_object)
+{
+    TIMEMORY_BLANK_OBJECT(auto_tuple_t, details::get_test_name());
+    details::do_sleep(25);
+    details::consume(75);
+    timemory_variable_101.stop();
+    auto              key = timemory_variable_101.key();
+    std::stringstream expected;
+    expected << details::get_test_name();
+    if(key != expected.str())
+    {
+        std::cout << std::endl;
+        std::cout << std::setw(12) << "key"
+                  << ": " << key << std::endl;
+        std::cout << std::setw(12) << "expected"
+                  << ": " << expected.str() << std::endl;
+        std::cout << std::endl;
+        FAIL();
+    }
+    else
+        SUCCEED();
+}
+
+//--------------------------------------------------------------------------------------//
+
+TEST_F(macro_tests, basic_object)
+{
+    TIMEMORY_BASIC_OBJECT(auto_tuple_t, "_", details::get_test_name());
+    details::do_sleep(25);
+    details::consume(75);
+    timemory_variable_126.stop();
+    auto              key = timemory_variable_126.key();
+    std::stringstream expected;
+    expected << __FUNCTION__ << "_" << details::get_test_name();
+    if(key != expected.str())
+    {
+        std::cout << std::endl;
+        std::cout << std::setw(12) << "key"
+                  << ": " << key << std::endl;
+        std::cout << std::setw(12) << "expected"
+                  << ": " << expected.str() << std::endl;
+        std::cout << std::endl;
+        FAIL();
+    }
+    else
+        SUCCEED();
+}
+
+//--------------------------------------------------------------------------------------//
+
+int
+main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    return RUN_ALL_TESTS();
+}
+
+//--------------------------------------------------------------------------------------//

--- a/source/tests/timing_tests.cpp
+++ b/source/tests/timing_tests.cpp
@@ -24,9 +24,12 @@
 
 #include "gtest/gtest.h"
 
-#include <chrono>
-#include <thread>
 #include <timemory/timemory.hpp>
+
+#include <chrono>
+#include <condition_variable>
+#include <mutex>
+#include <thread>
 
 using namespace tim::component;
 using mutex_t   = std::mutex;

--- a/source/timemory/components/rusage.hpp
+++ b/source/timemory/components/rusage.hpp
@@ -695,9 +695,8 @@ struct read_bytes : public base<read_bytes, std::tuple<int64_t, int64_t>>
 
 //--------------------------------------------------------------------------------------//
 /// \class written_bytes
-/// \brief I/O counter: bytes read Attempt to count the number of bytes which this process
-/// really did cause to be fetched from the storage layer. Done at the submit_bio() level,
-/// so it is accurate for block-backed filesystems.
+/// \brief I/O counter: Attempt to count the number of bytes which this process caused to
+/// be sent to the storage layer. This is done at page-dirtying time.
 //
 struct written_bytes : public base<written_bytes, std::tuple<int64_t, int64_t>>
 {

--- a/source/timemory/ctimemory.h
+++ b/source/timemory/ctimemory.h
@@ -38,6 +38,23 @@
 #include <stdlib.h>
 #include <string.h>
 
+#if defined(DISABLE_TIMEMORY)
+
+#    define TIMEMORY_SETTINGS_INIT                                                       \
+        {                                                                                \
+        }
+#    define TIMEMORY_INIT(...)
+#    define TIMEMORY_BLANK_AUTO_TIMER(...) NULL
+#    define TIMEMORY_BASIC_AUTO_TIMER(...) NULL
+#    define TIMEMORY_AUTO_TIMER(...) NULL
+#    define TIMEMORY_BASIC_AUTO_TUPLE(...) NULL
+#    define TIMEMORY_BLANK_AUTO_TUPLE(...) NULL
+#    define TIMEMORY_AUTO_TUPLE(...) NULL
+#    define FREE_TIMEMORY_AUTO_TIMER(...)
+#    define FREE_TIMEMORY_AUTO_TUPLE(...)
+
+#else  // !defined(DISABLE_TIMEMORY)
+
 //======================================================================================//
 //
 //      Operating System
@@ -45,48 +62,49 @@
 //======================================================================================//
 
 // machine bits
-#if defined(__x86_64__)
-#    if !defined(_64BIT)
-#        define _64BIT
+#    if defined(__x86_64__)
+#        if !defined(_64BIT)
+#            define _64BIT
+#        endif
+#    else
+#        if !defined(_32BIT)
+#            define _32BIT
+#        endif
 #    endif
-#else
-#    if !defined(_32BIT)
-#        define _32BIT
-#    endif
-#endif
 
 //--------------------------------------------------------------------------------------//
 // base operating system
 
-#if defined(_WIN32) || defined(_WIN64)
-#    if !defined(_WINDOWS)
-#        define _WINDOWS
-#    endif
+#    if defined(_WIN32) || defined(_WIN64)
+#        if !defined(_WINDOWS)
+#            define _WINDOWS
+#        endif
 //--------------------------------------------------------------------------------------//
 
-#elif defined(__APPLE__) || defined(__MACH__)
-#    if !defined(_MACOS)
-#        define _MACOS
-#    endif
-#    if !defined(_UNIX)
-#        define _UNIX
-#    endif
+#    elif defined(__APPLE__) || defined(__MACH__)
+#        if !defined(_MACOS)
+#            define _MACOS
+#        endif
+#        if !defined(_UNIX)
+#            define _UNIX
+#        endif
 //--------------------------------------------------------------------------------------//
 
-#elif defined(__linux__) || defined(__linux) || defined(linux) || defined(__gnu_linux__)
-#    if !defined(_LINUX)
-#        define _LINUX
-#    endif
-#    if !defined(_UNIX)
-#        define _UNIX
-#    endif
+#    elif defined(__linux__) || defined(__linux) || defined(linux) ||                    \
+        defined(__gnu_linux__)
+#        if !defined(_LINUX)
+#            define _LINUX
+#        endif
+#        if !defined(_UNIX)
+#            define _UNIX
+#        endif
 //--------------------------------------------------------------------------------------//
 
-#elif defined(__unix__) || defined(__unix) || defined(unix) || defined(_)
-#    if !defined(_UNIX)
-#        define _UNIX
+#    elif defined(__unix__) || defined(__unix) || defined(unix) || defined(_)
+#        if !defined(_UNIX)
+#            define _UNIX
+#        endif
 #    endif
-#endif
 
 //======================================================================================//
 //
@@ -95,18 +113,18 @@
 //======================================================================================//
 
 // Define macros for WIN32 for importing/exporting external symbols to DLLs
-#if defined(_WINDOWS) && !defined(_TIMEMORY_ARCHIVE)
-#    if defined(_TIMEMORY_DLL)
-#        define tim_api __declspec(dllexport)
-#        define tim_api_static static __declspec(dllexport)
+#    if defined(_WINDOWS) && !defined(_TIMEMORY_ARCHIVE)
+#        if defined(_TIMEMORY_DLL)
+#            define tim_api __declspec(dllexport)
+#            define tim_api_static static __declspec(dllexport)
+#        else
+#            define tim_api __declspec(dllimport)
+#            define tim_api_static static __declspec(dllimport)
+#        endif
 #    else
-#        define tim_api __declspec(dllimport)
-#        define tim_api_static static __declspec(dllimport)
+#        define tim_api
+#        define tim_api_static static
 #    endif
-#else
-#    define tim_api
-#    define tim_api_static static
-#endif
 
 //======================================================================================//
 //
@@ -160,10 +178,10 @@ enum TIMEMORY_COMPONENT
 //
 //======================================================================================//
 
-#if defined(__cplusplus)
+#    if defined(__cplusplus)
 extern "C"
 {
-#endif
+#    endif
 
     typedef struct
     {
@@ -179,9 +197,9 @@ extern "C"
         // skipping remainder
     } timemory_settings;
 
-#if defined(__cplusplus)
+#    if defined(__cplusplus)
 }
-#endif
+#    endif
 
 //======================================================================================//
 //
@@ -213,44 +231,44 @@ c_timemory_auto_str(const char*, const char*, const char*, int);
 //======================================================================================//
 
 // only define for C
-#if !defined(__cplusplus)
+#    if !defined(__cplusplus)
 
-#    if !defined(__FUNCTION__) && defined(__func__)
-#        define __FUNCTION__ __func__
-#    endif
+#        if !defined(__FUNCTION__) && defined(__func__)
+#            define __FUNCTION__ __func__
+#        endif
 
-#    if defined(TIMEMORY_PRETTY_FUNCTION) && !defined(_WINDOWS)
-#        define __TIMEMORY_FUNCTION__ __PRETTY_FUNCTION__
-#    else
-#        define __TIMEMORY_FUNCTION__ __FUNCTION__
-#    endif
+#        if defined(TIMEMORY_PRETTY_FUNCTION) && !defined(_WINDOWS)
+#            define __TIMEMORY_FUNCTION__ __PRETTY_FUNCTION__
+#        else
+#            define __TIMEMORY_FUNCTION__ __FUNCTION__
+#        endif
 
 // stringify some macro -- uses TIMEMORY_STRINGIFY2 which does the actual
 //   "stringify-ing" after the macro has been substituted by it's result
-#    if !defined(TIMEMORY_STRINGIZE)
-#        define TIMEMORY_STRINGIZE(X) TIMEMORY_STRINGIZE2(X)
-#    endif
+#        if !defined(TIMEMORY_STRINGIZE)
+#            define TIMEMORY_STRINGIZE(X) TIMEMORY_STRINGIZE2(X)
+#        endif
 
 // actual stringifying
-#    if !defined(TIMEMORY_STRINGIZE2)
-#        define TIMEMORY_STRINGIZE2(X) #        X
-#    endif
+#        if !defined(TIMEMORY_STRINGIZE2)
+#            define TIMEMORY_STRINGIZE2(X) #            X
+#        endif
 
 // stringify the __LINE__ macro
-#    if !defined(TIMEMORY_LINE_STRING)
-#        define TIMEMORY_LINE_STRING TIMEMORY_STRINGIZE(__LINE__)
-#    endif
+#        if !defined(TIMEMORY_LINE_STRING)
+#            define TIMEMORY_LINE_STRING TIMEMORY_STRINGIZE(__LINE__)
+#        endif
 
 //--------------------------------------------------------------------------------------//
 //
-#    if !defined(TIMEMORY_AUTO_LABEL)
-#        define TIMEMORY_AUTO_LABEL(c_str)                                               \
-            c_timemory_auto_str(__TIMEMORY_FUNCTION__, c_str, __FILE__, __LINE__)
-#    endif
+#        if !defined(TIMEMORY_AUTO_LABEL)
+#            define TIMEMORY_AUTO_LABEL(c_str)                                           \
+                c_timemory_auto_str(__TIMEMORY_FUNCTION__, c_str, __FILE__, __LINE__)
+#        endif
 
 //--------------------------------------------------------------------------------------//
-#    define TIMEMORY_SETTINGS_INIT { 1, -1, -1, -1, -1, -1, -1, -1, -1 };
-#    define TIMEMORY_INIT(argc, argv, settings) c_timemory_init(argc, argv, settings);
+#        define TIMEMORY_SETTINGS_INIT { 1, -1, -1, -1, -1, -1, -1, -1, -1 };
+#        define TIMEMORY_INIT(argc, argv, settings) c_timemory_init(argc, argv, settings)
 
 //--------------------------------------------------------------------------------------//
 /*! \def TIMEMORY_BLANK_AUTO_TIMER(c_str)
@@ -264,7 +282,8 @@ c_timemory_auto_str(const char*, const char*, const char*, int);
  *          FREE_TIMEMORY_AUTO_TIMER(timer);
  *      }
  */
-#    define TIMEMORY_BLANK_AUTO_TIMER(c_str) c_timemory_create_auto_timer(c_str, __LINE__)
+#        define TIMEMORY_BLANK_AUTO_TIMER(c_str)                                         \
+            c_timemory_create_auto_timer(c_str, __LINE__)
 
 //--------------------------------------------------------------------------------------//
 /*! \def TIMEMORY_BASIC_AUTO_TIMER(c_str)
@@ -278,9 +297,9 @@ c_timemory_auto_str(const char*, const char*, const char*, int);
  *          FREE_TIMEMORY_AUTO_TIMER(timer);
  *      }
  */
-#    define TIMEMORY_BASIC_AUTO_TIMER(c_str)                                             \
-        c_timemory_create_auto_timer(                                                    \
-            c_timemory_string_combine(__TIMEMORY_FUNCTION__, c_str), __LINE__)
+#        define TIMEMORY_BASIC_AUTO_TIMER(c_str)                                         \
+            c_timemory_create_auto_timer(                                                \
+                c_timemory_string_combine(__TIMEMORY_FUNCTION__, c_str), __LINE__)
 
 //--------------------------------------------------------------------------------------//
 /*! \def TIMEMORY_AUTO_TIMER(str)
@@ -295,63 +314,63 @@ c_timemory_auto_str(const char*, const char*, const char*, int);
  *      }
  *
  */
-#    define TIMEMORY_AUTO_TIMER(c_str)                                                   \
-        c_timemory_create_auto_timer(                                                    \
-            c_timemory_auto_str(__TIMEMORY_FUNCTION__, c_str, __FILE__, __LINE__),       \
-            __LINE__)
+#        define TIMEMORY_AUTO_TIMER(c_str)                                               \
+            c_timemory_create_auto_timer(                                                \
+                c_timemory_auto_str(__TIMEMORY_FUNCTION__, c_str, __FILE__, __LINE__),   \
+                __LINE__)
 
 //--------------------------------------------------------------------------------------//
-/*! \def TIMEMORY_BASIC_AUTO_TUPLE(c_str, ...)
+/*! \def TIMEMORY_BASIC_OBJECT(c_str, ...)
  *
  * Usage:
  *
  *      void some_func()
  *      {
- *          void* timer = new TIMEMORY_BASIC_AUTO_TUPLE("", WALL_CLOCK, CPU_CLOCK);
+ *          void* timer = new TIMEMORY_BASIC_OBJECT("", WALL_CLOCK, CPU_CLOCK);
  *          ...
- *          FREE_TIMEMORY_AUTO_TUPLE(timer);
+ *          FREE_TIMEMORY_OBJECT(timer);
  *      }
  *
  */
-#    define TIMEMORY_BASIC_AUTO_TUPLE(c_str, ...)                                        \
-        c_timemory_create_auto_tuple(                                                    \
-            c_timemory_auto_str(__TIMEMORY_FUNCTION__, c_str, __FILE__, __LINE__),       \
-            __LINE__, __VA_ARGS__, TIMEMORY_COMPONENTS_END)
+#        define TIMEMORY_BASIC_OBJECT(c_str, ...)                                        \
+            c_timemory_create_auto_tuple(                                                \
+                c_timemory_auto_str(__TIMEMORY_FUNCTION__, c_str, __FILE__, __LINE__),   \
+                __LINE__, __VA_ARGS__, TIMEMORY_COMPONENTS_END)
 
 //--------------------------------------------------------------------------------------//
-/*! \def TIMEMORY_BLANK_AUTO_TUPLE(c_str, ...)
+/*! \def TIMEMORY_BLANK_OBJECT(c_str, ...)
  *
  * Usage:
  *
  *      void some_func()
  *      {
- *          void* timer = new TIMEMORY_BLANK_AUTO_TUPLE("id", WALL_CLOCK, CPU_CLOCK);
+ *          void* timer = new TIMEMORY_BLANK_OBJECT("id", WALL_CLOCK, CPU_CLOCK);
  *          ...
- *          FREE_TIMEMORY_AUTO_TUPLE(timer);
+ *          FREE_TIMEMORY_OBJECT(timer);
  *      }
  *
  */
-#    define TIMEMORY_BLANK_AUTO_TUPLE(c_str, ...)                                        \
-        c_timemory_create_auto_tuple(c_str, __LINE__, __VA_ARGS__,                       \
-                                     TIMEMORY_COMPONENTS_END)
+#        define TIMEMORY_BLANK_OBJECT(c_str, ...)                                        \
+            c_timemory_create_auto_tuple(c_str, __LINE__, __VA_ARGS__,                   \
+                                         TIMEMORY_COMPONENTS_END)
 
 //--------------------------------------------------------------------------------------//
-/*! \def TIMEMORY_AUTO_TUPLE(c_str, ...)
+/*! \def TIMEMORY_OBJECT(c_str, ...)
  *
  * Usage:
  *
  *      void some_func()
  *      {
- *          void* timer = new TIMEMORY_AUTO_TUPLE("", WALL_CLOCK, SYS_CLOCK, CPU_CLOCK);
+ *          void* timer = new TIMEMORY_OBJECT("", WALL_CLOCK, SYS_CLOCK, CPU_CLOCK);
  *          ...
- *          FREE_TIMEMORY_AUTO_TUPLE(timer);
+ *          FREE_TIMEMORY_OBJECT(timer);
  *      }
  *
  */
-#    define TIMEMORY_AUTO_TUPLE(c_str, ...)                                              \
-        c_timemory_create_auto_tuple(                                                    \
-            c_timemory_string_combine(__TIMEMORY_FUNCTION__, c_str), __LINE__,           \
-            __VA_ARGS__, TIMEMORY_COMPONENTS_END)
+#        define TIMEMORY_OBJECT(c_str, ...)                                              \
+            c_timemory_create_auto_tuple(                                                \
+                c_timemory_string_combine(__TIMEMORY_FUNCTION__, c_str), __LINE__,       \
+                __VA_ARGS__, TIMEMORY_COMPONENTS_END)
 
 //--------------------------------------------------------------------------------------//
 /*! \def FREE_TIMEMORY_AUTO_TIMER(ctimer)
@@ -365,22 +384,25 @@ c_timemory_auto_str(const char*, const char*, const char*, int);
  *          FREE_TIMEMORY_AUTO_TIMER(timer);
  *      }
  */
-#    define FREE_TIMEMORY_AUTO_TIMER(ctimer) c_timemory_delete_auto_timer((void*) ctimer);
+#        define FREE_TIMEMORY_AUTO_TIMER(ctimer)                                         \
+            c_timemory_delete_auto_timer((void*) ctimer)
 
 //--------------------------------------------------------------------------------------//
-/*! \def FREE_TIMEMORY_AUTO_TUPLE(ctimer)
+/*! \def FREE_TIMEMORY_OBJECT(ctimer)
  *
  * Usage:
  *
  *      void some_func()
  *      {
- *          void* timer = new TIMEMORY_AUTO_TUPLE("", WALL_CLOCK);
+ *          void* timer = new TIMEMORY_OBJECT("", WALL_CLOCK);
  *          ...
- *          FREE_TIMEMORY_AUTO_TUPLE(timer);
+ *          FREE_TIMEMORY_OBJECT(timer);
  *      }
  */
-#    define FREE_TIMEMORY_AUTO_TUPLE(ctimer) c_timemory_delete_auto_tuple((void*) ctimer);
+#        define FREE_TIMEMORY_OBJECT(ctimer) c_timemory_delete_auto_tuple((void*) ctimer)
 
 //--------------------------------------------------------------------------------------//
 
-#endif  // !defined(__cplusplus)
+#    endif  // !defined(__cplusplus)
+
+#endif  // !defined(DISABLE_TIMEMORY)

--- a/source/timemory/timemory.hpp
+++ b/source/timemory/timemory.hpp
@@ -30,18 +30,100 @@
 
 #pragma once
 
-#include "timemory/components.hpp"
-#include "timemory/manager.hpp"
-#include "timemory/settings.hpp"
-#include "timemory/units.hpp"
-#include "timemory/utility/macros.hpp"
-#include "timemory/utility/utility.hpp"
-#include "timemory/variadic/auto_hybrid.hpp"
-#include "timemory/variadic/auto_list.hpp"
-#include "timemory/variadic/auto_timer.hpp"
-#include "timemory/variadic/macros.hpp"
+#if defined(DISABLE_TIMEMORY)
 
-#include "timemory/ctimemory.h"
+namespace tim
+{
+void
+print_env()
+{
+}
+template <typename... _Args>
+void
+timemory_init(_Args...)
+{
+}
+void
+timemory_finalize()
+{
+}
+
+/// this provides "functionality" for *_INSTANCE macros
+/// and can be omitted if these macros are not utilized
+struct dummy
+{
+    template <typename... _Args>
+    dummy(_Args&&...)
+    {
+    }
+    ~dummy()            = default;
+    dummy(const dummy&) = default;
+    dummy(dummy&&)      = default;
+    dummy& operator=(const dummy&) = default;
+    dummy& operator=(dummy&&) = default;
+
+    void start() {}
+    void stop() {}
+    void conditional_start() {}
+    void conditional_stop() {}
+    void report_at_exit(bool) {}
+    template <typename... _Args>
+    void mark_begin(_Args&&...)
+    {
+    }
+    template <typename... _Args>
+    void mark_end(_Args&&...)
+    {
+    }
+    friend std::ostream& operator<<(std::ostream& os, const dummy&) { return os; }
+};
+}  // namespace tim
+
+// creates a label
+#    define TIMEMORY_BASIC_LABEL(...) std::string("")
+#    define TIMEMORY_LABEL(...) std::string("")
+
+// define an object
+#    define TIMEMORY_BLANK_OBJECT(...)
+#    define TIMEMORY_BASIC_OBJECT(...)
+#    define TIMEMORY_OBJECT(...)
+
+// define an object with a caliper reference
+#    define TIMEMORY_BLANK_CALIPER(...)
+#    define TIMEMORY_BASIC_CALIPER(...)
+#    define TIMEMORY_CALIPER(...)
+#    define TIMEMORY_CALIPER_APPLY(...)
+#    define TIMEMORY_CALIPER_TYPE_APPLY(...)
+
+// define an object
+#    define TIMEMORY_BLANK_INSTANCE(...) tim::dummy()
+#    define TIMEMORY_BASIC_INSTANCE(...) tim::dummy()
+#    define TIMEMORY_INSTANCE(...) tim::dummy()
+
+// debug only
+#    define TIMEMORY_DEBUG_BASIC_OBJECT(...)
+#    define TIMEMORY_DEBUG_OBJECT(...)
+#    define TIMEMORY_DEBUG_BASIC_OBJECT(...)
+#    define TIMEMORY_DEBUG_OBJECT(...)
+
+// for CUDA
+#    define TIMEMORY_CALIPER_MARK_STREAM_BEGIN(...)
+#    define TIMEMORY_CALIPER_MARK_STREAM_END(...)
+
+#else
+
+#    include "timemory/components.hpp"
+#    include "timemory/manager.hpp"
+#    include "timemory/settings.hpp"
+#    include "timemory/units.hpp"
+#    include "timemory/utility/macros.hpp"
+#    include "timemory/utility/utility.hpp"
+#    include "timemory/variadic/auto_hybrid.hpp"
+#    include "timemory/variadic/auto_list.hpp"
+#    include "timemory/variadic/auto_timer.hpp"
+#    include "timemory/variadic/macros.hpp"
+
+#    include "timemory/ctimemory.h"
 
 //======================================================================================//
 
@@ -84,21 +166,21 @@ using recommended_hybrid_t = component_hybrid<recommended_tuple_t, recommended_l
 
 //======================================================================================//
 
-#if defined(TIMEMORY_EXTERN_TEMPLATES)
-#    include "timemory/templates/native_extern.hpp"
-#endif
+#    if defined(TIMEMORY_EXTERN_TEMPLATES)
+#        include "timemory/templates/native_extern.hpp"
+#    endif
 
 //======================================================================================//
 
-#if defined(TIMEMORY_EXTERN_TEMPLATES) && defined(TIMEMORY_USE_CUDA)
+#    if defined(TIMEMORY_EXTERN_TEMPLATES) && defined(TIMEMORY_USE_CUDA)
 // not yet implemented
 // #    include "timemory/templates/cuda_extern.hpp"
-#endif
+#    endif
 
 //======================================================================================//
 
-#if defined(TIMEMORY_EXTERN_INIT)
-#    include "timemory/utility/storage.hpp"
+#    if defined(TIMEMORY_EXTERN_INIT)
+#        include "timemory/utility/storage.hpp"
 
 TIMEMORY_DECLARE_EXTERN_STORAGE(real_clock)
 TIMEMORY_DECLARE_EXTERN_STORAGE(system_clock)
@@ -126,6 +208,8 @@ TIMEMORY_DECLARE_EXTERN_STORAGE(num_signals)
 TIMEMORY_DECLARE_EXTERN_STORAGE(voluntary_context_switch)
 TIMEMORY_DECLARE_EXTERN_STORAGE(priority_context_switch)
 
-#endif
+#    endif  // defined(TIMEMORY_EXTERN_INIT)
 
 //======================================================================================//
+
+#endif  // ! defined(DISABLE_TIMEMORY)

--- a/source/timemory/utility/utility.hpp
+++ b/source/timemory/utility/utility.hpp
@@ -244,8 +244,9 @@ get_max_threads()
 template <typename _Container = std::vector<std::string>,
           typename _Predicate = std::function<string_t(string_t)>>
 inline _Container
-delimit(const string_t& line, const string_t& delimiters = ",; ",
-        _Predicate&& predicate = [](string_t s) -> string_t { return s; })
+delimit(
+    const string_t& line, const string_t& delimiters = ",; ",
+    _Predicate&& predicate = [](string_t s) -> string_t { return s; })
 {
     auto _get_first_not_of = [&delimiters](const string_t& _string, const size_t& _beg) {
         return _string.find_first_not_of(delimiters, _beg);
@@ -472,8 +473,9 @@ delimit(std::string _str, const std::string& _delims)
 //  delimit line : e.g. delimit_line("a B\t c", " \t") --> { "a", "B", "c"}
 template <typename _Func>
 inline str_list_t
-delimit(std::string _str, const std::string& _delims,
-        const _Func& strop = [](const std::string& s) { return s; })
+delimit(
+    std::string _str, const std::string& _delims,
+    const _Func& strop = [](const std::string& s) { return s; })
 {
     str_list_t _list;
     while(_str.length() > 0)

--- a/source/timemory/variadic/auto_hybrid.hpp
+++ b/source/timemory/variadic/auto_hybrid.hpp
@@ -25,15 +25,9 @@
 
 /** \file auto_hybrid.hpp
  * \headerfile auto_hybrid.hpp "timemory/variadic/auto_hybrid.hpp"
- * Automatic starting and stopping of components. Accept unlimited number of
- * parameters. The constructor starts the components, the destructor stops the
- * components
+ * Automatic starting and stopping of components. Accept a component_tuple as first
+ * type and component_list as second type
  *
- * Usage with macros (recommended):
- *    \param TIMEMORY_AUTO_TUPLE()
- *    \param TIMEMORY_BASIC_AUTO_TUPLE()
- *    \param auto t = TIMEMORY_AUTO_TUPLE_OBJ()
- *    \param auto t = TIMEMORY_BASIC_AUTO_TUPLE_OBJ()
  */
 
 #pragma once

--- a/source/timemory/variadic/auto_list.hpp
+++ b/source/timemory/variadic/auto_list.hpp
@@ -53,20 +53,20 @@ namespace tim
 
 template <typename... Types>
 class auto_list
-: public tim::counted_object<auto_list<Types...>>
-, public tim::hashed_object<auto_list<Types...>>
+: public counted_object<auto_list<Types...>>
+, public hashed_object<auto_list<Types...>>
 {
 public:
-    using component_type = tim::component_list<Types...>;
+    using component_type = component_list<Types...>;
     using this_type      = auto_list<Types...>;
     using data_type      = typename component_type::data_type;
-    using counter_type   = tim::counted_object<this_type>;
-    using counter_void   = tim::counted_object<void>;
-    using hashed_type    = tim::hashed_object<this_type>;
+    using counter_type   = counted_object<this_type>;
+    using counter_void   = counted_object<void>;
+    using hashed_type    = hashed_object<this_type>;
     using string_t       = std::string;
     using string_hash    = std::hash<string_t>;
     using base_type      = component_type;
-    using language_t     = tim::language;
+    using language_t     = language;
     using tuple_type     = implemented<Types...>;
     using init_func_t    = std::function<void(this_type&)>;
 
@@ -93,8 +93,8 @@ public:
 
 public:
     // public member functions
-    inline component_type&       component_list() { return m_temporary_object; }
-    inline const component_type& component_list() const { return m_temporary_object; }
+    inline component_type&       get_component_type() { return m_temporary_object; }
+    inline const component_type& get_component_type() const { return m_temporary_object; }
 
     // partial interface to underlying component_list
     inline void record() { m_temporary_object.record(); }
@@ -108,6 +108,14 @@ public:
 
     inline void report_at_exit(bool val) { m_report_at_exit = val; }
     inline bool report_at_exit() const { return m_report_at_exit; }
+
+    inline const bool&      store() const { return m_temporary_object.store(); }
+    inline const data_type& data() const { return m_temporary_object.data(); }
+    inline int64_t          laps() const { return m_temporary_object.laps(); }
+    inline const int64_t&   hash() const { return m_temporary_object.hash(); }
+    inline const string_t&  key() const { return m_temporary_object.key(); }
+    inline const language&  lang() const { return m_temporary_object.lang(); }
+    inline const string_t&  identifier() const { return m_temporary_object.identifier(); }
 
 public:
     template <std::size_t _N>
@@ -135,27 +143,27 @@ public:
     }
 
     template <typename _Tp, typename... _Args,
-              tim::enable_if_t<(is_one_of<_Tp, tuple_type>::value == true), int> = 0>
+              enable_if_t<(is_one_of<_Tp, tuple_type>::value == true), int> = 0>
     void init(_Args&&... _args)
     {
         m_temporary_object.template init<_Tp>(std::forward<_Args>(_args)...);
     }
 
     template <typename _Tp, typename... _Args,
-              tim::enable_if_t<(is_one_of<_Tp, tuple_type>::value == false), int> = 0>
+              enable_if_t<(is_one_of<_Tp, tuple_type>::value == false), int> = 0>
     void init(_Args&&...)
     {
     }
 
     template <typename _Tp, typename... _Tail,
-              tim::enable_if_t<(sizeof...(_Tail) == 0), int> = 0>
+              enable_if_t<(sizeof...(_Tail) == 0), int> = 0>
     void initialize()
     {
         this->init<_Tp>();
     }
 
     template <typename _Tp, typename... _Tail,
-              tim::enable_if_t<(sizeof...(_Tail) > 0), int> = 0>
+              enable_if_t<(sizeof...(_Tail) > 0), int> = 0>
     void initialize()
     {
         this->init<_Tp>();
@@ -165,7 +173,7 @@ public:
     static init_func_t& get_initializer()
     {
         static init_func_t _instance = [](this_type& al) {
-            tim::env::initialize(al, "TIMEMORY_AUTO_LIST_INIT", "");
+            env::initialize(al, "TIMEMORY_AUTO_LIST_INIT", "");
         };
         return _instance;
     }

--- a/source/timemory/variadic/auto_tuple.hpp
+++ b/source/timemory/variadic/auto_tuple.hpp
@@ -53,20 +53,20 @@ namespace tim
 
 template <typename... Types>
 class auto_tuple
-: public tim::counted_object<auto_tuple<Types...>>
-, public tim::hashed_object<auto_tuple<Types...>>
+: public counted_object<auto_tuple<Types...>>
+, public hashed_object<auto_tuple<Types...>>
 {
 public:
-    using component_type = tim::component_tuple<Types...>;
+    using component_type = component_tuple<Types...>;
     using this_type      = auto_tuple<Types...>;
     using data_type      = typename component_type::data_type;
-    using counter_type   = tim::counted_object<this_type>;
-    using counter_void   = tim::counted_object<void>;
-    using hashed_type    = tim::hashed_object<this_type>;
+    using counter_type   = counted_object<this_type>;
+    using counter_void   = counted_object<void>;
+    using hashed_type    = hashed_object<this_type>;
     using string_t       = std::string;
     using string_hash    = std::hash<string_t>;
     using base_type      = component_type;
-    using language_t     = tim::language;
+    using language_t     = language;
 
 public:
     inline explicit auto_tuple(const string_t&, const int64_t& lineno = 0,
@@ -91,8 +91,8 @@ public:
 
 public:
     // public member functions
-    inline component_type&       component_tuple() { return m_temporary_object; }
-    inline const component_type& component_tuple() const { return m_temporary_object; }
+    inline component_type&       get_component_type() { return m_temporary_object; }
+    inline const component_type& get_component_type() const { return m_temporary_object; }
 
     // partial interface to underlying component_tuple
     inline void record() { m_temporary_object.record(); }
@@ -105,6 +105,14 @@ public:
 
     inline void report_at_exit(bool val) { m_report_at_exit = val; }
     inline bool report_at_exit() const { return m_report_at_exit; }
+
+    inline const bool&      store() const { return m_temporary_object.store(); }
+    inline const data_type& data() const { return m_temporary_object.data(); }
+    inline int64_t          laps() const { return m_temporary_object.laps(); }
+    inline const int64_t&   hash() const { return m_temporary_object.hash(); }
+    inline const string_t&  key() const { return m_temporary_object.key(); }
+    inline const language&  lang() const { return m_temporary_object.lang(); }
+    inline const string_t&  identifier() const { return m_temporary_object.identifier(); }
 
 public:
     template <std::size_t _N>
@@ -155,7 +163,7 @@ auto_tuple<Types...>::auto_tuple(const string_t& object_tag, const int64_t& line
                   ? (string_hash()(object_tag) * static_cast<int64_t>(lang) +
                      (counter_type::live() + hashed_type::live() + lineno))
                   : 0)
-, m_enabled(counter_type::enable() && tim::settings::enabled())
+, m_enabled(counter_type::enable() && settings::enabled())
 , m_report_at_exit(report_at_exit)
 , m_temporary_object(object_tag, lang, counter_type::m_count, hashed_type::m_hash,
                      m_enabled)
@@ -219,45 +227,57 @@ auto_tuple<Types...>::~auto_tuple()
 
 //======================================================================================//
 
+//  DEPRECATED use macros in timemory/variadic/macros.hpp!
+/// DEPRECATED
 #define TIMEMORY_BLANK_AUTO_TUPLE(auto_tuple_type, ...)                                  \
     TIMEMORY_BLANK_OBJECT(auto_tuple_type, __VA_ARGS__)
 
+/// DEPRECATED
 #define TIMEMORY_BASIC_AUTO_TUPLE(auto_tuple_type, ...)                                  \
     TIMEMORY_BASIC_OBJECT(auto_tuple_type, __VA_ARGS__)
 
+/// DEPRECATED
 #define TIMEMORY_AUTO_TUPLE(auto_tuple_type, ...)                                        \
     TIMEMORY_OBJECT(auto_tuple_type, __VA_ARGS__)
 
 //--------------------------------------------------------------------------------------//
-// caliper versions
+// caliper versions -- DEPRECATED use macros in timemory/variadic/macros.hpp!
 
+/// DEPRECATED
 #define TIMEMORY_BLANK_AUTO_TUPLE_CALIPER(id, auto_tuple_type, ...)                      \
     TIMEMORY_BLANK_CALIPER(id, auto_tuple_type, __VA_ARGS__)
 
+/// DEPRECATED
 #define TIMEMORY_BASIC_AUTO_TUPLE_CALIPER(id, auto_tuple_type, ...)                      \
     TIMEMORY_BASIC_CALIPER(id, auto_tuple_type, __VA_ARGS__)
 
+/// DEPRECATED
 #define TIMEMORY_AUTO_TUPLE_CALIPER(id, auto_tuple_type, ...)                            \
     TIMEMORY_CALIPER(id, auto_tuple_type, __VA_ARGS__)
 
 //--------------------------------------------------------------------------------------//
-// instance versions
+// instance versions -- DEPRECATED use macros in timemory/variadic/macros.hpp!
 
+/// DEPRECATED
 #define TIMEMORY_BLANK_AUTO_TUPLE_INSTANCE(auto_tuple_type, ...)                         \
     TIMEMORY_BLANK_INSTANCE(auto_tuple_type, __VA_ARGS__)
 
+/// DEPRECATED
 #define TIMEMORY_BASIC_AUTO_TUPLE_INSTANCE(auto_tuple_type, ...)                         \
     TIMEMORY_BASIC_INSTANCE(auto_tuple_type, __VA_ARGS__)
 
+/// DEPRECATED
 #define TIMEMORY_AUTO_TUPLE_INSTANCE(auto_tuple_type, ...)                               \
     TIMEMORY_INSTANCE(auto_tuple_type, __VA_ARGS__)
 
 //--------------------------------------------------------------------------------------//
-// debug versions
+// debug versions -- DEPRECATED use macros in timemory/variadic/macros.hpp!
 
+/// DEPRECATED
 #define TIMEMORY_DEBUG_BASIC_AUTO_TUPLE(auto_tuple_type, ...)                            \
     TIMEMORY_DEBUG_BASIC_OBJECT(auto_tuple_type, __VA_ARGS__)
 
+/// DEPRECATED
 #define TIMEMORY_DEBUG_AUTO_TUPLE(auto_tuple_type, ...)                                  \
     TIMEMORY_DEBUG_OBJECT(auto_tuple_type, __VA_ARGS__)
 

--- a/source/timemory/variadic/macros.hpp
+++ b/source/timemory/variadic/macros.hpp
@@ -81,8 +81,8 @@ using str = tim::apply<std::string>;
 //
 #    define _LINE_STRING priv::apply::join("", __LINE__)
 #    define _AUTO_NAME_COMBINE(X, Y) X##Y
-#    define _AUTO_NAME(Y) _AUTO_NAME_COMBINE(_tim_auto_variable, Y)
-#    define _AUTO_TYPEDEF(Y) _AUTO_NAME_COMBINE(typedef_auto_tuple, Y)
+#    define _AUTO_NAME(Y) _AUTO_NAME_COMBINE(timemory_variable_, Y)
+#    define _AUTO_TYPEDEF(Y) _AUTO_NAME_COMBINE(timemory_variable_type_, Y)
 //
 // helper macro for "__FUNCTION__@'__FILE__':__LINE__" tagging
 //
@@ -121,7 +121,7 @@ using str = tim::apply<std::string>;
 #    define TIMEMORY_JOIN(delim, ...) priv::apply::join(delim, __VA_ARGS__)
 
 //--------------------------------------------------------------------------------------//
-/*! \def TIMEMORY_BASIC_AUTO_LABEL(...)
+/*! \def TIMEMORY_BASIC_LABEL(...)
  *
  * helper macro for "__FUNCTION__" + ... tagging
  *
@@ -129,15 +129,15 @@ using str = tim::apply<std::string>;
  *
  *      void func()
  *      {
- *          auto_timer_t timer(TIMEMORY_BASIC_AUTO_LABEL("example"), __LINE__)
+ *          auto_timer_t timer(TIMEMORY_BASIC_LABEL("example"), __LINE__)
  *          ...
  *      }
  */
-#    define TIMEMORY_BASIC_AUTO_LABEL(...)                                               \
+#    define TIMEMORY_BASIC_LABEL(...)                                                    \
         priv::apply::join("", __TIMEMORY_FUNCTION__, __VA_ARGS__)
 
 //--------------------------------------------------------------------------------------//
-/*! \def TIMEMORY_AUTO_LABEL(...)
+/*! \def TIMEMORY_LABEL(...)
  *
  * helper macro for "__FUNCTION__" + ... + '@__FILE__':__LINE__" tagging
  *
@@ -145,11 +145,11 @@ using str = tim::apply<std::string>;
  *
  *      void func()
  *      {
- *          auto_timer_t timer(TIMEMORY_AUTO_LABEL("example"), __LINE__)
+ *          auto_timer_t timer(TIMEMORY_LABEL("example"), __LINE__)
  *          ...
  *      }
  */
-#    define TIMEMORY_AUTO_LABEL(...)                                                     \
+#    define TIMEMORY_LABEL(...)                                                          \
         priv::apply::join("", __TIMEMORY_FUNCTION__, __VA_ARGS__,                        \
                           _AUTO_STR(__FILE__, _LINE_STRING))
 


### PR DESCRIPTION
- replace `TIMEMORY_AUTO_TUPLE`, etc. recommendations with more generic macros since `TIMEMORY_AUTO_TUPLE`, etc. did not actually require the type to be an `tim::auto_tuple`.
- documentation updates