### PR TITLE
Only apply CMP0082 for CMake>=3.14

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -31,6 +31,8 @@ cmake_policy(SET CMP0048 NEW)
 cmake_policy(SET CMP0042 NEW)
 if(NOT CMAKE_VERSION VERSION_LESS 3.13)
     cmake_policy(SET CMP0079 NEW)
+endif()
+if(NOT CMAKE_VERSION VERSION_LESS 3.14)
     cmake_policy(SET CMP0082 NEW)
 endif()
 # set these as the defaults


### PR DESCRIPTION
A very minor issue spotted on an Easybuild stack that only had CMake 3.13 available. Policy `CMP0082` is only available from CMake 3.14, but was being applied to CMake 3.13 as well, resulting in an error.

Protect policy setting for CMP0082 with an additional check on CMake version.