### PR TITLE
cupti_counters includes secondary data and C++17 fixes

### DIFF
--- a/cmake/Modules/Packages.cmake
+++ b/cmake/Modules/Packages.cmake
@@ -576,11 +576,18 @@ if(TIMEMORY_USE_CUDA)
         target_link_libraries(timemory-cudart INTERFACE
             ${CUDA_CUDART_LIBRARY} ${CUDA_rt_LIBRARY})
 
+        target_compile_options(timemory-cudart INTERFACE
+            $<$<COMPILE_LANGUAGE:CUDA>:--cudart=shared>)
+
         target_link_libraries(timemory-cudart-device INTERFACE
             ${CUDA_cudadevrt_LIBRARY} ${CUDA_rt_LIBRARY})
 
         target_link_libraries(timemory-cudart-static INTERFACE
             ${CUDA_cudart_static_LIBRARY} ${CUDA_rt_LIBRARY})
+
+        target_compile_options(timemory-cudart-static INTERFACE
+            $<$<COMPILE_LANGUAGE:CUDA>:--cudart=static>)
+
     else()
         inform_empty_interface(timemory-cuda "CUDA")
         set(TIMEMORY_USE_CUDA OFF)

--- a/examples/ex-cuda-event/CMakeLists.txt
+++ b/examples/ex-cuda-event/CMakeLists.txt
@@ -11,7 +11,7 @@ endif()
 project(timemory-CUDA-Event-Example LANGUAGES C CXX CUDA)
 
 set(EXE_NAME ex_cuda_event)
-set(COMPONENTS cuda nvtx threading compile-options analysis-tools)
+set(COMPONENTS cuda nvtx threading compile-options analysis-tools cudart)
 
 option(USE_CUPTI "Enable CUPTI" OFF)
 if(USE_CUPTI)

--- a/source/tests/gotcha_tests.cpp
+++ b/source/tests/gotcha_tests.cpp
@@ -884,8 +884,10 @@ main(int argc, char** argv)
     tim::settings::json_output()  = true;
     tim::timemory_init(argc, argv);  // parses environment, sets output paths
     tim::mpi::initialize(argc, argv);
+#if defined(TIMEMORY_USE_PAPI)
     cpu_roofline_sp_flops::ert_config_type<float>::configure(1, 64);
     cpu_roofline_dp_flops::ert_config_type<double>::configure(1, 64);
+#endif
     tim::settings::dart_output() = true;
     tim::settings::dart_count()  = 1;
     tim::settings::banner()      = false;

--- a/source/timemory/components/base.hpp
+++ b/source/timemory/components/base.hpp
@@ -340,25 +340,25 @@ public:
     //----------------------------------------------------------------------------------//
     // value type operators (complex data)
     //
-    template <typename U = value_type, enable_if_t<(!std::is_pod<U>::value), int> = 0>
+    template <typename U = value_type, enable_if_t<!(std::is_pod<U>::value), int> = 0>
     Type& operator+=(const value_type& rhs)
     {
         return static_cast<Type&>(*this).operator+=(rhs);
     }
 
-    template <typename U = value_type, enable_if_t<(!std::is_pod<U>::value), int> = 0>
+    template <typename U = value_type, enable_if_t<!(std::is_pod<U>::value), int> = 0>
     Type& operator-=(const value_type& rhs)
     {
         return static_cast<Type&>(*this).operator-=(rhs);
     }
 
-    template <typename U = value_type, enable_if_t<(!std::is_pod<U>::value), int> = 0>
+    template <typename U = value_type, enable_if_t<!(std::is_pod<U>::value), int> = 0>
     Type& operator*=(const value_type& rhs)
     {
         return static_cast<Type&>(*this).operator*=(rhs);
     }
 
-    template <typename U = value_type, enable_if_t<(!std::is_pod<U>::value), int> = 0>
+    template <typename U = value_type, enable_if_t<!(std::is_pod<U>::value), int> = 0>
     Type& operator/=(const value_type& rhs)
     {
         return static_cast<Type&>(*this).operator/=(rhs);

--- a/source/timemory/mpl/apply.hpp
+++ b/source/timemory/mpl/apply.hpp
@@ -219,6 +219,67 @@ struct function_traits<R(C::*)>
     using call_type                 = std::tuple<C&>;
 };
 
+#if __cplusplus >= 201703L
+
+template <typename R, typename... Args>
+struct function_traits<std::function<R(Args...) noexcept>>
+{
+    static constexpr bool   is_memfun = false;
+    static constexpr bool   is_const  = false;
+    static constexpr size_t nargs     = sizeof...(Args);
+    using result_type                 = R;
+    using args_type                   = std::tuple<Args...>;
+    using call_type                   = args_type;
+};
+
+template <typename R, typename... Args>
+struct function_traits<R (*)(Args...) noexcept>
+{
+    static constexpr bool   is_memfun = false;
+    static constexpr bool   is_const  = false;
+    static constexpr size_t nargs     = sizeof...(Args);
+    using result_type                 = R;
+    using args_type                   = std::tuple<Args...>;
+    using call_type                   = args_type;
+};
+
+template <typename R, typename... Args>
+struct function_traits<R(Args...) noexcept>
+{
+    static constexpr bool   is_memfun = false;
+    static constexpr bool   is_const  = false;
+    static constexpr size_t nargs     = sizeof...(Args);
+    using result_type                 = R;
+    using args_type                   = std::tuple<Args...>;
+    using call_type                   = args_type;
+};
+
+// member function pointer
+template <typename C, typename R, typename... Args>
+struct function_traits<R (C::*)(Args...) noexcept>
+{
+    static constexpr bool   is_memfun = true;
+    static constexpr bool   is_const  = false;
+    static constexpr size_t nargs     = sizeof...(Args);
+    using result_type                 = R;
+    using args_type                   = std::tuple<Args...>;
+    using call_type                   = std::tuple<C&, Args...>;
+};
+
+// const member function pointer
+template <typename C, typename R, typename... Args>
+struct function_traits<R (C::*)(Args...) const noexcept>
+{
+    static constexpr bool   is_memfun = true;
+    static constexpr bool   is_const  = true;
+    static constexpr size_t nargs     = sizeof...(Args);
+    using result_type                 = R;
+    using args_type                   = std::tuple<Args...>;
+    using call_type                   = std::tuple<C&, Args...>;
+};
+
+#endif
+
 //======================================================================================//
 //
 //  Pre-C++11 tuple expansion

--- a/source/timemory/mpl/type_traits.hpp
+++ b/source/timemory/mpl/type_traits.hpp
@@ -668,6 +668,11 @@ struct secondary_data<component::cupti_activity> : std::true_type
 {
 };
 
+template <>
+struct secondary_data<component::cupti_counters> : std::true_type
+{
+};
+
 #endif  // TIMEMORY_USE_CUPTI
 
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/utility/bits/storage.hpp
+++ b/source/timemory/utility/bits/storage.hpp
@@ -103,8 +103,12 @@ combine(std::tuple<_Types...>& lhs, const std::tuple<_Types...>& rhs)
 
 //--------------------------------------------------------------------------------------//
 
-template <typename _Tp, typename... _ExtraArgs,
-          template <typename, typename...> class _Container>
+template <
+    typename _Tp, typename... _ExtraArgs,
+    template <typename, typename...> class _Container,
+    typename _TupleA = _Container<_Tp, _ExtraArgs...>,
+    typename _TupleB = std::tuple<_Tp, _ExtraArgs...>,
+    typename std::enable_if<!(std::is_same<_TupleA, _TupleB>::value), int>::type = 0>
 void
 combine(_Container<_Tp, _ExtraArgs...>& lhs, const _Container<_Tp, _ExtraArgs...>& rhs)
 {
@@ -155,8 +159,12 @@ compute_percentage(const std::tuple<_Types...>&, const std::tuple<_Types...>&)
 
 //--------------------------------------------------------------------------------------//
 
-template <typename _Tp, typename... _ExtraArgs,
-          template <typename, typename...> class _Container, typename _Ret = _Tp>
+template <
+    typename _Tp, typename... _ExtraArgs,
+    template <typename, typename...> class _Container, typename _Ret = _Tp,
+    typename _TupleA = _Container<_Tp, _ExtraArgs...>,
+    typename _TupleB = std::tuple<_Tp, _ExtraArgs...>,
+    typename std::enable_if<!(std::is_same<_TupleA, _TupleB>::value), int>::type = 0>
 _Container<_Ret>
 compute_percentage(const _Container<_Tp, _ExtraArgs...>& lhs,
                    const _Container<_Tp, _ExtraArgs...>& rhs)
@@ -207,8 +215,12 @@ compute_percentage(_Tp& lhs, const _Tp& rhs)
 //
 //--------------------------------------------------------------------------------------//
 
-template <typename _Tp, typename... _ExtraArgs,
-          template <typename, typename...> class _Container>
+template <
+    typename _Tp, typename... _ExtraArgs,
+    template <typename, typename...> class _Container,
+    typename _TupleA = _Container<_Tp, _ExtraArgs...>,
+    typename _TupleB = std::tuple<_Tp, _ExtraArgs...>,
+    typename std::enable_if<!(std::is_same<_TupleA, _TupleB>::value), int>::type = 0>
 void
 print_percentage(std::ostream& os, const _Container<_Tp, _ExtraArgs...>& obj)
 {

--- a/source/timemory/variadic/component_list.hpp
+++ b/source/timemory/variadic/component_list.hpp
@@ -594,7 +594,6 @@ public:
               enable_if_t<!(is_one_of<_Tp, reference_type>::value), int> = 0>
     _Tp* get() const
     {
-        PRINT_HERE("");
         return nullptr;
     }
 


### PR DESCRIPTION
- added support for `trait::secondary_data` to `component::cupti_counters`
  - enables capturing the individual kernels as children of the timemory marker
- fixed some C++17 issues for GCC
