### PR TITLE
Pre-compiled headers support + re-worked API usage + settings config files

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -291,6 +291,9 @@ if(TIMEMORY_BUILD_EXAMPLES)
     set(timemory_DIR "${PROJECT_BINARY_DIR}" CACHE STRING
         "timemory build examples directory" FORCE)
     add_subdirectory(examples)
+elseif(TIMEMORY_BUILD_MINIMAL_TESTING AND (TIMEMORY_USE_PYTHON OR TIMEMORY_BUILD_PYTHON))
+    # copies over some python scripts
+    add_subdirectory(examples/ex-python)
 endif()
 
 #----------------------------------------------------------------------------------------#

--- a/cmake/Modules/MacroUtilities.cmake
+++ b/cmake/Modules/MacroUtilities.cmake
@@ -216,7 +216,7 @@ FUNCTION(ADD_TIMEMORY_GOOGLE_TEST TEST_NAME)
         ADD_TEST(
             NAME                ${TEST_NAME}
             COMMAND             ${TEST_COMMAND}
-            WORKING_DIRECTORY   ${CMAKE_CURRENT_LIST_DIR}
+            WORKING_DIRECTORY   ${CMAKE_CURRENT_BINARY_DIR}
             ${TEST_OPTIONS})
         SET_TESTS_PROPERTIES(${TEST_NAME} PROPERTIES ENVIRONMENT "${TEST_ENVIRONMENT}")
     endif()
@@ -664,10 +664,37 @@ macro(INSTALL_HEADER_FILES)
 endmacro()
 
 
+#-----------------------------------------------------------------------
+# Add pre-compiled headers
+#
+FUNCTION(TIMEMORY_TARGET_PRECOMPILE_HEADERS _TARG)
+    cmake_parse_arguments(
+        HEAD "INSTALL_INTERFACE" "" "FILES" ${ARGN})
+
+    if(TIMEMORY_PRECOMPILE_HEADERS)
+        set(_BINARY_IFACE)
+        set(_INSTALL_IFACE)
+        foreach(_HEADER ${HEAD_FILES})
+            string(REPLACE "${PROJECT_SOURCE_DIR}/" "" _HEADER "${_HEADER}")
+            list(APPEND _BINARY_IFACE "${_HEADER}")
+            string(REPLACE "external/cereal/include/" "" _HEADER "${_HEADER}")
+            string(REPLACE "source/" "" _HEADER "${_HEADER}")
+            list(APPEND _INSTALL_IFACE "<${_HEADER}>")
+        endforeach()
+        target_precompile_headers(${_TARG} INTERFACE
+            $<BUILD_INTERFACE:${_BINARY_IFACE}>)
+        if(HEAD_INSTALL_INTERFACE)
+            target_precompile_headers(${_TARG} INTERFACE
+                $<BUILD_INTERFACE:${_PRECOMPILE_HEADERS}>)
+        endif()
+    endif()
+ENDFUNCTION()
+
+
 #----------------------------------------------------------------------------------------#
 # macro to build a library of type: shared, static, object
 #
-macro(BUILD_INTERMEDIATE_LIBRARY)
+FUNCTION(BUILD_INTERMEDIATE_LIBRARY)
 
     # options
     set(_options    USE_INTERFACE
@@ -861,7 +888,7 @@ macro(BUILD_INTERMEDIATE_LIBRARY)
         add_dependencies(timemory-${COMP_TARGET}-shared timemory-${COMP_TARGET}-static)
     endif()
 
-endmacro()
+ENDFUNCTION()
 
 
 FUNCTION(ADD_CMAKE_DEFINES _VAR)

--- a/cmake/Modules/Options.cmake
+++ b/cmake/Modules/Options.cmake
@@ -226,6 +226,12 @@ add_option(TIMEMORY_BUILD_GOTCHA
     "Enable building GOTCHA (set to OFF for external)" ON)
 add_option(TIMEMORY_UNITY_BUILD
     "Same as CMAKE_UNITY_BUILD but is not propagated to submodules" ON)
+if(NOT CMAKE_VERSION VERSION_LESS 3.16)
+    add_option(TIMEMORY_PRECOMPILE_HEADERS
+        "Pre-compile headers where possible" ON)
+else()
+    set(TIMEMORY_PRECOMPILE_HEADERS OFF)
+endif()
 
 if(NOT _NON_APPLE_UNIX)
     set(TIMEMORY_BUILD_GOTCHA OFF)

--- a/cmake/Modules/Options.cmake
+++ b/cmake/Modules/Options.cmake
@@ -228,7 +228,7 @@ add_option(TIMEMORY_UNITY_BUILD
     "Same as CMAKE_UNITY_BUILD but is not propagated to submodules" ON)
 if(NOT CMAKE_VERSION VERSION_LESS 3.16)
     add_option(TIMEMORY_PRECOMPILE_HEADERS
-        "Pre-compile headers where possible" ON)
+        "Pre-compile headers where possible" OFF)
 else()
     set(TIMEMORY_PRECOMPILE_HEADERS OFF)
 endif()

--- a/docs/getting_started/integrating.md
+++ b/docs/getting_started/integrating.md
@@ -80,6 +80,7 @@ were not available when timemory was installed.
 | `timemory::timemory-papi-static` | Enables PAPI support + links to static library |
 | `timemory::timemory-papi` | Enables PAPI support |
 | `timemory::timemory-plotting` | Enables python plotting support (system call) |
+| `timemory::timemory-precompiled-headers` | Provides timemory-headers + precompiles headers if CMAKE_VERSION >= 3.16 |
 | `timemory::timemory-python` | Enables python support (embedded interpreter) |
 | `timemory::timemory-roofline-options` | Compiler flags for roofline generation |
 | `timemory::timemory-roofline` | Enables flags and libraries for proper roofline generation |

--- a/examples/ex-python/CMakeLists.txt
+++ b/examples/ex-python/CMakeLists.txt
@@ -31,6 +31,10 @@ foreach(_TYPE sample profiler general builtin external)
         OPTIONAL)
 endforeach()
 
+if(TIMEMORY_BUILD_MINIMAL_TESTING)
+    return()
+endif()
+
 if(NOT TARGET pybind11::module)
     find_package(pybind11 QUIET)
 endif()

--- a/pyctest-runner.py
+++ b/pyctest-runner.py
@@ -423,6 +423,9 @@ def run_pyctest():
         "PYTHON_EXECUTABLE": "{}".format(sys.executable),
     }
 
+    if args.quick and args.python:
+        build_opts["TIMEMORY_BUILD_MINIMAL_TESTING"] = "ON"
+
     if args.papi:
         build_opts["USE_PAPI"] = "ON"
 
@@ -724,7 +727,7 @@ def run_pyctest():
                 "peak_rss",
                 "--",
                 "./ex_python_builtin",
-                "20",
+                "10",
             ],
             {
                 "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
@@ -769,7 +772,7 @@ def run_pyctest():
                 "wall_clock",
                 "--",
                 "./ex_python_builtin",
-                "20",
+                "10",
             ],
             {
                 "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -56,15 +56,6 @@ endif()
 file(GLOB pyheaders ${CMAKE_CURRENT_LIST_DIR}/python/*.hpp)
 file(GLOB pysources ${CMAKE_CURRENT_LIST_DIR}/python/*.cpp)
 
-if(NOT CMAKE_VERSION VERSION_LESS 3.16)
-    set(_PRECOMPILE_HEADERS)
-    foreach(_HEADER ${cereal_headers} ${cxx_header_tpls})
-        list(APPEND _PRECOMPILE_HEADERS [[${_HEADER}]])
-    endforeach()
-    target_precompile_headers(timemory-headers INTERFACE
-        $<BUILD_INTERFACE:${_PRECOMPILE_HEADERS}>)
-endif()
-
 #----------------------------------------------------------------------------------------#
 # build library setup
 #

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -56,6 +56,15 @@ endif()
 file(GLOB pyheaders ${CMAKE_CURRENT_LIST_DIR}/python/*.hpp)
 file(GLOB pysources ${CMAKE_CURRENT_LIST_DIR}/python/*.cpp)
 
+if(NOT CMAKE_VERSION VERSION_LESS 3.16)
+    set(_PRECOMPILE_HEADERS)
+    foreach(_HEADER ${cereal_headers} ${cxx_header_tpls})
+        list(APPEND _PRECOMPILE_HEADERS [[${_HEADER}]])
+    endforeach()
+    target_precompile_headers(timemory-headers INTERFACE
+        $<BUILD_INTERFACE:${_PRECOMPILE_HEADERS}>)
+endif()
+
 #----------------------------------------------------------------------------------------#
 # build library setup
 #

--- a/source/kokkosp.cpp
+++ b/source/kokkosp.cpp
@@ -113,7 +113,7 @@ extern "C"
 
     void kokkosp_begin_parallel_for(const char* name, uint32_t devid, uint64_t* kernid)
     {
-        auto pname = TIMEMORY_JOIN("/", "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
+        auto pname = TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
         *kernid    = kokkosp::get_unique_id();
         kokkosp::create_profiler<kokkosp::kokkos_bundle>(pname, *kernid);
         kokkosp::start_profiler<kokkosp::kokkos_bundle>(*kernid);
@@ -129,7 +129,7 @@ extern "C"
 
     void kokkosp_begin_parallel_reduce(const char* name, uint32_t devid, uint64_t* kernid)
     {
-        auto pname = TIMEMORY_JOIN("/", "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
+        auto pname = TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
         *kernid    = kokkosp::get_unique_id();
         kokkosp::create_profiler<kokkosp::kokkos_bundle>(pname, *kernid);
         kokkosp::start_profiler<kokkosp::kokkos_bundle>(*kernid);
@@ -145,7 +145,7 @@ extern "C"
 
     void kokkosp_begin_parallel_scan(const char* name, uint32_t devid, uint64_t* kernid)
     {
-        auto pname = TIMEMORY_JOIN("/", "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
+        auto pname = TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
         *kernid    = kokkosp::get_unique_id();
         kokkosp::create_profiler<kokkosp::kokkos_bundle>(pname, *kernid);
         kokkosp::start_profiler<kokkosp::kokkos_bundle>(*kernid);
@@ -180,7 +180,7 @@ extern "C"
     {
         *secid = kokkosp::get_unique_id();
         auto pname =
-            TIMEMORY_JOIN("/", "kokkos", TIMEMORY_JOIN("", "section", secid), name);
+            TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "section", secid), name);
         kokkosp::create_profiler<kokkosp::kokkos_bundle>(pname, *secid);
     }
 

--- a/source/python/libpytimemory-component-bundle.hpp
+++ b/source/python/libpytimemory-component-bundle.hpp
@@ -123,7 +123,7 @@ component_bundle(const std::string& func, const std::string& file, const int lin
         try
         {
             auto v = itr.cast<std::string>();
-            sargs  = (sargs.empty()) ? v : TIMEMORY_JOIN("/", sargs, v);
+            sargs  = (sargs.empty()) ? v : TIMEMORY_JOIN('/', sargs, v);
         } catch(...)
         {}
     }
@@ -197,16 +197,7 @@ generate(py::module& _pymod, const char* _name, const char* _doc)
 
         if(tim::settings::debug() || tim::settings::verbose() > 3)
         {
-            size_t fsize = bundle_t::size();
-            if((fsize - isize) < components.size())
-            {
-                std::stringstream ss;
-                ss << "Warning: final size " << fsize << ", input size " << isize
-                   << ". Difference is less than the components size: "
-                   << components.size();
-                PRINT_HERE("%s", ss.str().c_str());
-                throw std::runtime_error(ss.str());
-            }
+            auto fsize = components.size();
             PRINT_HERE("final size: %lu, input size: %lu, components size: %lu\n",
                        (unsigned long) fsize, (unsigned long) isize,
                        (unsigned long) components.size());

--- a/source/python/libpytimemory-components.cpp
+++ b/source/python/libpytimemory-components.cpp
@@ -224,10 +224,10 @@ get_display_unit(py::class_<pytuple_t<T>>& _pyclass, long, long)
 template <typename T, typename... Args>
 static inline auto
 configure(py::class_<pytuple_t<T>>& _pyclass, int, int, Args&&... args)
-    -> decltype(T::configure(tim::api::python{}, std::forward<Args>(args)...), void())
+    -> decltype(T::configure(tim::project::python{}, std::forward<Args>(args)...), void())
 {
     auto _configure = [](Args&&... _args) {
-        T::configure(tim::api::python{}, std::forward<Args>(_args)...);
+        T::configure(tim::project::python{}, std::forward<Args>(_args)...);
     };
     _pyclass.def_static("configure", _configure, "Configure the tool");
 }
@@ -238,13 +238,13 @@ template <typename T, typename... Args>
 static inline auto
 configure(py::class_<pytuple_t<T>>& _pyclass, int, long, Args&&... args)
     -> decltype(std::declval<pytuple_t<T>>().template get<T>()->configure(
-                    tim::api::python{}, std::forward<Args>(args)...),
+                    tim::project::python{}, std::forward<Args>(args)...),
                 void())
 {
     using bundle_t  = pytuple_t<T>;
     auto _configure = [](bundle_t* obj, Args&&... _args) {
         if(obj->template get<T>())
-            obj->template get<T>()->configure(tim::api::python{},
+            obj->template get<T>()->configure(tim::project::python{},
                                               std::forward<Args>(_args)...);
     };
     _pyclass.def("configure", _configure, "Configure the tool");
@@ -262,9 +262,9 @@ configure(py::class_<pytuple_t<T>>&, long, long, Args&&...)
 template <typename T>
 static inline auto
 configure(py::class_<pytuple_t<T>>& _pyclass, int)
-    -> decltype(T::configure(tim::api::python{}, _pyclass))
+    -> decltype(T::configure(tim::project::python{}, _pyclass))
 {
-    T::configure(tim::api::python{}, _pyclass);
+    T::configure(tim::project::python{}, _pyclass);
 }
 //
 //--------------------------------------------------------------------------------------//

--- a/source/python/libpytimemory-settings.cpp
+++ b/source/python/libpytimemory-settings.cpp
@@ -144,6 +144,13 @@ generate(py::module& _pymod)
         else
             tim::settings::parse(_obj);
     };
+    auto _read = [](py::object _instance, std::string inp) {
+        auto* _obj = _instance.cast<tim::settings*>();
+        if(_instance.is_none() || _obj == nullptr)
+            tim::settings::instance()->read(inp);
+        else
+            _obj->read(inp);
+    };
 
     // create an instance
     settings.def(py::init(_init), "Create a copy of the global settings");
@@ -151,6 +158,7 @@ generate(py::module& _pymod)
     settings.def_static("parse", _parse,
                         "Update the values of the settings from the current environment",
                         py::arg("instance") = py::none{});
+    settings.def_static("read", _read, "Read the settings from JSON or text file");
 
     std::set<std::string> names;
     auto                  _settings = tim::settings::instance<tim::api::native_tag>();

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -106,6 +106,19 @@ if(_LIBRARY_TARGET)
         LINK_LIBRARIES  ${_LIBRARY_TARGET})
 endif()
 
+add_timemory_google_test(api_tests
+    DISCOVER_TESTS
+    SOURCES         api_tests.cpp
+    LINK_LIBRARIES  common-test-libs
+                    timemory::timemory-core
+                    timemory::timemory-timing-component)
+
+add_timemory_google_test(type_trait_tests
+    DISCOVER_TESTS
+    SOURCES         type_trait_tests.cpp
+    LINK_LIBRARIES  common-test-libs
+                    timemory::timemory-core)
+
 add_timemory_google_test(warning_tests
     SOURCES         warning_tests.cpp
     LINK_LIBRARIES  test-werror-flags)

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -32,19 +32,21 @@ if(TIMEMORY_USE_OMPT)
     endif()
 endif()
 
-# add_library(no-store-merge INTERFACE)
-# add_target_cxx_flag_if_avail(no-store-merge "-fno-store-merging")
+# Optimization flags
 add_library(test-opt-flags INTERFACE)
 string(REPLACE " " ";" _FLAGS "${CMAKE_CXX_FLAGS_RELEASE}")
 target_compile_options(test-opt-flags INTERFACE ${_FLAGS})
 if(NOT TIMEMORY_USE_ARCH)
   add_target_flag_if_avail(test-opt-flags "-march=native")
 endif()
+
+# Debug flags
 add_library(test-debug-flags INTERFACE)
 string(REPLACE " " ";" _FLAGS "${CMAKE_CXX_FLAGS_DEBUG}")
 target_compile_options(test-debug-flags INTERFACE ${_FLAGS})
-add_target_flag_if_avail(test-debug-flags "-O0")
+add_target_flag_if_avail(test-debug-flags "-O0" "-g")
 
+# Any warnings trigger an error flags
 add_library(test-werror-flags INTERFACE)
 add_target_flag_if_avail(test-werror-flags "-W" "-Wall" "-Wextra" "-pedantic"
     "-Wno-mismatched-tags" "-Werror")
@@ -121,7 +123,8 @@ add_timemory_google_test(type_trait_tests
 
 add_timemory_google_test(warning_tests
     SOURCES         warning_tests.cpp
-    LINK_LIBRARIES  test-werror-flags)
+    LINK_LIBRARIES  test-werror-flags
+                    test-debug-flags)
 
 add_timemory_google_test(socket_tests
     SOURCES         socket_tests.cpp

--- a/source/tests/api_tests.cpp
+++ b/source/tests/api_tests.cpp
@@ -40,8 +40,6 @@ static char** _argv = nullptr;
 using mutex_t = std::mutex;
 using lock_t  = std::unique_lock<mutex_t>;
 
-using namespace tim::component;
-
 //--------------------------------------------------------------------------------------//
 
 namespace details
@@ -135,13 +133,15 @@ protected:
     }
 };
 
-namespace os       = tim::os;
-namespace api      = tim::api;
-namespace project  = tim::project;
-namespace category = tim::category;
-namespace tpls     = tim::tpls;
-namespace trait    = tim::trait;
-namespace concepts = tim::concepts;
+namespace os       = ::tim::os;
+namespace api      = ::tim::api;
+namespace project  = ::tim::project;
+namespace category = ::tim::category;
+namespace tpls     = ::tim::tpls;
+namespace trait    = ::tim::trait;
+namespace concepts = ::tim::concepts;
+
+using namespace tim::component;
 
 using tim_bundle_t  = tim::component_bundle<project::timemory, wall_clock, cpu_clock>;
 using cali_bundle_t = tim::component_bundle<tpls::caliper, caliper_marker, wall_clock>;

--- a/source/tests/api_tests.cpp
+++ b/source/tests/api_tests.cpp
@@ -1,0 +1,261 @@
+// MIT License
+//
+// Copyright (c) 2020, The Regents of the University of California,
+// through Lawrence Berkeley National Laboratory (subject to receipt of any
+// required approvals from the U.S. Dept. of Energy).  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "gtest/gtest.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <iostream>
+#include <mutex>
+#include <random>
+#include <thread>
+#include <vector>
+
+#include "timemory/timemory.hpp"
+
+static int    _argc = 0;
+static char** _argv = nullptr;
+
+using mutex_t = std::mutex;
+using lock_t  = std::unique_lock<mutex_t>;
+
+using namespace tim::component;
+
+//--------------------------------------------------------------------------------------//
+
+namespace details
+{
+//--------------------------------------------------------------------------------------//
+//  Get the current tests name
+//
+inline std::string
+get_test_name()
+{
+    return ::testing::UnitTest::GetInstance()->current_test_info()->name();
+}
+
+// this function consumes approximately "n" milliseconds of real time
+inline void
+do_sleep(long n)
+{
+    std::this_thread::sleep_for(std::chrono::milliseconds(n));
+}
+
+// this function consumes an unknown number of cpu resources
+inline long
+fibonacci(long n)
+{
+    return (n < 2) ? n : (fibonacci(n - 1) + fibonacci(n - 2));
+}
+
+// this function consumes approximately "t" milliseconds of cpu time
+void
+consume(long n)
+{
+    // a mutex held by one lock
+    mutex_t mutex;
+    // acquire lock
+    lock_t hold_lk(mutex);
+    // associate but defer
+    lock_t try_lk(mutex, std::defer_lock);
+    // get current time
+    auto now = std::chrono::steady_clock::now();
+    // try until time point
+    while(std::chrono::steady_clock::now() < (now + std::chrono::milliseconds(n)))
+        try_lk.try_lock();
+}
+
+// get a random entry from vector
+template <typename Tp>
+void
+random_fill(std::vector<Tp>& v, Tp scale, Tp offset = 1.0)
+{
+    std::mt19937 rng;
+    rng.seed(std::random_device()());
+    std::generate(v.begin(), v.end(), [&]() {
+        return (scale * std::generate_canonical<Tp, 10>(rng)) + offset;
+    });
+}
+
+// get a random entry from vector
+template <typename Tp>
+size_t
+random_entry(const std::vector<Tp>& v)
+{
+    std::mt19937 rng;
+    rng.seed(std::random_device()());
+    std::uniform_int_distribution<std::mt19937::result_type> dist(0, v.size() - 1);
+    return v.at(dist(rng));
+}
+
+}  // namespace details
+
+//--------------------------------------------------------------------------------------//
+
+class api_tests : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        static bool configured = false;
+        if(!configured)
+        {
+            configured                   = true;
+            tim::settings::verbose()     = 0;
+            tim::settings::debug()       = false;
+            tim::settings::json_output() = true;
+            tim::settings::mpi_thread()  = false;
+            tim::dmp::initialize(_argc, _argv);
+            tim::timemory_init(_argc, _argv);
+            tim::settings::dart_output() = true;
+            tim::settings::dart_count()  = 1;
+            tim::settings::banner()      = false;
+        }
+    }
+};
+
+namespace os       = tim::os;
+namespace api      = tim::api;
+namespace project  = tim::project;
+namespace category = tim::category;
+namespace tpls     = tim::tpls;
+namespace trait    = tim::trait;
+namespace concepts = tim::concepts;
+
+using tim_bundle_t  = tim::component_bundle<project::timemory, wall_clock, cpu_clock>;
+using cali_bundle_t = tim::component_bundle<tpls::caliper, caliper_marker, wall_clock>;
+using time_bundle_t = tim::component_tuple<wall_clock, cpu_clock, num_minor_page_faults>;
+using os_bundle_t   = tim::component_bundle<os::agnostic, wall_clock, cpu_clock>;
+
+//--------------------------------------------------------------------------------------//
+
+TEST_F(api_tests, timemory)
+{
+    using test_t  = project::timemory;
+    auto incoming = trait::runtime_enabled<test_t>::get();
+    trait::runtime_enabled<test_t>::set(false);
+
+    tim_bundle_t _obj(details::get_test_name());
+    _obj.start();
+    details::consume(1000);
+    _obj.stop();
+    EXPECT_NEAR(_obj.get<wall_clock>()->get(), 0.0, 1.0e-6);
+    EXPECT_NEAR(_obj.get<cpu_clock>()->get(), 0.0, 1.0e-6);
+
+    trait::runtime_enabled<test_t>::set(incoming);
+}
+
+//--------------------------------------------------------------------------------------//
+
+TEST_F(api_tests, tpls)
+{
+    using test_t  = tpls::caliper;
+    auto incoming = trait::runtime_enabled<test_t>::get();
+    trait::runtime_enabled<test_t>::set(false);
+
+    cali_bundle_t _obj(details::get_test_name());
+    _obj.start();
+    details::consume(1000);
+    _obj.stop();
+    EXPECT_EQ(_obj.get<wall_clock>(), nullptr);
+
+    trait::runtime_enabled<test_t>::set(incoming);
+}
+
+//--------------------------------------------------------------------------------------//
+
+TEST_F(api_tests, category)
+{
+    using test_t  = category::timing;
+    auto incoming = trait::runtime_enabled<test_t>::get();
+    trait::runtime_enabled<test_t>::set(false);
+
+    using wc_api_t   = trait::component_apis_t<wall_clock>;
+    using wc_true_t  = tim::get_true_types_t<trait::runtime_configurable, wc_api_t>;
+    using wc_false_t = tim::get_false_types_t<trait::runtime_configurable, wc_api_t>;
+    using apitypes_t = typename trait::runtime_enabled<wall_clock>::api_type_list;
+
+    puts("");
+    PRINT_HERE("component-apis : %s", tim::demangle<wc_api_t>().c_str());
+    PRINT_HERE("true-types     : %s", tim::demangle<wc_false_t>().c_str());
+    PRINT_HERE("false-types    : %s", tim::demangle<wc_true_t>().c_str());
+    PRINT_HERE("type-traits    : %s", tim::demangle<apitypes_t>().c_str());
+    puts("");
+
+    EXPECT_FALSE(trait::runtime_enabled<wall_clock>::get());
+    EXPECT_FALSE(trait::runtime_enabled<cpu_clock>::get());
+    EXPECT_TRUE(trait::runtime_enabled<num_minor_page_faults>::get());
+
+    time_bundle_t _obj(details::get_test_name());
+    _obj.start();
+    details::consume(500);
+    for(size_t i = 0; i < 10; ++i)
+    {
+        std::vector<double> _data(10000, 0.0);
+        details::random_fill(_data, 10.0, 1.0);
+        auto val = details::random_entry(_data);
+        EXPECT_GE(val, 1.0);
+        EXPECT_LE(val, 11.0);
+    }
+    _obj.stop();
+    EXPECT_NEAR(_obj.get<wall_clock>()->get(), 0.0, 1.0e-6);
+    EXPECT_NEAR(_obj.get<cpu_clock>()->get(), 0.0, 1.0e-6);
+    EXPECT_GT(_obj.get<num_minor_page_faults>()->get(), 0);
+
+    trait::runtime_enabled<test_t>::set(incoming);
+}
+
+//--------------------------------------------------------------------------------------//
+
+TEST_F(api_tests, os)
+{
+    trait::apply<trait::runtime_enabled>::set<os::unix, os::windows, wall_clock>(false);
+
+    os_bundle_t _obj(details::get_test_name());
+    _obj.start();
+    details::consume(1000);
+    _obj.stop();
+    EXPECT_NEAR(_obj.get<wall_clock>()->get(), 0.0, 1.0e-6);
+    EXPECT_NEAR(_obj.get<cpu_clock>()->get(), 1.0, 0.1);
+
+    trait::apply<trait::runtime_enabled>::set<os::unix, os::windows, wall_clock>(true);
+}
+
+//--------------------------------------------------------------------------------------//
+
+int
+main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    _argc = argc;
+    _argv = argv;
+
+    auto ret = RUN_ALL_TESTS();
+
+    tim::timemory_finalize();
+    tim::dmp::finalize();
+    return ret;
+}
+
+//--------------------------------------------------------------------------------------//

--- a/source/tests/type_trait_tests.cpp
+++ b/source/tests/type_trait_tests.cpp
@@ -125,7 +125,6 @@ protected:
 
 using namespace tim;
 using namespace tim::component;
-namespace concepts = tim::concepts;
 
 #define TEST_API TIMEMORY_API
 #define TEST_NAME(A, ...)                                                                \

--- a/source/tests/type_trait_tests.cpp
+++ b/source/tests/type_trait_tests.cpp
@@ -1,0 +1,318 @@
+// MIT License
+//
+// Copyright (c) 2020, The Regents of the University of California,
+// through Lawrence Berkeley National Laboratory (subject to receipt of any
+// required approvals from the U.S. Dept. of Energy).  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "gtest/gtest.h"
+
+#include <chrono>
+#include <condition_variable>
+#include <iostream>
+#include <mutex>
+#include <random>
+#include <thread>
+#include <vector>
+
+#include "timemory/timemory.hpp"
+
+static int    _argc = 0;
+static char** _argv = nullptr;
+
+using mutex_t = std::mutex;
+using lock_t  = std::unique_lock<mutex_t>;
+
+//--------------------------------------------------------------------------------------//
+
+namespace details
+{
+//--------------------------------------------------------------------------------------//
+//  Get the current tests name
+//
+inline std::string
+get_test_name()
+{
+    return ::testing::UnitTest::GetInstance()->current_test_info()->name();
+}
+
+// this function consumes approximately "n" milliseconds of real time
+inline void
+do_sleep(long n)
+{
+    std::this_thread::sleep_for(std::chrono::milliseconds(n));
+}
+
+// this function consumes an unknown number of cpu resources
+inline long
+fibonacci(long n)
+{
+    return (n < 2) ? n : (fibonacci(n - 1) + fibonacci(n - 2));
+}
+
+// this function consumes approximately "t" milliseconds of cpu time
+void
+consume(long n)
+{
+    // a mutex held by one lock
+    mutex_t mutex;
+    // acquire lock
+    lock_t hold_lk(mutex);
+    // associate but defer
+    lock_t try_lk(mutex, std::defer_lock);
+    // get current time
+    auto now = std::chrono::steady_clock::now();
+    // try until time point
+    while(std::chrono::steady_clock::now() < (now + std::chrono::milliseconds(n)))
+        try_lk.try_lock();
+}
+
+// get a random entry from vector
+template <typename Tp>
+size_t
+random_entry(const std::vector<Tp>& v)
+{
+    std::mt19937 rng;
+    rng.seed(std::random_device()());
+    std::uniform_int_distribution<std::mt19937::result_type> dist(0, v.size() - 1);
+    return v.at(dist(rng));
+}
+
+}  // namespace details
+
+//--------------------------------------------------------------------------------------//
+
+class type_trait_tests : public ::testing::Test
+{
+protected:
+    void SetUp() override
+    {
+        static bool configured = false;
+        if(!configured)
+        {
+            configured                   = true;
+            tim::settings::verbose()     = 0;
+            tim::settings::debug()       = false;
+            tim::settings::json_output() = true;
+            tim::settings::mpi_thread()  = false;
+            tim::dmp::initialize(_argc, _argv);
+            tim::timemory_init(_argc, _argv);
+            tim::settings::dart_output() = true;
+            tim::settings::dart_count()  = 1;
+            tim::settings::banner()      = false;
+        }
+    }
+};
+
+//--------------------------------------------------------------------------------------//
+
+using namespace tim;
+using namespace tim::component;
+namespace concepts = tim::concepts;
+
+#define TEST_API TIMEMORY_API
+#define TEST_NAME(A, ...)                                                                \
+    std::string(#A).substr(0, std::string(#A).find_first_of('<')).c_str()
+
+#define TEST_TRUE_TRAIT(CONCEPT, ...)                                                    \
+    {                                                                                    \
+        constexpr auto expr_v = CONCEPT<__VA_ARGS__>::value;                             \
+        printf("%s for %s is %s\n", TEST_NAME(CONCEPT, ""), TEST_NAME(__VA_ARGS__, ""),  \
+               (expr_v) ? "true" : "false");                                             \
+        EXPECT_TRUE(expr_v);                                                             \
+    }
+
+#define TEST_FALSE_TRAIT(CONCEPT, ...)                                                   \
+    {                                                                                    \
+        constexpr auto expr_v = CONCEPT<__VA_ARGS__>::value;                             \
+        printf("%s for %s is %s\n", TEST_NAME(CONCEPT, ""), TEST_NAME(__VA_ARGS__, ""),  \
+               (expr_v) ? "true" : "false");                                             \
+        EXPECT_FALSE(expr_v);                                                            \
+    }
+
+//--------------------------------------------------------------------------------------//
+
+using comp_hybrid_t = component_hybrid<type_list<wall_clock>, type_list<cpu_clock>>;
+using autp_hybrid_t = auto_hybrid<type_list<wall_clock>, type_list<cpu_clock>>;
+
+//--------------------------------------------------------------------------------------//
+
+TEST_F(type_trait_tests, is_null_type)
+{
+    puts("");
+    puts("[expect: false]");
+    TEST_FALSE_TRAIT(concepts::is_null_type, double)
+    TEST_FALSE_TRAIT(concepts::is_null_type, true_type)
+    TEST_FALSE_TRAIT(concepts::is_null_type, std::tuple<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_null_type, type_list<wall_clock, cpu_clock>)
+    TEST_FALSE_TRAIT(concepts::is_null_type, component_bundle<TEST_API, wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_null_type, component_tuple<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_null_type, component_list<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_null_type, auto_bundle<TEST_API, wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_null_type, auto_tuple<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_null_type, auto_list<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_null_type, lightweight_tuple<wall_clock>)
+    puts("[expect: true]");
+    TEST_TRUE_TRAIT(concepts::is_null_type, void)
+    TEST_TRUE_TRAIT(concepts::is_null_type, false_type)
+    TEST_TRUE_TRAIT(concepts::is_null_type, null_type)
+    TEST_TRUE_TRAIT(concepts::is_null_type, std::tuple<>)
+    TEST_TRUE_TRAIT(concepts::is_null_type, type_list<>)
+    TEST_TRUE_TRAIT(concepts::is_null_type, component_tuple<>)
+    TEST_TRUE_TRAIT(concepts::is_null_type, component_list<>)
+    TEST_TRUE_TRAIT(concepts::is_null_type, auto_tuple<>)
+    TEST_TRUE_TRAIT(concepts::is_null_type, auto_list<>)
+    TEST_TRUE_TRAIT(concepts::is_null_type, lightweight_tuple<>)
+    puts("");
+}
+
+TEST_F(type_trait_tests, is_empty)
+{
+    puts("");
+    puts("[expect: false]");
+    TEST_FALSE_TRAIT(concepts::is_empty, std::tuple<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_empty, type_list<wall_clock, cpu_clock>)
+    TEST_FALSE_TRAIT(concepts::is_empty, component_bundle<TEST_API, wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_empty, component_tuple<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_empty, component_list<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_empty, auto_bundle<TEST_API, wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_empty, auto_tuple<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_empty, auto_list<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_empty, lightweight_tuple<wall_clock>)
+    puts("[expect: true]");
+    TEST_TRUE_TRAIT(concepts::is_empty, std::tuple<>)
+    TEST_TRUE_TRAIT(concepts::is_empty, type_list<>)
+    TEST_TRUE_TRAIT(concepts::is_empty, component_bundle<TEST_API>)
+    TEST_TRUE_TRAIT(concepts::is_empty, component_tuple<>)
+    TEST_TRUE_TRAIT(concepts::is_empty, component_list<>)
+    TEST_TRUE_TRAIT(concepts::is_empty, auto_bundle<TEST_API>)
+    TEST_TRUE_TRAIT(concepts::is_empty, auto_tuple<>)
+    TEST_TRUE_TRAIT(concepts::is_empty, auto_list<>)
+    TEST_TRUE_TRAIT(concepts::is_empty, lightweight_tuple<>)
+    puts("");
+}
+
+TEST_F(type_trait_tests, is_variadic)
+{
+    puts("");
+    TEST_TRUE_TRAIT(concepts::is_variadic, std::tuple<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_variadic, type_list<wall_clock, cpu_clock>)
+    TEST_TRUE_TRAIT(concepts::is_variadic, component_bundle<TEST_API, wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_variadic, component_tuple<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_variadic, component_list<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_variadic, auto_bundle<TEST_API, wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_variadic, auto_tuple<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_variadic, auto_list<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_variadic, lightweight_tuple<wall_clock>)
+    puts("");
+}
+
+TEST_F(type_trait_tests, is_wrapper)
+{
+    puts("");
+    TEST_FALSE_TRAIT(concepts::is_wrapper, std::tuple<wall_clock, cpu_clock>)
+    TEST_FALSE_TRAIT(concepts::is_wrapper, type_list<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_wrapper, component_bundle<TEST_API, wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_wrapper, component_tuple<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_wrapper, component_list<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_wrapper, auto_bundle<TEST_API, wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_wrapper, auto_tuple<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_wrapper, auto_list<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_wrapper, lightweight_tuple<wall_clock>)
+    puts("");
+}
+
+TEST_F(type_trait_tests, is_stack_wrapper)
+{
+    puts("");
+    TEST_FALSE_TRAIT(concepts::is_stack_wrapper, std::tuple<wall_clock, cpu_clock>)
+    TEST_FALSE_TRAIT(concepts::is_stack_wrapper, type_list<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_stack_wrapper, component_bundle<TEST_API, wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_stack_wrapper, component_tuple<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_stack_wrapper, component_list<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_stack_wrapper, auto_bundle<TEST_API, wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_stack_wrapper, auto_tuple<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_stack_wrapper, auto_list<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_stack_wrapper, lightweight_tuple<wall_clock>)
+    puts("");
+}
+
+TEST_F(type_trait_tests, is_heap_wrapper)
+{
+    puts("");
+    TEST_FALSE_TRAIT(concepts::is_heap_wrapper, std::tuple<wall_clock, cpu_clock>)
+    TEST_FALSE_TRAIT(concepts::is_heap_wrapper, type_list<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_heap_wrapper, component_bundle<TEST_API, wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_heap_wrapper, component_tuple<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_heap_wrapper, component_list<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_heap_wrapper, auto_bundle<TEST_API, wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_heap_wrapper, auto_tuple<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_heap_wrapper, auto_list<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_heap_wrapper, lightweight_tuple<wall_clock>)
+    puts("");
+}
+
+TEST_F(type_trait_tests, is_auto_wrapper)
+{
+    puts("");
+    TEST_FALSE_TRAIT(concepts::is_auto_wrapper, std::tuple<wall_clock, cpu_clock>)
+    TEST_FALSE_TRAIT(concepts::is_auto_wrapper, type_list<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_auto_wrapper, component_bundle<TEST_API, wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_auto_wrapper, component_tuple<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_auto_wrapper, component_list<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_auto_wrapper, auto_bundle<TEST_API, wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_auto_wrapper, auto_tuple<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_auto_wrapper, auto_list<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_auto_wrapper, lightweight_tuple<wall_clock>)
+    puts("");
+}
+
+TEST_F(type_trait_tests, is_comp_wrapper)
+{
+    puts("");
+    TEST_FALSE_TRAIT(concepts::is_comp_wrapper, std::tuple<wall_clock, cpu_clock>)
+    TEST_FALSE_TRAIT(concepts::is_comp_wrapper, type_list<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_comp_wrapper, component_bundle<TEST_API, wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_comp_wrapper, component_tuple<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_comp_wrapper, component_list<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_comp_wrapper, auto_bundle<TEST_API, wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_comp_wrapper, auto_tuple<wall_clock>)
+    TEST_FALSE_TRAIT(concepts::is_comp_wrapper, auto_list<wall_clock>)
+    TEST_TRUE_TRAIT(concepts::is_comp_wrapper, lightweight_tuple<wall_clock>)
+    puts("");
+}
+
+//--------------------------------------------------------------------------------------//
+
+int
+main(int argc, char** argv)
+{
+    ::testing::InitGoogleTest(&argc, argv);
+    _argc = argc;
+    _argv = argv;
+
+    auto ret = RUN_ALL_TESTS();
+
+    tim::timemory_finalize();
+    tim::dmp::finalize();
+    return ret;
+}
+
+//--------------------------------------------------------------------------------------//

--- a/source/timemory/api.hpp
+++ b/source/timemory/api.hpp
@@ -24,87 +24,176 @@
 
 #pragma once
 
-/** \file timemory/api.hpp
- * \headerfile timemory/api.hpp "timemory/api.hpp"
- *
- * This is a declaration of API types
- *
- */
-
 #include "timemory/defines.h"
+#include "timemory/macros/os.hpp"
+#include "timemory/mpl/concepts.hpp"
 #include "timemory/version.h"
 
 #include <type_traits>
 
-//
-//--------------------------------------------------------------------------------------//
-//
-/**
- * \macro TIMEMORY_DECLARE_API
- * \brief Declare an API category
- */
-
-#if !defined(TIMEMORY_DECLARE_API)
-#    define TIMEMORY_DECLARE_API(NAME)                                                   \
+/// \macro TIMEMORY_DECLARE_NS_API(NS, NAME)
+/// \brief Declare an API category. APIs are used to designate
+/// different project implementations, different external library tools, etc.
+///
+#if !defined(TIMEMORY_DECLARE_NS_API)
+#    define TIMEMORY_DECLARE_NS_API(NS, NAME)                                            \
         namespace tim                                                                    \
         {                                                                                \
-        namespace api                                                                    \
+        namespace NS                                                                     \
         {                                                                                \
         struct NAME;                                                                     \
         }                                                                                \
         }
 #endif
-//
-//--------------------------------------------------------------------------------------//
-//
-/**
- * \macro TIMEMORY_DEFINE_API
- * \brief Define an API category
- */
 
-#if !defined(TIMEMORY_DEFINE_API)
-#    define TIMEMORY_DEFINE_API(NAME)                                                    \
+#if !defined(TIMEMORY_DECLARE_API)
+#    define TIMEMORY_DECLARE_API(NAME) TIMEMORY_DECLARE_NS_API(api, NAME)
+#endif
+
+//
+/// \macro TIMEMORY_DEFINE_NS_API(NS, NAME)
+/// \param NS sub-namespace within tim::api
+/// \param NAME the name of the API
+///
+/// \brief Define an API category within a namespace
+///
+#if !defined(TIMEMORY_DEFINE_NS_API)
+#    define TIMEMORY_DEFINE_NS_API(NS, NAME)                                             \
         namespace tim                                                                    \
         {                                                                                \
-        namespace api                                                                    \
+        namespace NS                                                                     \
         {                                                                                \
-        struct NAME                                                                      \
-        {};                                                                              \
-        }                                                                                \
-        namespace trait                                                                  \
-        {                                                                                \
-        template <>                                                                      \
-        struct is_api<api::NAME> : true_type                                             \
+        struct NAME : public concepts::api                                               \
         {};                                                                              \
         }                                                                                \
         }
 #endif
+
+///
+/// \macro TIMEMORY_DEFINE_API
+/// \brief Define an API category. APIs are used to designate
+/// different project implementations, different external library tools, etc.
+/// Note: this macro inherits from \ref concepts::api instead of specializing
+/// is_api<...>, thus allowing specialization from tools downstream
+///
+#if !defined(TIMEMORY_DEFINE_API)
+#    define TIMEMORY_DEFINE_API(NAME) TIMEMORY_DEFINE_NS_API(api, NAME)
+#endif
+
+//
+// General APIs
+//
+TIMEMORY_DEFINE_NS_API(project, none)      // dummy type
+TIMEMORY_DEFINE_NS_API(project, timemory)  // provided by timemory API exclusively
+TIMEMORY_DEFINE_NS_API(project, python)    // provided by timemory python interface
+//
+// Device APIs
+//
+TIMEMORY_DECLARE_NS_API(device, cpu)  // collects data on CPU
+TIMEMORY_DECLARE_NS_API(device, gpu)  // collects data on GPU
+//
+// Category APIs
+//
+TIMEMORY_DEFINE_NS_API(category, debugger)          // provided debugging utilities
+TIMEMORY_DEFINE_NS_API(category, decorator)         // decorates external profiler
+TIMEMORY_DEFINE_NS_API(category, external)          // relies on external package
+TIMEMORY_DEFINE_NS_API(category, io)                // collects I/O data
+TIMEMORY_DEFINE_NS_API(category, logger)            // logs generic data or messages
+TIMEMORY_DEFINE_NS_API(category, hardware_counter)  // collects HW counter data
+TIMEMORY_DEFINE_NS_API(category, memory)            // collects memory data
+TIMEMORY_DEFINE_NS_API(category, resource_usage)    // collects resource usage data
+TIMEMORY_DEFINE_NS_API(category, timing)            // collects timing data
+TIMEMORY_DEFINE_NS_API(category, visualization)     // related to viz (currently unused)
+//
+// External Third-party library APIs
+//
+TIMEMORY_DEFINE_NS_API(tpls, allinea)
+TIMEMORY_DEFINE_NS_API(tpls, caliper)
+TIMEMORY_DEFINE_NS_API(tpls, craypat)
+TIMEMORY_DEFINE_NS_API(tpls, gotcha)
+TIMEMORY_DEFINE_NS_API(tpls, gperftools)
+TIMEMORY_DEFINE_NS_API(tpls, intel)
+TIMEMORY_DEFINE_NS_API(tpls, likwid)
+TIMEMORY_DEFINE_NS_API(tpls, nvidia)
+TIMEMORY_DEFINE_NS_API(tpls, openmp)
+TIMEMORY_DEFINE_NS_API(tpls, papi)
+TIMEMORY_DEFINE_NS_API(tpls, tau)
+//
+// OS-specific APIs
+//
+TIMEMORY_DEFINE_NS_API(os, agnostic)
+TIMEMORY_DEFINE_NS_API(os, unix)
+TIMEMORY_DEFINE_NS_API(os, linux)
+TIMEMORY_DEFINE_NS_API(os, darwin)
+TIMEMORY_DEFINE_NS_API(os, windows)
 //
 //--------------------------------------------------------------------------------------//
+//
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, project::timemory, true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, project::python, true_type)
+//
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, category::debugger, true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, category::decorator, true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, category::external, true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, category::io, true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, category::logger, true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, category::hardware_counter,
+                                 true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, category::resource_usage,
+                                 true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, category::timing, true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, category::visualization,
+                                 true_type)
+//
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, tpls::allinea, true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, tpls::caliper, true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, tpls::craypat, true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, tpls::gotcha, true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, tpls::gperftools, true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, tpls::intel, true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, tpls::likwid, true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, tpls::nvidia, true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, tpls::openmp, true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, tpls::papi, true_type)
+TIMEMORY_DEFINE_CONCRETE_CONCEPT(is_runtime_configurable, tpls::tau, true_type)
 //
 namespace tim
 {
-//
-using true_type  = std::true_type;
-using false_type = std::false_type;
+namespace api
+{
+using native_tag = project::timemory;
+}
 //
 namespace trait
 {
-template <typename T>
-struct is_api : false_type
+//
+#if !defined(_UNIX)
+template <>
+struct is_available<os::unix> : false_type
 {};
+#endif
+//
+#if !defined(_LINUX)
+template <>
+struct is_available<os::linux> : false_type
+{};
+#endif
+//
+#if !defined(_MACOS)
+template <>
+struct is_available<os::darwin> : false_type
+{};
+#endif
+//
+#if !defined(_WINDOWS)
+template <>
+struct is_available<os::windows> : false_type
+{};
+#endif
+//
 }  // namespace trait
 //
 }  // namespace tim
-
-//
-//--------------------------------------------------------------------------------------//
-//
-TIMEMORY_DECLARE_API(native_tag)
-TIMEMORY_DEFINE_API(native_tag)
-
-TIMEMORY_DECLARE_API(python)
-TIMEMORY_DEFINE_API(python)
 //
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/backends/callback.hpp
+++ b/source/timemory/backends/callback.hpp
@@ -25,12 +25,26 @@
 
 /** \file callback.hpp
  * \headerfile callback.hpp "timemory/details/callback.hpp"
- * Provides implementation of callback for cuda_event
+ * Provides implementation of callback for cudaEvent_t
  *
  */
 
 #pragma once
 
+#if defined(TIMEMORY_USE_CUDA)
+
+#    include <condition_variable>
+#    include <memory>
+#    include <mutex>
+#    include <thread>
+
+#    include <cuda.h>
+#    include <cuda_runtime_api.h>
+
+namespace tim
+{
+namespace cuda
+{
 //--------------------------------------------------------------------------------------//
 // Create thread
 //
@@ -125,7 +139,7 @@ struct heterogeneous_workload
     int          id;
     int          cudaDeviceID;
     cudaStream_t stream;
-    cuda_event*  event;
+    cudaEvent_t* event;
     bool         success;
 };
 
@@ -161,3 +175,8 @@ static void CUDART_CB
 {
     cutStartThread(postprocess, data);
 }
+
+}  // namespace cuda
+}  // namespace tim
+
+#endif

--- a/source/timemory/backends/cupti.hpp
+++ b/source/timemory/backends/cupti.hpp
@@ -30,26 +30,28 @@
 
 #pragma once
 
-#include "timemory/backends/device.hpp"
-#include "timemory/backends/hardware_counters.hpp"
-#include "timemory/backends/types/cupti.hpp"
-#include "timemory/components/cuda/backends.hpp"
-#include "timemory/macros.hpp"
-#include "timemory/settings/declaration.hpp"
-#include "timemory/utility/utility.hpp"
+#if defined(TIMEMORY_USE_CUPTI)
 
-#include <cassert>
-#include <cstdint>
-#include <cstdio>
-#include <cstring>
-#include <iostream>
-#include <list>
-#include <map>
-#include <sstream>
-#include <string>
-#include <thread>
-#include <unordered_map>
-#include <vector>
+#    include "timemory/backends/device.hpp"
+#    include "timemory/backends/hardware_counters.hpp"
+#    include "timemory/backends/types/cupti.hpp"
+#    include "timemory/components/cuda/backends.hpp"
+#    include "timemory/macros.hpp"
+#    include "timemory/settings/declaration.hpp"
+#    include "timemory/utility/utility.hpp"
+
+#    include <cassert>
+#    include <cstdint>
+#    include <cstdio>
+#    include <cstring>
+#    include <iostream>
+#    include <list>
+#    include <map>
+#    include <sstream>
+#    include <string>
+#    include <thread>
+#    include <unordered_map>
+#    include <vector>
 
 //--------------------------------------------------------------------------------------//
 
@@ -277,7 +279,7 @@ static void CUPTIAPI
     // get the correlation data ID
     uint64_t corr_data = *cbInfo->correlationData;
 
-#if defined(DEBUG)
+#    if defined(DEBUG)
     printf("[kern] %s\n", cbInfo->symbolName);
     // construct a name
     std::stringstream _kernel_name_ss;
@@ -285,7 +287,7 @@ static void CUPTIAPI
     _kernel_name_ss << std::string(_sym_name) << "_" << cbInfo->contextUid << "_"
                     << corr_data;
     auto current_kernel_name = _kernel_name_ss.str();
-#endif
+#    endif
 
     _LOG("... begin callback for %s...\n", current_kernel_name.c_str());
     if(cbInfo->callbackSite == CUPTI_API_ENTER)
@@ -366,7 +368,7 @@ static void CUPTIAPI
                     pass_data.event_values.push_back(normalized);
 
 // print collected value
-#if defined(DEBUG)
+#    if defined(DEBUG)
                     {
                         char   eventName[128];
                         size_t eventNameSize = sizeof(eventName) - 1;
@@ -386,7 +388,7 @@ static void CUPTIAPI
                              (unsigned long long) sum, numTotalInstances, numInstances,
                              (unsigned long long) normalized);
                     }
-#endif
+#    endif
                 }
                 free(values);
                 free(eventIds);
@@ -1064,7 +1066,7 @@ compute_api_kind(CUpti_ActivityComputeApiKind kind)
 inline int64_t
 get_elapsed(CUpti_Activity* record)
 {
-#define _CUPTI_CAST_RECORD(ToType, var) ToType* var = (ToType*) record
+#    define _CUPTI_CAST_RECORD(ToType, var) ToType* var = (ToType*) record
 
     switch(record->kind)
     {
@@ -1109,7 +1111,7 @@ get_elapsed(CUpti_Activity* record)
         default: break;
     }
     return 0;
-#undef _CUPTI_CAST_RECORD
+#    undef _CUPTI_CAST_RECORD
 }
 
 //--------------------------------------------------------------------------------------//
@@ -1117,7 +1119,7 @@ get_elapsed(CUpti_Activity* record)
 inline const char*
 get_name(CUpti_Activity* record)
 {
-#define _CUPTI_CAST_RECORD(ToType, var) ToType* var = (ToType*) record
+#    define _CUPTI_CAST_RECORD(ToType, var) ToType* var = (ToType*) record
 
     switch(record->kind)
     {
@@ -1164,7 +1166,7 @@ get_name(CUpti_Activity* record)
         default: break;
     }
     return "";
-#undef _CUPTI_CAST_RECORD
+#    undef _CUPTI_CAST_RECORD
 }
 
 //--------------------------------------------------------------------------------------//
@@ -1862,8 +1864,10 @@ tim::cupti::available_metrics_info(CUdevice device)
     return metric_info;
 }
 
-#undef TIMEMORY_CUPTI_PROFILER_NAME_SHORT
-#undef TIMEMORY_CUPTI_PROFILER_NAME_LONG
-#undef TIMEMORY_CUPTI_BUFFER_SIZE
-#undef TIMEMORY_CUPTI_ALIGN_SIZE
-#undef TIMEMORY_CUPTI_ALIGN_BUFFER
+#    undef TIMEMORY_CUPTI_PROFILER_NAME_SHORT
+#    undef TIMEMORY_CUPTI_PROFILER_NAME_LONG
+#    undef TIMEMORY_CUPTI_BUFFER_SIZE
+#    undef TIMEMORY_CUPTI_ALIGN_SIZE
+#    undef TIMEMORY_CUPTI_ALIGN_BUFFER
+
+#endif

--- a/source/timemory/components/allinea/types.hpp
+++ b/source/timemory/components/allinea/types.hpp
@@ -38,9 +38,13 @@
 //
 TIMEMORY_DECLARE_COMPONENT(allinea_map)
 //
+TIMEMORY_SET_COMPONENT_API(component::allinea_map, tpls::allinea, category::external,
+                           os::linux)
+//
 //--------------------------------------------------------------------------------------//
 //
 #if !defined(TIMEMORY_USE_ALLINEA_MAP)
+TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, tpls::allinea, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::allinea_map, false_type)
 #endif
 //

--- a/source/timemory/components/caliper/timemory.hpp
+++ b/source/timemory/components/caliper/timemory.hpp
@@ -166,7 +166,7 @@ struct caliper_config
     ///     args --> pybind11::args --> pybind11::tuple
     ///     kwargs --> pybind11::kwargs --> pybind11::dict
     ///
-    void configure(api::python, pybind11::args _args, pybind11::kwargs _kwargs)
+    void configure(project::python, pybind11::args _args, pybind11::kwargs _kwargs)
     {
         std::string cmd = "";
         {
@@ -276,7 +276,7 @@ public:
     ///     without that member function is not invalid
     ///
     template <template <typename...> class BundleT>
-    static void configure(api::python,
+    static void configure(project::python,
                           pybind11::class_<BundleT<caliper_marker>>& _pyclass)
     {
         // define two lambdas to pass to pybind11 instead of &caliper_marker
@@ -367,7 +367,7 @@ struct caliper_loop_marker
 
 #if defined(TIMEMORY_PYBIND11_SOURCE)
     template <template <typename...> class BundleT>
-    static void configure(api::python, pybind11::class_<BundleT<caliper_marker>>&)
+    static void configure(project::python, pybind11::class_<BundleT<caliper_marker>>&)
     {}
 #endif
 

--- a/source/timemory/components/caliper/types.hpp
+++ b/source/timemory/components/caliper/types.hpp
@@ -29,14 +29,12 @@
 
 #pragma once
 
+#include "timemory/api.hpp"
 #include "timemory/components/macros.hpp"
 #include "timemory/enum.h"
 #include "timemory/mpl/type_traits.hpp"
 #include "timemory/mpl/types.hpp"
 
-//======================================================================================//
-//
-TIMEMORY_DEFINE_API(caliper)
 //
 TIMEMORY_DECLARE_COMPONENT(caliper_config)
 TIMEMORY_DECLARE_COMPONENT(caliper_marker)
@@ -46,12 +44,17 @@ TIMEMORY_DECLARE_COMPONENT(caliper_loop_marker)
 //
 TIMEMORY_COMPONENT_ALIAS(caliper, caliper_marker)
 //
-TIMEMORY_DECLARE_API_COMPONENTS(api::caliper, component::caliper_marker,
-                                component::caliper_config, component::caliper_loop_marker)
+TIMEMORY_SET_COMPONENT_API(component::caliper_config, tpls::caliper, category::external,
+                           os::unix)
+TIMEMORY_SET_COMPONENT_API(component::caliper_marker, tpls::caliper, category::external,
+                           os::unix)
+TIMEMORY_SET_COMPONENT_API(component::caliper_loop_marker, tpls::caliper,
+                           category::external, os::unix)
 //
 //--------------------------------------------------------------------------------------//
 //
 #if !defined(TIMEMORY_USE_CALIPER)
+TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, tpls::caliper, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::caliper_marker, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::caliper_config, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::caliper_loop_marker, false_type)

--- a/source/timemory/components/craypat/types.hpp
+++ b/source/timemory/components/craypat/types.hpp
@@ -29,20 +29,34 @@
 
 #pragma once
 
+#include "timemory/components/craypat/backends.hpp"
 #include "timemory/components/macros.hpp"
 #include "timemory/enum.h"
 #include "timemory/mpl/type_traits.hpp"
 #include "timemory/mpl/types.hpp"
-//
-#include "timemory/components/craypat/backends.hpp"
 
-//======================================================================================//
-//
 TIMEMORY_DECLARE_COMPONENT(craypat_record)
 TIMEMORY_DECLARE_COMPONENT(craypat_region)
 TIMEMORY_DECLARE_COMPONENT(craypat_counters)
 TIMEMORY_DECLARE_COMPONENT(craypat_heap_stats)
 TIMEMORY_DECLARE_COMPONENT(craypat_flush_buffer)
+
+//--------------------------------------------------------------------------------------//
+//
+//                                  APIs
+//
+//--------------------------------------------------------------------------------------//
+//
+TIMEMORY_SET_COMPONENT_API(component::craypat_record, tpls::craypat, category::external,
+                           os::linux)
+TIMEMORY_SET_COMPONENT_API(component::craypat_region, tpls::craypat, category::external,
+                           category::decorator, os::linux)
+TIMEMORY_SET_COMPONENT_API(component::craypat_counters, tpls::craypat, category::external,
+                           os::linux)
+TIMEMORY_SET_COMPONENT_API(component::craypat_heap_stats, tpls::craypat,
+                           category::external, os::linux)
+TIMEMORY_SET_COMPONENT_API(component::craypat_flush_buffer, tpls::craypat,
+                           category::external, os::linux)
 //
 //--------------------------------------------------------------------------------------//
 //
@@ -61,6 +75,7 @@ TIMEMORY_STATISTICS_TYPE(component::craypat_counters, std::vector<unsigned long>
 //
 #if !defined(TIMEMORY_USE_CRAYPAT)
 //
+TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, tpls::craypat, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::craypat_record, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::craypat_region, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::craypat_counters, false_type)

--- a/source/timemory/components/cuda/components.hpp
+++ b/source/timemory/components/cuda/components.hpp
@@ -249,7 +249,8 @@ public:
     ///     without that member function is not invalid
     ///
     template <template <typename...> class BundleT>
-    static void configure(api::python, pybind11::class_<BundleT<cuda_event>>& _pyclass)
+    static void configure(project::python,
+                          pybind11::class_<BundleT<cuda_event>>& _pyclass)
     {
         auto _sync = [](BundleT<cuda_event>* obj) {
             obj->template get<cuda_event>()->sync();
@@ -357,7 +358,7 @@ public:
     ///     args --> pybind11::args --> pybind11::tuple
     ///     kwargs --> pybind11::kwargs --> pybind11::dict
     ///
-    static void configure(api::python, pybind11::args _args, pybind11::kwargs _kwargs)
+    static void configure(project::python, pybind11::args _args, pybind11::kwargs _kwargs)
     {
         auto _config = get_initializer()();
         if(_args.size() > 0)
@@ -545,7 +546,8 @@ public:
     ///     without that member function is not invalid
     ///
     template <template <typename...> class BundleT>
-    static void configure(api::python, pybind11::class_<BundleT<nvtx_marker>>& _pyclass)
+    static void configure(project::python,
+                          pybind11::class_<BundleT<nvtx_marker>>& _pyclass)
     {
         _pyclass.def_property_static(
             "use_device_sync", [](pybind11::object) { return use_device_sync(); },

--- a/source/timemory/components/cuda/types.hpp
+++ b/source/timemory/components/cuda/types.hpp
@@ -43,18 +43,25 @@ class object;
 }
 #endif
 
-//======================================================================================//
-//
 TIMEMORY_DECLARE_COMPONENT(cuda_event)
 TIMEMORY_DECLARE_COMPONENT(cuda_profiler)
 TIMEMORY_DECLARE_COMPONENT(nvtx_marker)
 TIMEMORY_COMPONENT_ALIAS(cuda_nvtx, nvtx_marker)
+
+//--------------------------------------------------------------------------------------//
 //
-//======================================================================================//
+//                                  APIs
 //
-//                              TYPE-TRAITS
+//--------------------------------------------------------------------------------------//
 //
-//======================================================================================//
+TIMEMORY_SET_COMPONENT_API(component::cuda_event, tpls::nvidia, device::gpu,
+                           category::external, os::agnostic)
+TIMEMORY_SET_COMPONENT_API(component::cuda_profiler, tpls::nvidia, category::external,
+                           os::agnostic)
+TIMEMORY_SET_COMPONENT_API(component::nvtx_marker, tpls::nvidia, category::external,
+                           category::decorator, os::agnostic)
+//
+//--------------------------------------------------------------------------------------//
 //
 //                              STATISTICS
 //
@@ -111,6 +118,7 @@ TIMEMORY_DEFINE_CONCRETE_TRAIT(requires_prefix, component::nvtx_marker, true_typ
 //--------------------------------------------------------------------------------------//
 //
 #if !defined(TIMEMORY_USE_CUDA)
+TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, tpls::nvidia, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::cuda_event, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::cuda_profiler, false_type)
 #endif

--- a/source/timemory/components/cupti/types.hpp
+++ b/source/timemory/components/cupti/types.hpp
@@ -34,13 +34,24 @@
 #include "timemory/mpl/type_traits.hpp"
 #include "timemory/mpl/types.hpp"
 
-//======================================================================================//
-//
 TIMEMORY_DECLARE_COMPONENT(cupti_activity)
 TIMEMORY_DECLARE_COMPONENT(cupti_counters)
 TIMEMORY_DECLARE_COMPONENT(cupti_profiler)
+
+//--------------------------------------------------------------------------------------//
 //
-//======================================================================================//
+//                                  APIs
+//
+//--------------------------------------------------------------------------------------//
+//
+TIMEMORY_SET_COMPONENT_API(component::cupti_activity, tpls::nvidia, device::gpu,
+                           category::external, category::timing, os::agnostic)
+TIMEMORY_SET_COMPONENT_API(component::cupti_counters, tpls::nvidia, device::gpu,
+                           category::external, category::hardware_counter, os::agnostic)
+TIMEMORY_SET_COMPONENT_API(component::cupti_profiler, tpls::nvidia, device::gpu,
+                           category::external, category::hardware_counter, os::agnostic)
+//
+//--------------------------------------------------------------------------------------//
 //
 //                              STATISTICS
 //
@@ -59,6 +70,10 @@ TIMEMORY_STATISTICS_TYPE(component::cupti_profiler, std::vector<double>)
 #if !defined(TIMEMORY_USE_CUPTI) || !defined(TIMEMORY_USE_CUDA)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::cupti_counters, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::cupti_activity, false_type)
+#endif
+//
+#if !defined(TIMEMORY_USE_CUPTI) || !defined(TIMEMORY_USE_CUDA) ||                       \
+    !defined(TIMEMORY_USE_CUPTI_NVPERF)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::cupti_profiler, false_type)
 #endif
 //

--- a/source/timemory/components/data_tracker/types.hpp
+++ b/source/timemory/components/data_tracker/types.hpp
@@ -36,12 +36,28 @@
 #include "timemory/mpl/type_traits.hpp"
 #include "timemory/mpl/types.hpp"
 
-//======================================================================================//
-//
 TIMEMORY_DECLARE_TEMPLATE_COMPONENT(data_tracker, typename InpT,
                                     typename Tag     = api::native_tag,
                                     typename Handler = data::handler<InpT, Tag>,
                                     typename StoreT  = InpT)
+
+//--------------------------------------------------------------------------------------//
+//
+//                                  APIs
+//
+//--------------------------------------------------------------------------------------//
+//
+namespace tim
+{
+namespace trait
+{
+template <typename InpT, typename Tag, typename Handler, typename StoreT>
+struct component_apis<component::data_tracker<InpT, Tag, Handler, StoreT>>
+{
+    using type = type_list<project::timemory, category::logger, os::agnostic>;
+};
+}  // namespace trait
+}  // namespace tim
 //
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/components/gotcha/components.hpp
+++ b/source/timemory/components/gotcha/components.hpp
@@ -56,7 +56,9 @@ namespace component
 //  TODO: filter any gotcha components out of Components
 //
 template <size_t Nt, typename Components, typename Differentiator>
-struct gotcha : public base<gotcha<Nt, Components, Differentiator>, void>
+struct gotcha
+: public base<gotcha<Nt, Components, Differentiator>, void>
+, public concepts::external_function_wrapper
 {
     static_assert(concepts::has_gotcha<Components>::value == false,
                   "Error! {auto,component}_{list,tuple,hybrid} in a GOTCHA specification "
@@ -1020,7 +1022,9 @@ namespace component
 {
 //======================================================================================//
 //
-struct malloc_gotcha : base<malloc_gotcha, double>
+struct malloc_gotcha
+: base<malloc_gotcha, double>
+, public concepts::external_function_wrapper
 {
 #if defined(TIMEMORY_USE_CUDA)
     static constexpr uintmax_t data_size = 5;

--- a/source/timemory/components/gotcha/mpip.hpp
+++ b/source/timemory/components/gotcha/mpip.hpp
@@ -208,9 +208,8 @@ tim::component::deactivate_mpip(uint64_t id)
 //
 #if !defined(TIMEMORY_USE_GOTCHA) || !defined(TIMEMORY_USE_MPI)
 //
-template <typename Toolset, typename Tag, typename... Args>
-void
-tim::component::configure_mpip(Args&&...)
+template <typename Toolset, typename Tag>
+void configure_mpip(std::set<std::string>, std::set<std::string>)
 {}
 //
 #else

--- a/source/timemory/components/gotcha/ncclp.hpp
+++ b/source/timemory/components/gotcha/ncclp.hpp
@@ -209,9 +209,8 @@ tim::component::deactivate_ncclp(uint64_t id)
 //
 #if !defined(TIMEMORY_USE_GOTCHA) || !defined(TIMEMORY_USE_NCCL)
 //
-template <typename Toolset, typename Tag, typename... Args>
-void
-tim::component::configure_ncclp(Args&&...)
+template <typename Toolset, typename Tag>
+void configure_ncclp(std::set<std::string>, std::set<std::string>)
 {}
 //
 #else

--- a/source/timemory/components/gotcha/types.hpp
+++ b/source/timemory/components/gotcha/types.hpp
@@ -37,16 +37,36 @@
 #include "timemory/mpl/type_traits.hpp"
 #include "timemory/mpl/types.hpp"
 
-//======================================================================================//
-//
-TIMEMORY_DECLARE_TEMPLATE_COMPONENT(gotcha, size_t Nt, typename Components,
-                                    typename Differentiator = void)
+// Declared in timemory/mpl/concepts.hpp
+// TIMEMORY_DECLARE_TEMPLATE_COMPONENT(gotcha, size_t Nt, typename Components,
+//                                    typename Differentiator = anonymous_t<void>)
 //
 TIMEMORY_DECLARE_COMPONENT(malloc_gotcha)
 //
 TIMEMORY_DECLARE_TEMPLATE_COMPONENT(mpip_handle, typename Toolset, typename Tag)
+
+//--------------------------------------------------------------------------------------//
 //
-//======================================================================================//
+//                                  APIs
+//
+//--------------------------------------------------------------------------------------//
+//
+namespace tim
+{
+namespace trait
+{
+template <size_t Nt, typename ComponentsT, typename DiffT>
+struct component_apis<component::gotcha<Nt, ComponentsT, DiffT>>
+{
+    using type = type_list<tpls::gotcha, category::external, os::linux>;
+};
+}  // namespace trait
+}  // namespace tim
+//
+TIMEMORY_SET_COMPONENT_API(component::malloc_gotcha, tpls::gotcha, category::external,
+                           category::memory, os::linux)
+//
+//--------------------------------------------------------------------------------------//
 //
 //                              STATISTICS
 //
@@ -62,6 +82,7 @@ TIMEMORY_STATISTICS_TYPE(component::malloc_gotcha, double)
 //
 #if !defined(TIMEMORY_USE_GOTCHA)
 //
+TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, tpls::gotcha, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::malloc_gotcha, false_type)
 //
 namespace tim

--- a/source/timemory/components/gperftools/types.hpp
+++ b/source/timemory/components/gperftools/types.hpp
@@ -34,8 +34,6 @@
 #include "timemory/mpl/type_traits.hpp"
 #include "timemory/mpl/types.hpp"
 
-//======================================================================================//
-//
 TIMEMORY_DECLARE_COMPONENT(gperftools_cpu_profiler)
 TIMEMORY_DECLARE_COMPONENT(gperftools_heap_profiler)
 //
@@ -43,12 +41,27 @@ TIMEMORY_DECLARE_COMPONENT(gperftools_heap_profiler)
 //
 TIMEMORY_COMPONENT_ALIAS(gperf_cpu_profiler, gperftools_cpu_profiler)
 TIMEMORY_COMPONENT_ALIAS(gperf_heap_profiler, gperftools_heap_profiler)
+
+//--------------------------------------------------------------------------------------//
 //
-//======================================================================================//
+//                                  APIs
+//
+//--------------------------------------------------------------------------------------//
+//
+TIMEMORY_SET_COMPONENT_API(component::gperftools_cpu_profiler, tpls::gperftools,
+                           category::external, category::timing, os::unix)
+TIMEMORY_SET_COMPONENT_API(component::gperftools_heap_profiler, tpls::gperftools,
+                           category::external, category::memory, os::unix)
+//
+//--------------------------------------------------------------------------------------//
 //
 //                              IS AVAILABLE
 //
 //--------------------------------------------------------------------------------------//
+//
+#if !defined(TIMEMORY_USE_GPERFTOOLS)
+TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, tpls::gperftools, false_type)
+#endif
 //
 //      GPERF and gperftools_heap_profiler
 //

--- a/source/timemory/components/io/components.hpp
+++ b/source/timemory/components/io/components.hpp
@@ -209,11 +209,11 @@ struct read_char : public base<read_char, std::pair<int64_t, int64_t>>
         if(settings::timing_units().length() > 0)
         {
             auto _tval = std::get<0>(units::get_timing_unit(settings::timing_units()));
-            _rate      = apply<std::string>::join("/", _mem, _tval);
+            _rate      = apply<std::string>::join('/', _mem, _tval);
         }
         else if(settings::memory_units().length() > 0)
         {
-            _rate = apply<std::string>::join("/", _mem, "sec");
+            _rate = apply<std::string>::join('/', _mem, "sec");
         }
 
         return _instance;
@@ -419,11 +419,11 @@ struct written_char : public base<written_char, std::array<int64_t, 2>>
         if(settings::timing_units().length() > 0)
         {
             auto _tval = std::get<0>(units::get_timing_unit(settings::timing_units()));
-            _rate      = apply<std::string>::join("/", _mem, _tval);
+            _rate      = apply<std::string>::join('/', _mem, _tval);
         }
         else if(settings::memory_units().length() > 0)
         {
-            _rate = apply<std::string>::join("/", _mem, "sec");
+            _rate = apply<std::string>::join('/', _mem, "sec");
         }
 
         return _instance;
@@ -626,11 +626,11 @@ struct read_bytes : public base<read_bytes, std::pair<int64_t, int64_t>>
         if(settings::timing_units().length() > 0)
         {
             auto _tval = std::get<0>(units::get_timing_unit(settings::timing_units()));
-            _rate      = apply<std::string>::join("/", _mem, _tval);
+            _rate      = apply<std::string>::join('/', _mem, _tval);
         }
         else if(settings::memory_units().length() > 0)
         {
-            _rate = apply<std::string>::join("/", _mem, "sec");
+            _rate = apply<std::string>::join('/', _mem, "sec");
         }
 
         return _instance;
@@ -834,11 +834,11 @@ struct written_bytes : public base<written_bytes, std::array<int64_t, 2>>
         if(settings::timing_units().length() > 0)
         {
             auto _tval = std::get<0>(units::get_timing_unit(settings::timing_units()));
-            _rate      = apply<std::string>::join("/", _mem, _tval);
+            _rate      = apply<std::string>::join('/', _mem, _tval);
         }
         else if(settings::memory_units().length() > 0)
         {
-            _rate = apply<std::string>::join("/", _mem, "sec");
+            _rate = apply<std::string>::join('/', _mem, "sec");
         }
 
         return _instance;

--- a/source/timemory/components/io/types.hpp
+++ b/source/timemory/components/io/types.hpp
@@ -55,6 +55,21 @@ using pair_dd_t = std::pair<double, double>;
 
 //--------------------------------------------------------------------------------------//
 //
+//                                      APIs
+//
+//--------------------------------------------------------------------------------------//
+//
+TIMEMORY_SET_COMPONENT_API(component::read_char, project::timemory, category::io,
+                           os::linux)
+TIMEMORY_SET_COMPONENT_API(component::written_char, project::timemory, category::io,
+                           os::linux)
+TIMEMORY_SET_COMPONENT_API(component::read_bytes, project::timemory, category::io,
+                           os::linux)
+TIMEMORY_SET_COMPONENT_API(component::written_bytes, project::timemory, category::io,
+                           os::linux)
+//
+//--------------------------------------------------------------------------------------//
+//
 //                                  AVAILABLE
 //
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/components/likwid/types.hpp
+++ b/source/timemory/components/likwid/types.hpp
@@ -62,7 +62,19 @@
 //
 TIMEMORY_DECLARE_COMPONENT(likwid_marker)
 TIMEMORY_DECLARE_COMPONENT(likwid_nvmarker)
+
+//--------------------------------------------------------------------------------------//
 //
+//                                  APIs
+//
+//--------------------------------------------------------------------------------------//
+//
+TIMEMORY_SET_COMPONENT_API(component::likwid_marker, tpls::likwid, category::external,
+                           category::decorator, category::hardware_counter, os::linux)
+TIMEMORY_SET_COMPONENT_API(component::likwid_nvmarker, tpls::likwid, device::gpu,
+                           category::external, category::decorator,
+                           category::hardware_counter, os::linux)
+
 namespace tim
 {
 namespace component
@@ -85,6 +97,7 @@ struct likwid_data;
 //--------------------------------------------------------------------------------------//
 //
 #if !defined(TIMEMORY_USE_LIKWID)
+TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, tpls::likwid, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::likwid_marker, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::likwid_nvmarker, false_type)
 #else

--- a/source/timemory/components/macros.hpp
+++ b/source/timemory/components/macros.hpp
@@ -90,6 +90,50 @@
 //--------------------------------------------------------------------------------------//
 //
 /**
+ * \macro TIMEMORY_SET_COMPONENT_APIS
+ * \brief Declare a component is part of one or more APIs
+ */
+
+#if !defined(TIMEMORY_SET_COMPONENT_API)
+#    define TIMEMORY_SET_COMPONENT_API(COMP, ...)                                        \
+        namespace tim                                                                    \
+        {                                                                                \
+        namespace trait                                                                  \
+        {                                                                                \
+        template <>                                                                      \
+        struct component_apis<COMP>                                                      \
+        {                                                                                \
+            using type = type_list<__VA_ARGS__>;                                         \
+        };                                                                               \
+        }                                                                                \
+        }
+#endif
+//
+//--------------------------------------------------------------------------------------//
+//
+/**
+ * \macro TIMEMORY_SET_TEMPLATE_COMPONENT_API
+ * \brief Declare a component is part of one or more APIs
+ */
+
+#if !defined(TIMEMORY_SET_TEMPLATE_COMPONENT_API)
+#    define TIMEMORY_SET_TEMPLATE_COMPONENT_API(TARGS, TSPECIAL, ...)                    \
+        namespace tim                                                                    \
+        {                                                                                \
+        namespace trait                                                                  \
+        {                                                                                \
+        template <TARGS>                                                                 \
+        struct component_apis<TSPECIAL>                                                  \
+        {                                                                                \
+            using type = type_list<__VA_ARGS__>;                                         \
+        };                                                                               \
+        }                                                                                \
+        }
+#endif
+//
+//--------------------------------------------------------------------------------------//
+//
+/**
  * \macro TIMEMORY_BUNDLE_INDEX
  * \brief Declare a bundle index
  */

--- a/source/timemory/components/macros.hpp
+++ b/source/timemory/components/macros.hpp
@@ -388,13 +388,12 @@
 //--------------------------------------------------------------------------------------//
 
 #if !defined(TIMEMORY_STORAGE_INITIALIZER)
-#    define TIMEMORY_STORAGE_INITIALIZER(TYPE, VAR)                                      \
+#    define TIMEMORY_STORAGE_INITIALIZER(TYPE, ...)                                      \
         namespace                                                                        \
         {                                                                                \
-        using namespace tim::component;                                                  \
-        namespace component = tim::component;                                            \
-        tim::storage_initializer _TIM_STORAGE_INIT(VAR) =                                \
-            tim::storage_initializer::get<TYPE>();                                       \
+        using namespace ::tim::component;                                                \
+        namespace component                 = ::tim::component;                          \
+        auto _TIM_STORAGE_INIT(__COUNTER__) = ::tim::storage_initializer::get<TYPE>();   \
         }
 #endif
 
@@ -404,55 +403,72 @@
 #    define TIMEMORY_INITIALIZE_STORAGE(...)                                             \
         namespace                                                                        \
         {                                                                                \
-        using namespace tim::component;                                                  \
-        namespace component              = tim::component;                               \
-        auto _TIM_STORAGE_INIT(__LINE__) = tim::storage_initializer::get<__VA_ARGS__>(); \
+        using namespace ::tim::component;                                                \
+        namespace component = ::tim::component;                                          \
+        auto _TIM_STORAGE_INIT(__COUNTER__) =                                            \
+            ::tim::storage_initializer::get<__VA_ARGS__>();                              \
         }
 #endif
-
+//
+//--------------------------------------------------------------------------------------//
+//
+#if !defined(TIMEMORY_EXTERN_STORAGE_ALIASES)
+#    define TIMEMORY_EXTERN_STORAGE_ALIASES                                              \
+        namespace tim                                                                    \
+        {                                                                                \
+        namespace alias                                                                  \
+        {                                                                                \
+        template <typename T>                                                            \
+        using storage_t = storage<T, typename T::value_type>;                            \
+        template <typename T>                                                            \
+        using storage_impl_t = impl::storage<T, trait::implements_storage<T>::value>;    \
+        template <typename T>                                                            \
+        using storage_deleter_t = impl::storage_deleter<storage_impl_t<T>>;              \
+        template <typename T>                                                            \
+        using storage_pointer_t =                                                        \
+            std::unique_ptr<alias::storage_impl_t<T>, alias::storage_deleter_t<T>>;      \
+        }                                                                                \
+        }
+#endif
+//
 //--------------------------------------------------------------------------------------//
 //
 #if !defined(TIMEMORY_DECLARE_EXTERN_STORAGE)
-#    define TIMEMORY_DECLARE_EXTERN_STORAGE(TYPE, VAR)                                                         \
-        namespace tim                                                                                          \
-        {                                                                                                      \
-        extern template class impl::storage<TYPE,                                                              \
-                                            trait::implements_storage<TYPE>::value>;                           \
-        extern template class storage<TYPE, typename TYPE::value_type>;                                        \
-        extern template class singleton<                                                                       \
-            impl::storage<TYPE, trait::implements_storage<TYPE>::value>,                                       \
-            std::unique_ptr<impl::storage<TYPE, trait::implements_storage<TYPE>::value>,                       \
-                            impl::storage_deleter<impl::storage<                                               \
-                                TYPE, trait::implements_storage<TYPE>::value>>>>;                              \
-        extern template storage_singleton<storage<TYPE, typename TYPE::value_type>>*                           \
-                                            get_storage_singleton<storage<TYPE, typename TYPE::value_type>>(); \
-        extern template storage_initializer storage_initializer::get<TYPE>();                                  \
+#    define TIMEMORY_DECLARE_EXTERN_STORAGE(TYPE, ...)                                       \
+        TIMEMORY_EXTERN_STORAGE_ALIASES                                                      \
+        namespace tim                                                                        \
+        {                                                                                    \
+        extern template class impl::storage<TYPE,                                            \
+                                            trait::implements_storage<TYPE>::value>;         \
+        extern template class storage<TYPE, typename TYPE::value_type>;                      \
+        extern template class singleton<alias::storage_impl_t<TYPE>,                         \
+                                        alias::storage_pointer_t<TYPE>>;                     \
+        extern template storage_singleton<alias::storage_t<TYPE>>*                           \
+                                            get_storage_singleton<alias::storage_t<TYPE>>(); \
+        extern template storage_initializer storage_initializer::get<TYPE>();                \
         }
 #endif
 //
 //--------------------------------------------------------------------------------------//
 //
 #if !defined(TIMEMORY_INSTANTIATE_EXTERN_STORAGE)
-#    define TIMEMORY_INSTANTIATE_EXTERN_STORAGE(TYPE, VAR)                                              \
-        namespace tim                                                                                   \
-        {                                                                                               \
-        template class impl::storage<TYPE, trait::implements_storage<TYPE>::value>;                     \
-        template class storage<TYPE, typename TYPE::value_type>;                                        \
-        template class singleton<                                                                       \
-            impl::storage<TYPE, trait::implements_storage<TYPE>::value>,                                \
-            std::unique_ptr<impl::storage<TYPE, trait::implements_storage<TYPE>::value>,                \
-                            impl::storage_deleter<impl::storage<                                        \
-                                TYPE, trait::implements_storage<TYPE>::value>>>>;                       \
-        template storage_singleton<storage<TYPE, typename TYPE::value_type>>*                           \
-                                     get_storage_singleton<storage<TYPE, typename TYPE::value_type>>(); \
-        template storage_initializer storage_initializer::get<TYPE>();                                  \
-        }                                                                                               \
-        namespace                                                                                       \
-        {                                                                                               \
-        using namespace tim::component;                                                                 \
-        namespace component = tim::component;                                                           \
-        tim::storage_initializer storage_initializer__##VAR =                                           \
-            tim::storage_initializer::get<TYPE>();                                                      \
+#    define TIMEMORY_INSTANTIATE_EXTERN_STORAGE(TYPE, ...)                               \
+        TIMEMORY_EXTERN_STORAGE_ALIASES                                                  \
+        namespace tim                                                                    \
+        {                                                                                \
+        template class impl::storage<TYPE, trait::implements_storage<TYPE>::value>;      \
+        template class storage<TYPE, typename TYPE::value_type>;                         \
+        template class singleton<alias::storage_impl_t<TYPE>,                            \
+                                 alias::storage_pointer_t<TYPE>>;                        \
+        template storage_singleton<alias::storage_t<TYPE>>*                              \
+                                     get_storage_singleton<alias::storage_t<TYPE>>();    \
+        template storage_initializer storage_initializer::get<TYPE>();                   \
+        }                                                                                \
+        namespace                                                                        \
+        {                                                                                \
+        using namespace ::tim::component;                                                \
+        namespace component                 = ::tim::component;                          \
+        auto _TIM_STORAGE_INIT(__COUNTER__) = ::tim::storage_initializer::get<TYPE>();   \
         }
 #endif
 

--- a/source/timemory/components/ompt/tool.hpp
+++ b/source/timemory/components/ompt/tool.hpp
@@ -459,7 +459,7 @@ public:
     context_handler(ompt_target_t kind, ompt_scope_endpoint_t endpoint, int device_num,
                     ompt_data_t* task_data, ompt_id_t target_id, const void* codeptr)
     : m_key(
-          apply<std::string>::join("_", ompt_target_type_labels[kind], "dev", device_num))
+          apply<std::string>::join('_', ompt_target_type_labels[kind], "dev", device_num))
     , m_data(
           { { (endpoint == ompt_scope_begin) ? construct_data() : task_data, nullptr } })
     {
@@ -473,7 +473,7 @@ public:
                     ompt_target_data_op_t optype, void* src_addr, int src_device_num,
                     void* dest_addr, int dest_device_num, size_t bytes,
                     const void* codeptr)
-    : m_key(apply<std::string>::join("_", ompt_target_data_op_labels[optype], "src",
+    : m_key(apply<std::string>::join('_', ompt_target_data_op_labels[optype], "src",
                                      src_device_num, "dest", dest_device_num))
     , m_data({ { construct_data(true), nullptr } })
     {
@@ -496,7 +496,7 @@ public:
     //----------------------------------------------------------------------------------//
     context_handler(ompt_id_t target_id, unsigned int nitems, void** host_addr,
                     void** device_addr, size_t* bytes, unsigned int* mapping_flags)
-    : m_key(apply<std::string>::join("_", "ompt_target_mapping", target_id))
+    : m_key(apply<std::string>::join('_', "ompt_target_mapping", target_id))
     , m_data({ { nullptr, nullptr } })
     {
         consume_parameters(nitems, host_addr, device_addr, bytes, mapping_flags);
@@ -507,7 +507,7 @@ public:
     //----------------------------------------------------------------------------------//
     context_handler(uint64_t device_num, const char* type, ompt_device_t* device,
                     ompt_function_lookup_t lookup, const char* documentation)
-    : m_key(apply<std::string>::join("_", "ompt_device", device_num, type))
+    : m_key(apply<std::string>::join('_', "ompt_device", device_num, type))
     , m_data({ { construct_data(), nullptr } })
     {
         get_data<device_state_tag>().insert({ device_num, m_data[0] });
@@ -533,7 +533,7 @@ public:
     context_handler(uint64_t device_num, const char* filename, int64_t offset_in_file,
                     void* vma_in_file, size_t bytes, void* host_addr, void* device_addr,
                     uint64_t module_id)
-    : m_key(apply<std::string>::join("_", "ompt_target_load", device_num, filename))
+    : m_key(apply<std::string>::join('_', "ompt_target_load", device_num, filename))
     , m_data({ { construct_data(), nullptr } })
     {
         get_data<device_load_tag, uint64_t, data_map_t>()[device_num].insert(

--- a/source/timemory/components/ompt/types.hpp
+++ b/source/timemory/components/ompt/types.hpp
@@ -46,7 +46,14 @@ TIMEMORY_BUNDLE_INDEX(ompt_bundle_idx, 11110)
 //
 TIMEMORY_COMPONENT_ALIAS(user_ompt_bundle, user_bundle<ompt_bundle_idx, api::native_tag>)
 //
-//======================================================================================//
+//--------------------------------------------------------------------------------------//
+//
+//                                  APIs
+//
+//--------------------------------------------------------------------------------------//
+//
+TIMEMORY_SET_COMPONENT_API(component::user_ompt_bundle, tpls::openmp, category::external,
+                           os::agnostic)
 //
 namespace tim
 {
@@ -70,6 +77,10 @@ using ompt_data_tracker_t = data_tracker<int64_t, ompt_target_data_tag>;
 }  // namespace tim
 //
 //--------------------------------------------------------------------------------------//
+//
+#if !defined(TIMEMORY_USE_OMPT)
+TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, tpls::openmp, false_type)
+#endif
 //
 namespace tim
 {

--- a/source/timemory/components/papi/components.hpp
+++ b/source/timemory/components/papi/components.hpp
@@ -165,7 +165,7 @@ public:
                 std::cerr << std::flush;
                 // disable all the papi APIs with concrete instantiations
                 tim::trait::apply<tim::trait::runtime_enabled>::set<
-                    api::papi, papi_array_t, papi_common, papi_vector, papi_array8_t,
+                    tpls::papi, papi_array_t, papi_common, papi_vector, papi_array8_t,
                     papi_array16_t, papi_array32_t>(false);
             }
         }

--- a/source/timemory/components/papi/components.hpp
+++ b/source/timemory/components/papi/components.hpp
@@ -163,6 +163,10 @@ public:
                 for(const auto& itr : get_events<void>())
                     std::cerr << "    " << papi::get_event_info(itr).short_descr << "\n";
                 std::cerr << std::flush;
+                // disable all the papi APIs with concrete instantiations
+                tim::trait::apply<tim::trait::runtime_enabled>::set<
+                    api::papi, papi_array_t, papi_common, papi_vector, papi_array8_t,
+                    papi_array16_t, papi_array32_t>(false);
             }
         }
         return _working;

--- a/source/timemory/components/papi/components.hpp
+++ b/source/timemory/components/papi/components.hpp
@@ -544,7 +544,7 @@ public:
         for(auto& itr : arr)
         {
             size_t n = std::string::npos;
-            while((n = itr.find("/")) != std::string::npos)
+            while((n = itr.find('/')) != std::string::npos)
                 itr.replace(n, 1, "_per_");
         }
 
@@ -865,7 +865,7 @@ public:
         for(auto& itr : arr)
         {
             size_t n = std::string::npos;
-            while((n = itr.find("/")) != std::string::npos)
+            while((n = itr.find('/')) != std::string::npos)
                 itr.replace(n, 1, "_per_");
         }
 

--- a/source/timemory/components/papi/types.hpp
+++ b/source/timemory/components/papi/types.hpp
@@ -39,10 +39,6 @@
 #    define TIMEMORY_PAPI_ARRAY_SIZE 8
 #endif
 
-//======================================================================================//
-//
-TIMEMORY_DECLARE_API(papi)
-TIMEMORY_DEFINE_API(papi)
 //
 TIMEMORY_DECLARE_COMPONENT(papi_vector)
 TIMEMORY_DECLARE_TEMPLATE_COMPONENT(papi_tuple, int... EventTypes)
@@ -54,23 +50,24 @@ TIMEMORY_COMPONENT_ALIAS(papi_array16_t, papi_array<16>)
 TIMEMORY_COMPONENT_ALIAS(papi_array32_t, papi_array<32>)
 TIMEMORY_COMPONENT_ALIAS(papi_array_t, papi_array<TIMEMORY_PAPI_ARRAY_SIZE>)
 //
-TIMEMORY_SET_COMPONENT_API(component::papi_vector, api::papi)
-TIMEMORY_SET_COMPONENT_API(component::papi_array8_t, api::papi)
-TIMEMORY_SET_COMPONENT_API(component::papi_array16_t, api::papi)
-TIMEMORY_SET_COMPONENT_API(component::papi_array32_t, api::papi)
+TIMEMORY_SET_COMPONENT_API(component::papi_vector, tpls::papi, category::external,
+                           category::hardware_counter, os::linux)
 //
-#if(TIMEMORY_PAPI_ARRAY_SIZE != 8 && TIMEMORY_PAPI_ARRAY_SIZE != 16 &&                   \
-    TIMEMORY_PAPI_ARRAY_SIZE != 32)
-TIMEMORY_SET_COMPONENT_API(component::papi_array_t, api::papi)
-#endif
+TIMEMORY_SET_TEMPLATE_COMPONENT_API(TIMEMORY_ESC(size_t MaxNumEvents),
+                                    TIMEMORY_ESC(component::papi_array<MaxNumEvents>),
+                                    tpls::papi, category::external,
+                                    category::hardware_counter, os::linux)
 //
 TIMEMORY_SET_TEMPLATE_COMPONENT_API(TIMEMORY_ESC(int... Evts),
                                     TIMEMORY_ESC(component::papi_tuple<Evts...>),
-                                    api::papi)
+                                    tpls::papi, category::external,
+                                    category::hardware_counter, os::linux)
 //
 TIMEMORY_SET_TEMPLATE_COMPONENT_API(TIMEMORY_ESC(int... Evts),
                                     TIMEMORY_ESC(component::papi_rate_tuple<Evts...>),
-                                    api::papi)
+                                    tpls::papi, category::external,
+                                    category::hardware_counter, category::timing,
+                                    os::linux)
 //
 //======================================================================================//
 //
@@ -108,6 +105,7 @@ struct statistics<component::papi_rate_tuple<Idx...>>
 //--------------------------------------------------------------------------------------//
 //
 #if !defined(TIMEMORY_USE_PAPI)
+TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, tpls::papi, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::papi_vector, false_type)
 TIMEMORY_DEFINE_TEMPLATE_TRAIT(is_available, component::papi_array, false_type, size_t)
 TIMEMORY_DEFINE_VARIADIC_TRAIT(is_available, component::papi_tuple, false_type, int)

--- a/source/timemory/components/papi/types.hpp
+++ b/source/timemory/components/papi/types.hpp
@@ -41,6 +41,9 @@
 
 //======================================================================================//
 //
+TIMEMORY_DECLARE_API(papi)
+TIMEMORY_DEFINE_API(papi)
+//
 TIMEMORY_DECLARE_COMPONENT(papi_vector)
 TIMEMORY_DECLARE_TEMPLATE_COMPONENT(papi_tuple, int... EventTypes)
 TIMEMORY_DECLARE_TEMPLATE_COMPONENT(papi_array, size_t MaxNumEvents)
@@ -50,6 +53,24 @@ TIMEMORY_COMPONENT_ALIAS(papi_array8_t, papi_array<8>)
 TIMEMORY_COMPONENT_ALIAS(papi_array16_t, papi_array<16>)
 TIMEMORY_COMPONENT_ALIAS(papi_array32_t, papi_array<32>)
 TIMEMORY_COMPONENT_ALIAS(papi_array_t, papi_array<TIMEMORY_PAPI_ARRAY_SIZE>)
+//
+TIMEMORY_SET_COMPONENT_API(component::papi_vector, api::papi)
+TIMEMORY_SET_COMPONENT_API(component::papi_array8_t, api::papi)
+TIMEMORY_SET_COMPONENT_API(component::papi_array16_t, api::papi)
+TIMEMORY_SET_COMPONENT_API(component::papi_array32_t, api::papi)
+//
+#if(TIMEMORY_PAPI_ARRAY_SIZE != 8 && TIMEMORY_PAPI_ARRAY_SIZE != 16 &&                   \
+    TIMEMORY_PAPI_ARRAY_SIZE != 32)
+TIMEMORY_SET_COMPONENT_API(component::papi_array_t, api::papi)
+#endif
+//
+TIMEMORY_SET_TEMPLATE_COMPONENT_API(TIMEMORY_ESC(int... Evts),
+                                    TIMEMORY_ESC(component::papi_tuple<Evts...>),
+                                    api::papi)
+//
+TIMEMORY_SET_TEMPLATE_COMPONENT_API(TIMEMORY_ESC(int... Evts),
+                                    TIMEMORY_ESC(component::papi_rate_tuple<Evts...>),
+                                    api::papi)
 //
 //======================================================================================//
 //
@@ -64,6 +85,7 @@ namespace tim
 {
 namespace trait
 {
+//
 template <int... Idx>
 struct statistics<component::papi_tuple<Idx...>>
 {
@@ -75,6 +97,7 @@ struct statistics<component::papi_rate_tuple<Idx...>>
 {
     using type = std::array<double, sizeof...(Idx)>;
 };
+//
 }  // namespace trait
 }  // namespace tim
 //

--- a/source/timemory/components/roofline/cpu_roofline.hpp
+++ b/source/timemory/components/roofline/cpu_roofline.hpp
@@ -331,7 +331,7 @@ struct cpu_roofline
 
     static std::string get_type_string()
     {
-        return apply<std::string>::join("_", demangle(typeid(Types).name())...);
+        return apply<std::string>::join('_', demangle(typeid(Types).name())...);
     }
 
     //----------------------------------------------------------------------------------//

--- a/source/timemory/components/roofline/gpu_roofline.hpp
+++ b/source/timemory/components/roofline/gpu_roofline.hpp
@@ -288,7 +288,7 @@ public:
 
     static std::string get_type_string()
     {
-        return apply<std::string>::join("_", demangle(typeid(Types).name())...);
+        return apply<std::string>::join('_', demangle(typeid(Types).name())...);
     }
 
     //----------------------------------------------------------------------------------//
@@ -1011,7 +1011,7 @@ public:
 
     static std::string get_type_string()
     {
-        return apply<std::string>::join("_", demangle(typeid(cuda::fp16_t).name()));
+        return apply<std::string>::join('_', demangle(typeid(cuda::fp16_t).name()));
     }
 
     //----------------------------------------------------------------------------------//

--- a/source/timemory/components/roofline/types.hpp
+++ b/source/timemory/components/roofline/types.hpp
@@ -53,8 +53,26 @@ TIMEMORY_COMPONENT_ALIAS(gpu_roofline_flops, gpu_roofline<cuda::fp16_t, float, d
 #else
 TIMEMORY_COMPONENT_ALIAS(gpu_roofline_flops, gpu_roofline<float, double>)
 #endif
+
+//--------------------------------------------------------------------------------------//
 //
-//======================================================================================//
+//                                  APIs
+//
+//--------------------------------------------------------------------------------------//
+
+TIMEMORY_SET_TEMPLATE_COMPONENT_API(TIMEMORY_ESC(typename... Types),
+                                    TIMEMORY_ESC(component::cpu_roofline<Types...>),
+                                    tpls::papi, category::external,
+                                    category::hardware_counter, category::timing,
+                                    os::linux)
+
+TIMEMORY_SET_TEMPLATE_COMPONENT_API(TIMEMORY_ESC(typename... Types),
+                                    TIMEMORY_ESC(component::gpu_roofline<Types...>),
+                                    tpls::nvidia, category::external,
+                                    category::hardware_counter, category::timing,
+                                    os::agnostic)
+
+//--------------------------------------------------------------------------------------//
 //
 //                              STATISTICS
 //

--- a/source/timemory/components/rusage/backends.hpp
+++ b/source/timemory/components/rusage/backends.hpp
@@ -32,6 +32,7 @@
 
 #include "timemory/backends/process.hpp"
 #include "timemory/macros/os.hpp"
+#include "timemory/units.hpp"
 #include "timemory/utility/macros.hpp"
 
 #include <cstdint>

--- a/source/timemory/components/rusage/types.hpp
+++ b/source/timemory/components/rusage/types.hpp
@@ -35,8 +35,6 @@
 #include "timemory/mpl/type_traits.hpp"
 #include "timemory/mpl/types.hpp"
 
-//======================================================================================//
-//
 TIMEMORY_DECLARE_COMPONENT(peak_rss)
 TIMEMORY_DECLARE_COMPONENT(page_rss)
 TIMEMORY_DECLARE_COMPONENT(num_io_in)
@@ -58,9 +56,7 @@ TIMEMORY_DECLARE_COMPONENT(data_rss)
 TIMEMORY_DECLARE_COMPONENT(num_msg_sent)
 TIMEMORY_DECLARE_COMPONENT(num_msg_recv)
 TIMEMORY_DECLARE_COMPONENT(num_signals)
-//
-//======================================================================================//
-//
+
 namespace tim
 {
 namespace resource_usage
@@ -71,6 +67,45 @@ using pair_dd_t = std::pair<double, double>;
 }  // namespace alias
 }  // namespace resource_usage
 }  // namespace tim
+
+//--------------------------------------------------------------------------------------//
+//
+//                                  APIs
+//
+//--------------------------------------------------------------------------------------//
+
+TIMEMORY_SET_COMPONENT_API(component::peak_rss, project::timemory, category::memory,
+                           category::resource_usage, os::agnostic)
+
+TIMEMORY_SET_COMPONENT_API(component::current_peak_rss, project::timemory,
+                           category::memory, category::resource_usage, os::agnostic)
+
+TIMEMORY_SET_COMPONENT_API(component::page_rss, project::timemory, category::memory,
+                           category::resource_usage, os::agnostic)
+
+TIMEMORY_SET_COMPONENT_API(component::virtual_memory, project::timemory, category::memory,
+                           category::resource_usage, os::linux)
+
+TIMEMORY_SET_COMPONENT_API(component::num_io_in, project::timemory, category::io,
+                           category::resource_usage, os::unix)
+
+TIMEMORY_SET_COMPONENT_API(component::num_io_out, project::timemory, category::io,
+                           category::resource_usage, os::unix)
+
+TIMEMORY_SET_COMPONENT_API(component::num_minor_page_faults, project::timemory,
+                           category::resource_usage, os::unix)
+
+TIMEMORY_SET_COMPONENT_API(component::voluntary_context_switch, project::timemory,
+                           category::resource_usage, os::unix)
+
+TIMEMORY_SET_COMPONENT_API(component::priority_context_switch, project::timemory,
+                           category::resource_usage, os::unix)
+
+TIMEMORY_SET_COMPONENT_API(component::user_mode_time, project::timemory, category::timing,
+                           os::unix)
+
+TIMEMORY_SET_COMPONENT_API(component::kernel_mode_time, project::timemory,
+                           category::timing, os::unix)
 
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/components/tau_marker/types.hpp
+++ b/source/timemory/components/tau_marker/types.hpp
@@ -22,11 +22,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-/**
- * \file timemory/components/tau_marker/types.hpp
- * \brief Declare the tau_marker component types
- */
-
 #pragma once
 
 #include "timemory/components/macros.hpp"
@@ -34,19 +29,26 @@
 #include "timemory/mpl/type_traits.hpp"
 #include "timemory/mpl/types.hpp"
 
-//======================================================================================//
-//
 /// \struct tau_marker
 /// \brief Forwards timemory labels to the TAU (Tuning and Analysis Utilities)
 TIMEMORY_DECLARE_COMPONENT(tau_marker)
+
+//--------------------------------------------------------------------------------------//
 //
-//======================================================================================//
+//                                  APIs
+//
+//--------------------------------------------------------------------------------------//
+
+TIMEMORY_SET_COMPONENT_API(component::tau_marker, category::external, tpls::tau)
+
+//--------------------------------------------------------------------------------------//
 //
 //                              IS AVAILABLE
 //
 //--------------------------------------------------------------------------------------//
 
 #if !defined(TIMEMORY_USE_TAU)
+TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, tpls::tau, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::tau_marker, false_type)
 #endif
 

--- a/source/timemory/components/timing/types.hpp
+++ b/source/timemory/components/timing/types.hpp
@@ -29,14 +29,11 @@
 
 #pragma once
 
+#include "timemory/api.hpp"
 #include "timemory/components/macros.hpp"
 #include "timemory/enum.h"
 #include "timemory/mpl/type_traits.hpp"
 #include "timemory/mpl/types.hpp"
-
-// timers API
-TIMEMORY_DECLARE_API(timers)
-TIMEMORY_DEFINE_API(timers)
 
 /// \struct wall_clock
 /// \brief the system's real time (i.e. wall time) clock, expressed as the amount of time
@@ -110,17 +107,30 @@ TIMEMORY_DECLARE_COMPONENT(thread_cpu_util)
 //
 //======================================================================================//
 //
-TIMEMORY_SET_COMPONENT_API(component::wall_clock, api::timers, api::native_tag)
-TIMEMORY_SET_COMPONENT_API(component::system_clock, api::timers, api::native_tag)
-TIMEMORY_SET_COMPONENT_API(component::user_clock, api::timers, api::native_tag)
-TIMEMORY_SET_COMPONENT_API(component::cpu_clock, api::timers, api::native_tag)
-TIMEMORY_SET_COMPONENT_API(component::monotonic_clock, api::timers, api::native_tag)
-TIMEMORY_SET_COMPONENT_API(component::monotonic_raw_clock, api::timers, api::native_tag)
-TIMEMORY_SET_COMPONENT_API(component::thread_cpu_clock, api::timers, api::native_tag)
-TIMEMORY_SET_COMPONENT_API(component::process_cpu_clock, api::timers, api::native_tag)
-TIMEMORY_SET_COMPONENT_API(component::cpu_util, api::timers, api::native_tag)
-TIMEMORY_SET_COMPONENT_API(component::process_cpu_util, api::timers, api::native_tag)
-TIMEMORY_SET_COMPONENT_API(component::thread_cpu_util, api::timers, api::native_tag)
+// OS-agnostic
+TIMEMORY_SET_COMPONENT_API(component::wall_clock, project::timemory, category::timing,
+                           os::agnostic)
+TIMEMORY_SET_COMPONENT_API(component::system_clock, project::timemory, category::timing,
+                           os::agnostic)
+TIMEMORY_SET_COMPONENT_API(component::user_clock, project::timemory, category::timing,
+                           os::agnostic)
+TIMEMORY_SET_COMPONENT_API(component::cpu_clock, project::timemory, category::timing,
+                           os::agnostic)
+TIMEMORY_SET_COMPONENT_API(component::cpu_util, project::timemory, category::timing,
+                           os::agnostic)
+// Available on Unix
+TIMEMORY_SET_COMPONENT_API(component::monotonic_clock, project::timemory,
+                           category::timing, os::unix)
+TIMEMORY_SET_COMPONENT_API(component::monotonic_raw_clock, project::timemory,
+                           category::timing, os::unix)
+TIMEMORY_SET_COMPONENT_API(component::thread_cpu_clock, project::timemory,
+                           category::timing, os::unix)
+TIMEMORY_SET_COMPONENT_API(component::process_cpu_clock, project::timemory,
+                           category::timing, os::unix)
+TIMEMORY_SET_COMPONENT_API(component::process_cpu_util, project::timemory,
+                           category::timing, os::unix)
+TIMEMORY_SET_COMPONENT_API(component::thread_cpu_util, project::timemory,
+                           category::timing, os::unix)
 //
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/components/timing/types.hpp
+++ b/source/timemory/components/timing/types.hpp
@@ -34,6 +34,10 @@
 #include "timemory/mpl/type_traits.hpp"
 #include "timemory/mpl/types.hpp"
 
+// timers API
+TIMEMORY_DECLARE_API(timers)
+TIMEMORY_DEFINE_API(timers)
+
 /// \struct wall_clock
 /// \brief the system's real time (i.e. wall time) clock, expressed as the amount of time
 /// since the epoch.
@@ -105,6 +109,20 @@ TIMEMORY_DECLARE_COMPONENT(thread_cpu_util)
 //                              TYPE-TRAITS
 //
 //======================================================================================//
+//
+TIMEMORY_SET_COMPONENT_API(component::wall_clock, api::timers, api::native_tag)
+TIMEMORY_SET_COMPONENT_API(component::system_clock, api::timers, api::native_tag)
+TIMEMORY_SET_COMPONENT_API(component::user_clock, api::timers, api::native_tag)
+TIMEMORY_SET_COMPONENT_API(component::cpu_clock, api::timers, api::native_tag)
+TIMEMORY_SET_COMPONENT_API(component::monotonic_clock, api::timers, api::native_tag)
+TIMEMORY_SET_COMPONENT_API(component::monotonic_raw_clock, api::timers, api::native_tag)
+TIMEMORY_SET_COMPONENT_API(component::thread_cpu_clock, api::timers, api::native_tag)
+TIMEMORY_SET_COMPONENT_API(component::process_cpu_clock, api::timers, api::native_tag)
+TIMEMORY_SET_COMPONENT_API(component::cpu_util, api::timers, api::native_tag)
+TIMEMORY_SET_COMPONENT_API(component::process_cpu_util, api::timers, api::native_tag)
+TIMEMORY_SET_COMPONENT_API(component::thread_cpu_util, api::timers, api::native_tag)
+//
+//--------------------------------------------------------------------------------------//
 //
 //                              STATISTICS
 //

--- a/source/timemory/components/trip_count/types.hpp
+++ b/source/timemory/components/trip_count/types.hpp
@@ -43,6 +43,8 @@
 /// trip-counts.
 TIMEMORY_DECLARE_COMPONENT(trip_count)
 //
+TIMEMORY_SET_COMPONENT_API(component::trip_count, project::timemory, os::agnostic)
+//
 TIMEMORY_DEFINE_CONCRETE_TRAIT(custom_laps_printing, component::trip_count, true_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(report_mean, component::trip_count, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(report_self, component::trip_count, false_type)

--- a/source/timemory/components/user_bundle/components.hpp
+++ b/source/timemory/components/user_bundle/components.hpp
@@ -168,7 +168,9 @@ namespace component
 //--------------------------------------------------------------------------------------//
 //
 template <size_t Idx, typename Tag>
-struct user_bundle : public base<user_bundle<Idx, Tag>, void>
+struct user_bundle
+: public base<user_bundle<Idx, Tag>, void>
+, concepts::runtime_configurable
 {
 public:
     static constexpr auto index = Idx;

--- a/source/timemory/components/user_bundle/types.hpp
+++ b/source/timemory/components/user_bundle/types.hpp
@@ -49,41 +49,31 @@
 TIMEMORY_DECLARE_TEMPLATE_COMPONENT(user_bundle, size_t Idx, typename Tag)
 //
 TIMEMORY_BUNDLE_INDEX(global_bundle_idx, 10000)
-//
 TIMEMORY_BUNDLE_INDEX(tuple_bundle_idx, 11000)
-//
 TIMEMORY_BUNDLE_INDEX(list_bundle_idx, 11100)
-//
 // TIMEMORY_BUNDLE_INDEX(ompt_bundle_idx, 11110)
-//
 TIMEMORY_BUNDLE_INDEX(mpip_bundle_idx, 11111)
-//
 TIMEMORY_BUNDLE_INDEX(ncclp_bundle_idx, 11112)
-//
 TIMEMORY_BUNDLE_INDEX(trace_bundle_idx, 20000)
-//
 TIMEMORY_BUNDLE_INDEX(profiler_bundle_idx, 22000)
 //
 TIMEMORY_COMPONENT_ALIAS(user_global_bundle,
-                         user_bundle<global_bundle_idx, api::native_tag>)
-//
+                         user_bundle<global_bundle_idx, project::timemory>)
 TIMEMORY_COMPONENT_ALIAS(user_tuple_bundle,
-                         user_bundle<tuple_bundle_idx, api::native_tag>)
-//
-TIMEMORY_COMPONENT_ALIAS(user_list_bundle, user_bundle<list_bundle_idx, api::native_tag>)
-//
-TIMEMORY_COMPONENT_ALIAS(user_ompt_bundle, user_bundle<ompt_bundle_idx, api::native_tag>)
-//
-TIMEMORY_COMPONENT_ALIAS(user_mpip_bundle, user_bundle<mpip_bundle_idx, api::native_tag>)
-//
+                         user_bundle<tuple_bundle_idx, project::timemory>)
+TIMEMORY_COMPONENT_ALIAS(user_list_bundle,
+                         user_bundle<list_bundle_idx, project::timemory>)
+TIMEMORY_COMPONENT_ALIAS(user_ompt_bundle,
+                         user_bundle<ompt_bundle_idx, project::timemory>)
+TIMEMORY_COMPONENT_ALIAS(user_mpip_bundle,
+                         user_bundle<mpip_bundle_idx, project::timemory>)
 TIMEMORY_COMPONENT_ALIAS(user_ncclp_bundle,
-                         user_bundle<ncclp_bundle_idx, api::native_tag>)
-//
+                         user_bundle<ncclp_bundle_idx, project::timemory>)
 TIMEMORY_COMPONENT_ALIAS(user_trace_bundle,
-                         user_bundle<trace_bundle_idx, api::native_tag>)
+                         user_bundle<trace_bundle_idx, project::timemory>)
 //
 TIMEMORY_COMPONENT_ALIAS(user_profiler_bundle,
-                         user_bundle<profiler_bundle_idx, api::native_tag>)
+                         user_bundle<profiler_bundle_idx, project::timemory>)
 //
 #if !defined(TIMEMORY_USE_OMPT)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::user_ompt_bundle, false_type)
@@ -103,7 +93,16 @@ TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::user_ncclp_bundle, false
 //                              REQUIRES PREFIX
 //
 //--------------------------------------------------------------------------------------//
-
+//
+TIMEMORY_SET_COMPONENT_API(component::user_global_bundle, project::timemory, os::agnostic)
+TIMEMORY_SET_COMPONENT_API(component::user_list_bundle, project::timemory, os::agnostic)
+TIMEMORY_SET_COMPONENT_API(component::user_tuple_bundle, project::timemory, os::agnostic)
+TIMEMORY_SET_COMPONENT_API(component::user_mpip_bundle, project::timemory, os::linux)
+TIMEMORY_SET_COMPONENT_API(component::user_ncclp_bundle, project::timemory, os::linux)
+TIMEMORY_SET_COMPONENT_API(component::user_trace_bundle, project::timemory, os::agnostic)
+TIMEMORY_SET_COMPONENT_API(component::user_profiler_bundle, project::timemory,
+                           os::agnostic)
+//
 namespace tim
 {
 namespace trait

--- a/source/timemory/components/vtune/types.hpp
+++ b/source/timemory/components/vtune/types.hpp
@@ -22,11 +22,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-/**
- * \file timemory/components/vtune/types.hpp
- * \brief Declare the vtune component types
- */
-
 #pragma once
 
 #include "timemory/components/macros.hpp"
@@ -34,19 +29,32 @@
 #include "timemory/mpl/type_traits.hpp"
 #include "timemory/mpl/types.hpp"
 
-//======================================================================================//
-//
 TIMEMORY_DECLARE_COMPONENT(vtune_event)
 TIMEMORY_DECLARE_COMPONENT(vtune_frame)
 TIMEMORY_DECLARE_COMPONENT(vtune_profiler)
+
+//--------------------------------------------------------------------------------------//
 //
-//======================================================================================//
+//                                  APIs
+//
+//--------------------------------------------------------------------------------------//
+
+TIMEMORY_SET_COMPONENT_API(component::vtune_event, category::logger, category::external,
+                           tpls::intel)
+
+TIMEMORY_SET_COMPONENT_API(component::vtune_frame, category::decorator,
+                           category::external, tpls::intel)
+
+TIMEMORY_SET_COMPONENT_API(component::vtune_profiler, category::external, tpls::intel)
+
+//--------------------------------------------------------------------------------------//
 //
 //                              IS AVAILABLE
 //
 //--------------------------------------------------------------------------------------//
 
 #if !defined(TIMEMORY_USE_VTUNE)
+TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, tpls::intel, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::vtune_event, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::vtune_frame, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::vtune_profiler, false_type)

--- a/source/timemory/config/definition.hpp
+++ b/source/timemory/config/definition.hpp
@@ -62,6 +62,34 @@ timemory_init(int argc, char** argv, const std::string& _prefix,
     {
         if(_settings->get_debug() || _settings->get_verbose() > 3)
             PRINT_HERE("%s", "");
+
+        auto _ncfg = _settings->get_suppress_config();
+        if(!_ncfg)
+        {
+            // default configuration files
+            std::set<std::string> _dcfg = {
+                get_env<string_t>("HOME") + std::string("/.timemory.cfg"),
+                get_env<string_t>("HOME") + std::string("/.timemory.json"),
+                get_env<string_t>("HOME") + std::string("/.config/timemory.cfg"),
+                get_env<string_t>("HOME") + std::string("/.config/timemory.json")
+            };
+
+            auto _cfg = _settings->get_config_file();
+            for(auto&& citr : tim::delimit(_cfg, ",;"))
+            {
+                try
+                {
+                    _settings->read(citr);
+                } catch(std::runtime_error& e)
+                {
+                    if(_dcfg.find(citr) == _dcfg.end())
+                    {
+                        std::cerr << e.what() << std::endl;
+                        throw;
+                    }
+                }
+            }
+        }
     }
 
     std::string exe_name = (argc > 0) ? argv[0] : "";

--- a/source/timemory/ert/cache_size.hpp
+++ b/source/timemory/ert/cache_size.hpp
@@ -134,7 +134,7 @@ cache_size(const int& _level)
     auto level = (_level == 1) ? 0 : (_level);
     // location of files
     std::stringstream fpath;
-    fpath << "/sys/devices/system/cpu/cpu0/cache/index" << level << "/";
+    fpath << "/sys/devices/system/cpu/cpu0/cache/index" << level << '/';
 
     // files to read
     const std::array<std::string, 3> files(

--- a/source/timemory/general/source_location.hpp
+++ b/source/timemory/general/source_location.hpp
@@ -115,7 +115,7 @@ public:
                         m_result = result_type(obj.m_prefix, add_hash_id(obj.m_prefix));
                     else
                     {
-                        auto _tmp = join_type::join("/", obj.m_prefix.c_str(), _suffix);
+                        auto _tmp = join_type::join('/', obj.m_prefix.c_str(), _suffix);
                         m_result  = result_type(_tmp, add_hash_id(_tmp));
                     }
                     break;
@@ -280,16 +280,16 @@ protected:
         if(_line < 0)
         {
             if(_filename.length() > 0)
-                m_prefix = join_type::join("", _func, "@", _filename);
+                m_prefix = join_type::join("", _func, '@', _filename);
             else
                 m_prefix = _func;
         }
         else
         {
             if(_filename.length() > 0)
-                m_prefix = join_type::join("", _func, "@", _filename, ":", _line);
+                m_prefix = join_type::join("", _func, '@', _filename, ':', _line);
             else
-                m_prefix = join_type::join("", _func, ":", _line);
+                m_prefix = join_type::join("", _func, ':', _line);
         }
     }
 
@@ -322,7 +322,7 @@ private:
     std::string _join(const char* _arg)
     {
         return (strcmp(_arg, "") == 0) ? m_prefix
-                                       : join_type::join("/", m_prefix.c_str(), _arg);
+                                       : join_type::join('/', m_prefix.c_str(), _arg);
     }
 };
 

--- a/source/timemory/mpl/apply.hpp
+++ b/source/timemory/mpl/apply.hpp
@@ -415,7 +415,7 @@ struct apply<std::string>
     template <typename SepT, typename Arg, if_string_t<Arg, true> = 0>
     static Ret join(SepT&&, Arg&& _arg) noexcept
     {
-        return std::move(_arg);
+        return std::forward<Arg>(_arg);
     }
 
     //----------------------------------------------------------------------------------//
@@ -430,7 +430,8 @@ struct apply<std::string>
 
     //----------------------------------------------------------------------------------//
 
-    static Ret join(const string_t&) noexcept { return Ret{ "" }; }
+    static Ret join(const string_t&) noexcept { return Ret{}; }
+    static Ret join(const char) noexcept { return Ret{}; }
 
     //----------------------------------------------------------------------------------//
 };

--- a/source/timemory/mpl/available.hpp
+++ b/source/timemory/mpl/available.hpp
@@ -105,7 +105,7 @@ template <template <typename> class Predicate, typename... Ts>
 struct filter_if_false<Predicate, std::tuple<Ts...>>
 {
     using type = tuple_concat_t<
-        typename filter_if_false_result<Predicate<Ts>::value, Ts>::type...>;
+        conditional_t<Predicate<Ts>::value, std::tuple<Ts>, std::tuple<>>...>;
 };
 
 //--------------------------------------------------------------------------------------//
@@ -113,10 +113,9 @@ struct filter_if_false<Predicate, std::tuple<Ts...>>
 template <template <typename> class Predicate, typename... Ts>
 struct filter_if_false<Predicate, type_list<Ts...>>
 {
-    using type =
-        convert_t<tuple_concat_t<
-                      typename filter_if_false_result<Predicate<Ts>::value, Ts>::type...>,
-                  type_list<>>;
+    using type = convert_t<tuple_concat_t<conditional_t<Predicate<Ts>::value,
+                                                        std::tuple<Ts>, std::tuple<>>...>,
+                           type_list<>>;
 };
 
 //--------------------------------------------------------------------------------------//
@@ -124,10 +123,9 @@ struct filter_if_false<Predicate, type_list<Ts...>>
 template <template <typename> class Predicate, typename... Ts>
 struct filter_if_false<Predicate, component_list<Ts...>>
 {
-    using type =
-        convert_t<tuple_concat_t<
-                      typename filter_if_false_result<Predicate<Ts>::value, Ts>::type...>,
-                  component_list<>>;
+    using type = convert_t<tuple_concat_t<conditional_t<Predicate<Ts>::value,
+                                                        std::tuple<Ts>, std::tuple<>>...>,
+                           component_list<>>;
 };
 
 //--------------------------------------------------------------------------------------//
@@ -135,10 +133,9 @@ struct filter_if_false<Predicate, component_list<Ts...>>
 template <template <typename> class Predicate, typename... Ts>
 struct filter_if_false<Predicate, component_tuple<Ts...>>
 {
-    using type =
-        convert_t<tuple_concat_t<
-                      typename filter_if_false_result<Predicate<Ts>::value, Ts>::type...>,
-                  component_tuple<>>;
+    using type = convert_t<tuple_concat_t<conditional_t<Predicate<Ts>::value,
+                                                        std::tuple<Ts>, std::tuple<>>...>,
+                           component_tuple<>>;
 };
 
 //--------------------------------------------------------------------------------------//
@@ -146,10 +143,9 @@ struct filter_if_false<Predicate, component_tuple<Ts...>>
 template <template <typename> class Predicate, typename... Ts>
 struct filter_if_false<Predicate, auto_list<Ts...>>
 {
-    using type =
-        convert_t<tuple_concat_t<
-                      typename filter_if_false_result<Predicate<Ts>::value, Ts>::type...>,
-                  auto_list<>>;
+    using type = convert_t<tuple_concat_t<conditional_t<Predicate<Ts>::value,
+                                                        std::tuple<Ts>, std::tuple<>>...>,
+                           auto_list<>>;
 };
 
 //--------------------------------------------------------------------------------------//
@@ -157,10 +153,9 @@ struct filter_if_false<Predicate, auto_list<Ts...>>
 template <template <typename> class Predicate, typename... Ts>
 struct filter_if_false<Predicate, auto_tuple<Ts...>>
 {
-    using type =
-        convert_t<tuple_concat_t<
-                      typename filter_if_false_result<Predicate<Ts>::value, Ts>::type...>,
-                  auto_tuple<>>;
+    using type = convert_t<tuple_concat_t<conditional_t<Predicate<Ts>::value,
+                                                        std::tuple<Ts>, std::tuple<>>...>,
+                           auto_tuple<>>;
 };
 
 //--------------------------------------------------------------------------------------//
@@ -184,8 +179,9 @@ struct filter_if_false_after_decay;
 template <template <typename> class Predicate, typename... Ts>
 struct filter_if_false_after_decay<Predicate, std::tuple<Ts...>>
 {
-    using type = tuple_concat_t<typename filter_if_false_result<
-        Predicate<decay_t<remove_pointer_t<Ts>>>::value, Ts>::type...>;
+    using type =
+        tuple_concat_t<conditional_t<Predicate<decay_t<remove_pointer_t<Ts>>>::value,
+                                     std::tuple<Ts>, std::tuple<>>...>;
 };
 
 //--------------------------------------------------------------------------------------//
@@ -193,10 +189,10 @@ struct filter_if_false_after_decay<Predicate, std::tuple<Ts...>>
 template <template <typename> class Predicate, typename... Ts>
 struct filter_if_false_after_decay<Predicate, type_list<Ts...>>
 {
-    using type =
-        convert_t<tuple_concat_t<typename filter_if_false_result<
-                      Predicate<decay_t<remove_pointer_t<Ts>>>::value, Ts>::type...>,
-                  std::tuple<>>;
+    using type = convert_t<
+        tuple_concat_t<conditional_t<Predicate<decay_t<remove_pointer_t<Ts>>>::value,
+                                     std::tuple<Ts>, std::tuple<>>...>,
+        type_list<>>;
 };
 
 //--------------------------------------------------------------------------------------//
@@ -214,8 +210,8 @@ using filter_false_after_decay_t =
 template <template <typename> class Predicate, typename... Ts>
 struct filter_if_true
 {
-    using type =
-        tuple_concat_t<typename filter_if_true_result<Predicate<Ts>::value, Ts>::type...>;
+    using type = tuple_concat_t<
+        conditional_t<Predicate<Ts>::value, std::tuple<>, std::tuple<Ts>>...>;
 };
 
 //--------------------------------------------------------------------------------------//
@@ -223,8 +219,8 @@ struct filter_if_true
 template <template <typename> class Predicate, typename... Ts>
 struct filter_if_true<Predicate, std::tuple<Ts...>>
 {
-    using type =
-        tuple_concat_t<typename filter_if_true_result<Predicate<Ts>::value, Ts>::type...>;
+    using type = tuple_concat_t<
+        conditional_t<Predicate<Ts>::value, std::tuple<>, std::tuple<Ts>>...>;
 };
 
 //--------------------------------------------------------------------------------------//
@@ -232,8 +228,9 @@ struct filter_if_true<Predicate, std::tuple<Ts...>>
 template <template <typename> class Predicate, typename... Ts>
 struct filter_if_true<Predicate, type_list<Ts...>>
 {
-    using type =
-        tuple_concat_t<typename filter_if_true_result<Predicate<Ts>::value, Ts>::type...>;
+    using type = convert_t<tuple_concat_t<conditional_t<Predicate<Ts>::value,
+                                                        std::tuple<>, std::tuple<Ts>>...>,
+                           type_list<>>;
 };
 
 //--------------------------------------------------------------------------------------//
@@ -246,6 +243,12 @@ using filter_true = typename filter_if_true<Predicate, Sequence>::type;
 }  // namespace impl
 
 //======================================================================================//
+
+template <template <typename> class Predicate, typename Sequence>
+using filter_true_t = impl::filter_true<Predicate, Sequence>;
+
+template <template <typename> class Predicate, typename Sequence>
+using filter_false_t = impl::filter_false<Predicate, Sequence>;
 
 ///
 ///  generic alias for extracting all types with a specified trait enabled
@@ -265,8 +268,12 @@ struct get_true_types<Predicate, std::tuple<Sequence...>>
 template <template <typename> class Predicate, typename... Sequence>
 struct get_true_types<Predicate, type_list<Sequence...>>
 {
-    using type = impl::filter_false<Predicate, std::tuple<Sequence...>>;
+    using type =
+        convert_t<impl::filter_false<Predicate, std::tuple<Sequence...>>, type_list<>>;
 };
+
+template <template <typename> class Predicate, typename... Sequence>
+using get_true_types_t = typename get_true_types<Predicate, Sequence...>::type;
 
 ///
 ///  generic alias for extracting all types with a specified trait disabled
@@ -286,8 +293,12 @@ struct get_false_types<Predicate, std::tuple<Sequence...>>
 template <template <typename> class Predicate, typename... Sequence>
 struct get_false_types<Predicate, type_list<Sequence...>>
 {
-    using type = impl::filter_true<Predicate, std::tuple<Sequence...>>;
+    using type =
+        convert_t<impl::filter_true<Predicate, std::tuple<Sequence...>>, type_list<>>;
 };
+
+template <template <typename> class Predicate, typename... Sequence>
+using get_false_types_t = typename get_false_types<Predicate, Sequence...>::type;
 
 //======================================================================================//
 //

--- a/source/timemory/mpl/concepts.hpp
+++ b/source/timemory/mpl/concepts.hpp
@@ -54,7 +54,7 @@
         static constexpr bool value =                                                    \
             is_##CONCEPT::template have<typename std::remove_cv<Tp>::type>::value;       \
     };
-// constexpr operator bool() const noexcept { return value; }                       \
+// constexpr operator bool() const noexcept { return value; }
 
 //--------------------------------------------------------------------------------------//
 

--- a/source/timemory/mpl/concepts.hpp
+++ b/source/timemory/mpl/concepts.hpp
@@ -29,23 +29,78 @@
 
 //--------------------------------------------------------------------------------------//
 
+#define TIMEMORY_IMPL_IS_CONCEPT(CONCEPT)                                                \
+    struct CONCEPT                                                                       \
+    {};                                                                                  \
+    template <typename Tp>                                                               \
+    struct is_##CONCEPT                                                                  \
+    {                                                                                    \
+    private:                                                                             \
+        template <typename, typename = std::true_type>                                   \
+        struct have : std::false_type                                                    \
+        {};                                                                              \
+        template <typename U>                                                            \
+        struct have<U, typename std::is_base_of<typename U::CONCEPT, U>::type>           \
+        : std::true_type                                                                 \
+        {};                                                                              \
+        template <typename U>                                                            \
+        struct have<U, typename std::is_base_of<typename U::CONCEPT##_type, U>::type>    \
+        : std::true_type                                                                 \
+        {};                                                                              \
+                                                                                         \
+    public:                                                                              \
+        using type = typename is_##CONCEPT::template have<                               \
+            typename std::remove_cv<Tp>::type>::type;                                    \
+        static constexpr bool value =                                                    \
+            is_##CONCEPT::template have<typename std::remove_cv<Tp>::type>::value;       \
+    };
+// constexpr operator bool() const noexcept { return value; }                       \
+
+//--------------------------------------------------------------------------------------//
+
 namespace tim
 {
 //
+using true_type  = std::true_type;
+using false_type = std::false_type;
+//
 struct null_type;
+//
+namespace trait
+{
+template <typename Tp>
+struct is_available;
+}
+//
+namespace
+{
+template <typename Tp>
+struct anonymous
+{
+    using type = Tp;
+};
+//
+template <typename Tp>
+using anonymous_t = typename anonymous<Tp>::type;
+}  // namespace
+//
+namespace component
+{
+template <size_t Idx, typename Tag>
+struct user_bundle;
+//
+template <size_t Nt, typename ComponentsT, typename DifferentiatorT = anonymous_t<void>>
+struct gotcha;
+}  // namespace component
 //
 namespace concepts
 {
-using false_type = std::false_type;
-using true_type  = std::true_type;
-
+//
 //----------------------------------------------------------------------------------//
 /// \struct tim::concepts::is_empty
 /// \brief concept that specifies that a variadic type is empty
 ///
-template <typename T>
-struct is_empty : false_type
-{};
+TIMEMORY_IMPL_IS_CONCEPT(empty)
 
 template <template <typename...> class Tuple>
 struct is_empty<Tuple<>> : true_type
@@ -55,9 +110,7 @@ struct is_empty<Tuple<>> : true_type
 /// \struct tim::concepts::is_null_type
 /// \brief concept that specifies that a type is not a useful type
 ///
-template <typename T>
-struct is_null_type : false_type
-{};
+TIMEMORY_IMPL_IS_CONCEPT(null_type)
 
 template <template <typename...> class Tuple>
 struct is_null_type<Tuple<>> : true_type
@@ -72,69 +125,89 @@ struct is_null_type<false_type> : true_type
 {};
 
 template <>
-struct is_null_type<null_type> : true_type
+struct is_null_type<::tim::null_type> : true_type
 {};
+
+//----------------------------------------------------------------------------------//
+/// \struct tim::concepts::is_api
+/// \brief concept that specifies that a type is an API. APIs are used to designate
+/// different project implementations, different external library tools, etc.
+///
+TIMEMORY_IMPL_IS_CONCEPT(api)
 
 //----------------------------------------------------------------------------------//
 /// \struct tim::concepts::is_variadic
 /// \brief concept that specifies that a type is a generic variadic wrapper
 ///
-template <typename T>
-struct is_variadic : false_type
-{};
+TIMEMORY_IMPL_IS_CONCEPT(variadic)
 
 //----------------------------------------------------------------------------------//
 /// \struct tim::concepts::is_wrapper
 /// \brief concept that specifies that a type is a timemory variadic wrapper
 ///
-template <typename T>
-struct is_wrapper : false_type
-{};
+TIMEMORY_IMPL_IS_CONCEPT(wrapper)
 
 //----------------------------------------------------------------------------------//
 /// \struct tim::concepts::is_stack_wrapper
 /// \brief concept that specifies that a type is a timemory variadic wrapper
 /// and components are stack-allocated
 ///
-template <typename T>
-struct is_stack_wrapper : false_type
-{};
+TIMEMORY_IMPL_IS_CONCEPT(stack_wrapper)
 
 //----------------------------------------------------------------------------------//
 /// \struct tim::concepts::is_heap_wrapper
 /// \brief concept that specifies that a type is a timemory variadic wrapper
 /// and components are heap-allocated
 ///
-template <typename T>
-struct is_heap_wrapper : false_type
-{};
+TIMEMORY_IMPL_IS_CONCEPT(heap_wrapper)
 
 //----------------------------------------------------------------------------------//
 /// \struct tim::concepts::is_hybrid_wrapper
 /// \brief concept that specifies that a type is a timemory variadic wrapper
 /// and components are stack- and heap- allocated
 ///
-template <typename T>
-struct is_hybrid_wrapper : false_type
-{};
+TIMEMORY_IMPL_IS_CONCEPT(hybrid_wrapper)
+
+//----------------------------------------------------------------------------------//
+/// \struct tim::concepts::is_mixed_wrapper
+/// \brief concept that specifies that a type is a timemory variadic wrapper
+/// and variadic types are mix of stack- and heap- allocated
+///
+TIMEMORY_IMPL_IS_CONCEPT(mixed_wrapper)
+
+//----------------------------------------------------------------------------------//
+/// \struct tim::concepts::is_tagged
+/// \brief concept that specifies that a type's template parameters include
+/// a API specific tag as one of the template parameters (usually first)
+///
+TIMEMORY_IMPL_IS_CONCEPT(tagged)
 
 //----------------------------------------------------------------------------------//
 /// \struct tim::concepts::is_comp_wrapper
 /// \brief concept that specifies that a type is a timemory variadic wrapper
 /// that does not perform auto start/stop, e.g. component_{tuple,list,hybrid}
 ///
-template <typename T>
-struct is_comp_wrapper : false_type
-{};
+TIMEMORY_IMPL_IS_CONCEPT(comp_wrapper)
 
 //----------------------------------------------------------------------------------//
 /// \struct tim::concepts::is_auto_wrapper
 /// \brief concept that specifies that a type is a timemory variadic wrapper
 /// that performs auto start/stop, e.g. auto_{tuple,list,hybrid}
 ///
-template <typename T>
-struct is_auto_wrapper : false_type
-{};
+TIMEMORY_IMPL_IS_CONCEPT(auto_wrapper)
+
+//----------------------------------------------------------------------------------//
+/// \struct tim::concepts::is_runtime_configurable
+/// \brief concept that specifies that a component type supports configurating the
+/// set of components that it collects at runtime (e.g. user_bundle)
+///
+TIMEMORY_IMPL_IS_CONCEPT(runtime_configurable)
+
+//----------------------------------------------------------------------------------//
+/// \struct tim::concepts::is_external_function_wrapper
+/// \brief concept that specifies that a component type wraps external functions
+///
+TIMEMORY_IMPL_IS_CONCEPT(external_function_wrapper)
 
 //----------------------------------------------------------------------------------//
 /// \struct tim::concepts::has_gotcha
@@ -327,52 +400,52 @@ TIMEMORY_CONCEPT_ALIAS(component_type_t, component_type)
 
 //--------------------------------------------------------------------------------------//
 
-#define TIMEMORY_DEFINE_CONCRETE_CONCEPT(CONCEPT, COMPONENT, VALUE)                      \
+#define TIMEMORY_DEFINE_CONCRETE_CONCEPT(CONCEPT, SPECIALIZED_TYPE, VALUE)               \
     namespace tim                                                                        \
     {                                                                                    \
     namespace concepts                                                                   \
     {                                                                                    \
     template <>                                                                          \
-    struct CONCEPT<COMPONENT> : VALUE                                                    \
+    struct CONCEPT<SPECIALIZED_TYPE> : VALUE                                             \
     {};                                                                                  \
     }                                                                                    \
     }
 
 //--------------------------------------------------------------------------------------//
 
-#define TIMEMORY_DEFINE_TEMPLATE_CONCEPT(CONCEPT, COMPONENT, VALUE, TYPE)                \
+#define TIMEMORY_DEFINE_TEMPLATE_CONCEPT(CONCEPT, SPECIALIZED_TYPE, VALUE, TYPE)         \
     namespace tim                                                                        \
     {                                                                                    \
     namespace concepts                                                                   \
     {                                                                                    \
     template <TYPE T>                                                                    \
-    struct CONCEPT<COMPONENT<T>> : VALUE                                                 \
+    struct CONCEPT<SPECIALIZED_TYPE<T>> : VALUE                                          \
     {};                                                                                  \
     }                                                                                    \
     }
 
 //--------------------------------------------------------------------------------------//
 
-#define TIMEMORY_DEFINE_VARIADIC_CONCEPT(CONCEPT, COMPONENT, VALUE, TYPE)                \
+#define TIMEMORY_DEFINE_VARIADIC_CONCEPT(CONCEPT, SPECIALIZED_TYPE, VALUE, TYPE)         \
     namespace tim                                                                        \
     {                                                                                    \
     namespace concepts                                                                   \
     {                                                                                    \
     template <TYPE... T>                                                                 \
-    struct CONCEPT<COMPONENT<T...>> : VALUE                                              \
+    struct CONCEPT<SPECIALIZED_TYPE<T...>> : VALUE                                       \
     {};                                                                                  \
     }                                                                                    \
     }
 
 //--------------------------------------------------------------------------------------//
 
-#define TIMEMORY_DEFINE_CONCRETE_CONCEPT_TYPE(CONCEPT, COMPONENT, ...)                   \
+#define TIMEMORY_DEFINE_CONCRETE_CONCEPT_TYPE(CONCEPT, SPECIALIZED_TYPE, ...)            \
     namespace tim                                                                        \
     {                                                                                    \
     namespace concepts                                                                   \
     {                                                                                    \
     template <>                                                                          \
-    struct CONCEPT<COMPONENT>                                                            \
+    struct CONCEPT<SPECIALIZED_TYPE>                                                     \
     {                                                                                    \
         using type = __VA_ARGS__;                                                        \
     };                                                                                   \
@@ -381,13 +454,13 @@ TIMEMORY_CONCEPT_ALIAS(component_type_t, component_type)
 
 //--------------------------------------------------------------------------------------//
 
-#define TIMEMORY_DEFINE_TEMPLATE_CONCEPT_TYPE(CONCEPT, COMPONENT, TYPE, ...)             \
+#define TIMEMORY_DEFINE_TEMPLATE_CONCEPT_TYPE(CONCEPT, SPECIALIZED_TYPE, TYPE, ...)      \
     namespace tim                                                                        \
     {                                                                                    \
     namespace concepts                                                                   \
     {                                                                                    \
     template <TYPE T>                                                                    \
-    struct CONCEPT<COMPONENT<T>>                                                         \
+    struct CONCEPT<SPECIALIZED_TYPE<T>>                                                  \
     {                                                                                    \
         using type = __VA_ARGS__;                                                        \
     };                                                                                   \
@@ -396,13 +469,13 @@ TIMEMORY_CONCEPT_ALIAS(component_type_t, component_type)
 
 //--------------------------------------------------------------------------------------//
 
-#define TIMEMORY_DEFINE_VARIADIC_CONCEPT_TYPE(CONCEPT, COMPONENT, TYPE, ...)             \
+#define TIMEMORY_DEFINE_VARIADIC_CONCEPT_TYPE(CONCEPT, SPECIALIZED_TYPE, TYPE, ...)      \
     namespace tim                                                                        \
     {                                                                                    \
     namespace concepts                                                                   \
     {                                                                                    \
     template <TYPE... T>                                                                 \
-    struct CONCEPT<COMPONENT<T...>>                                                      \
+    struct CONCEPT<SPECIALIZED_TYPE<T...>>                                               \
     {                                                                                    \
         using type = __VA_ARGS__;                                                        \
     };                                                                                   \

--- a/source/timemory/mpl/filters.hpp
+++ b/source/timemory/mpl/filters.hpp
@@ -392,13 +392,13 @@ using unique_t = convert_t<typename impl::unique<T, type_list<>>::type, TupleT>;
 
 /// filter out any types that are not available
 template <typename... Types>
-using filter_gotchas = impl::filter_false<trait::is_gotcha, std::tuple<Types...>>;
+using filter_gotchas = get_false_types_t<trait::is_gotcha, std::tuple<Types...>>;
 
 template <typename T>
-using filter_gotchas_t = impl::filter_false<trait::is_gotcha, T>;
+using filter_gotchas_t = get_false_types_t<trait::is_gotcha, T>;
 
 template <typename T>
-using filter_empty_t = impl::filter_true<concepts::is_empty, T>;
+using filter_empty_t = get_true_types_t<concepts::is_empty, T>;
 
 //======================================================================================//
 //
@@ -436,6 +436,14 @@ using sort = convert_t<typename impl::sortT<PrioT, convert_t<Tuple, type_list<>>
                                             convert_t<BegT, type_list<>>,
                                             convert_t<EndT, type_list<>>>::type,
                        std::tuple<>>;
+
+template <typename... Types>
+using runtime_configurable_t =
+    typename get_true_types<concepts::is_runtime_configurable, Types...>::type;
+
+template <typename... Types>
+using external_function_wrappers_t =
+    typename get_true_types<concepts::is_external_function_wrapper, Types...>::type;
 
 }  // namespace mpl
 

--- a/source/timemory/mpl/type_traits.hpp
+++ b/source/timemory/mpl/type_traits.hpp
@@ -33,6 +33,7 @@
 #pragma once
 
 #include "timemory/api.hpp"
+#include "timemory/mpl/available.hpp"
 #include "timemory/mpl/types.hpp"
 #include "timemory/tpls/cereal/archives.hpp"
 //
@@ -120,6 +121,9 @@ struct component_apis
     using type = type_list<>;
 };
 
+template <typename T>
+using component_apis_t = typename component_apis<T>::type;
+
 //--------------------------------------------------------------------------------------//
 
 template <>
@@ -148,36 +152,39 @@ private:
 template <typename T>
 struct runtime_enabled
 {
-    using apitypes_t = typename component_apis<T>::type;
+    // type-list of APIs that are runtime configurable
+    using api_type_list =
+        get_true_types_t<concepts::is_runtime_configurable, component_apis_t<T>>;
+
     // GET specialization if component is available
     template <typename U = T>
-    static enable_if_t<is_available<U>::value, bool> get()
+    TIMEMORY_HOT static inline enable_if_t<is_available<U>::value, bool> get()
     {
-        return (get_runtime_value() && runtime_enabled<void>::get() &&
-                apply<runtime_enabled>{}(apitypes_t{}));
+        return (runtime_enabled<void>::get() && get_runtime_value() &&
+                apply<runtime_enabled>{}(api_type_list{}));
     }
 
     // SET specialization if component is available
     template <typename U = T>
-    static enable_if_t<is_available<U>::value, void> set(bool val)
+    TIMEMORY_HOT static inline enable_if_t<is_available<U>::value, void> set(bool val)
     {
         get_runtime_value() = val;
     }
 
     // GET specialization if component is NOT available
     template <typename U = T>
-    static enable_if_t<!is_available<U>::value, bool> get()
+    static inline enable_if_t<!is_available<U>::value, bool> get()
     {
         return false;
     }
 
     // SET specialization if component is NOT available
     template <typename U = T>
-    static enable_if_t<!is_available<U>::value, void> set(bool)
+    static inline enable_if_t<!is_available<U>::value, void> set(bool)
     {}
 
 private:
-    static bool& get_runtime_value()
+    TIMEMORY_HOT static bool& get_runtime_value()
     {
         static bool _instance = is_available<T>::value;
         return _instance;

--- a/source/timemory/mpl/types.hpp
+++ b/source/timemory/mpl/types.hpp
@@ -75,6 +75,8 @@ template <template <typename...> class TraitT, typename... CommonT>
 struct apply
 {
     //
+    TIMEMORY_DEFAULT_OBJECT(apply)
+    //
     template <typename... Types, typename... Args>
     static inline void set(Args&&... args)
     {
@@ -87,6 +89,14 @@ struct apply
     {
         return std::make_tuple(
             TraitT<Types, CommonT...>::get(std::forward<Args>(args)...)...);
+    }
+    //
+    template <typename... Types>
+    inline bool operator()(type_list<Types...>)
+    {
+        bool _ret = true;
+        TIMEMORY_FOLD_EXPRESSION(_ret = _ret && TraitT<Types>::get());
+        return _ret;
     }
 };  //
 //
@@ -102,7 +112,7 @@ struct is_available;
 template <typename T>
 struct data;
 
-template <typename T>
+template <typename T = void>
 struct runtime_enabled;
 
 template <typename T>
@@ -152,6 +162,9 @@ struct is_component;
 
 template <typename T, typename Tag = void>
 struct api_components;
+
+template <typename T>
+struct component_apis;
 
 template <typename T>
 struct is_gotcha;

--- a/source/timemory/mpl/types.hpp
+++ b/source/timemory/mpl/types.hpp
@@ -112,6 +112,15 @@ struct is_available;
 template <typename T>
 struct data;
 
+template <typename T, bool>
+struct component_value_type;
+
+template <typename T>
+struct collects_data;
+
+template <typename T>
+using runtime_configurable = concepts::is_runtime_configurable<T>;
+
 template <typename T = void>
 struct runtime_enabled;
 
@@ -171,12 +180,6 @@ struct is_gotcha;
 
 template <typename T>
 struct is_user_bundle;
-
-template <typename T, bool>
-struct component_value_type;
-
-template <typename T>
-struct collects_data;
 
 template <typename T, typename Tuple>
 struct supports_args;

--- a/source/timemory/operations/declaration.hpp
+++ b/source/timemory/operations/declaration.hpp
@@ -492,10 +492,11 @@ public:
     //----------------------------------------------------------------------------------//
     /// shorthand for apply<string_t>::join(...)
     ///
-    template <typename... Args>
-    static string_t join(const std::string& _delim, Args&&... _args)
+    template <typename Tp, typename... Args>
+    static string_t join(Tp&& _delim, Args&&... _args)
     {
-        return apply<string_t>::join(_delim, std::forward<Args>(_args)...);
+        return apply<string_t>::join(std::forward<Tp>(_delim),
+                                     std::forward<Args>(_args)...);
     }
 
     //----------------------------------------------------------------------------------//

--- a/source/timemory/operations/types/echo_measurement.hpp
+++ b/source/timemory/operations/types/echo_measurement.hpp
@@ -77,7 +77,7 @@ struct echo_measurement<Tp, true> : public common_utils
                        : type::get_label();
         }
 
-        auto _extra = join("/", std::forward<Args>(_args)...);
+        auto _extra = join('/', std::forward<Args>(_args)...);
         auto _label = uppercase(type::get_label());
         _unit       = replace(_unit, "", { " " });
         string_t _name =

--- a/source/timemory/operations/types/finalize/print.hpp
+++ b/source/timemory/operations/types/finalize/print.hpp
@@ -386,7 +386,7 @@ print<Tp, true>::update_data()
                     std::cout << " :: ";
                 std::cout << data->get_prefix(_hierarchy[i]);
                 if(i + 1 < _hierarchy.size())
-                    std::cout << "/";
+                    std::cout << '/';
             }
             std::cout << std::endl;
         }

--- a/source/timemory/plotting/declaration.hpp
+++ b/source/timemory/plotting/declaration.hpp
@@ -163,7 +163,7 @@ inline void
 echo_dart_file(const string_t& filepath, attributes_t attributes)
 {
     auto attribute_string = [](const string_t& key, const string_t& item) {
-        return operation::join("", key, "=", "\"", item, "\"");
+        return operation::join("", key, '=', "\"", item, "\"");
     };
 
     auto lowercase = [](string_t _str) {

--- a/source/timemory/settings/settings.hpp
+++ b/source/timemory/settings/settings.hpp
@@ -104,7 +104,9 @@ struct settings
     //
     //==================================================================================//
 
+    TIMEMORY_SETTINGS_MEMBER_DECL(string_t, config_file, "TIMEMORY_CONFIG_FILE")
     TIMEMORY_SETTINGS_MEMBER_DECL(bool, suppress_parsing, "TIMEMORY_SUPPRESS_PARSING")
+    TIMEMORY_SETTINGS_MEMBER_DECL(bool, suppress_config, "TIMEMORY_SUPPRESS_CONFIG")
     TIMEMORY_SETTINGS_MEMBER_DECL(bool, enabled, "TIMEMORY_ENABLED")
     TIMEMORY_SETTINGS_MEMBER_DECL(bool, auto_output, "TIMEMORY_AUTO_OUTPUT")
     TIMEMORY_SETTINGS_MEMBER_DECL(bool, cout_output, "TIMEMORY_COUT_OUTPUT")
@@ -288,6 +290,7 @@ public:
 
     /// read a configuration file
     bool read(const string_t&);
+    bool read(std::istream&, string_t = "");
 
 public:
     template <size_t Idx = 0>

--- a/source/timemory/settings/vsettings.hpp
+++ b/source/timemory/settings/vsettings.hpp
@@ -104,6 +104,30 @@ struct vsettings
 
     virtual bool matches(const std::string&) const;
 
+    template <typename Tp>
+    std::pair<bool, Tp> get() const
+    {
+        auto _ref = dynamic_cast<const tsettings<Tp, Tp&>*>(this);
+        if(_ref)
+            return { true, _ref->get() };
+        else
+        {
+            auto _nref = dynamic_cast<const tsettings<Tp, Tp>*>(this);
+            if(_nref)
+                return { true, _nref->get() };
+        }
+        return { false, Tp{} };
+    }
+
+    template <typename Tp>
+    bool get(Tp& _val) const
+    {
+        auto&& _ret = this->get<Tp>();
+        if(_ret.first)
+            _val = _ret.second;
+        return _ret.first;
+    }
+
 protected:
     std::type_index          m_type_index  = std::type_index(typeid(void));
     std::type_index          m_value_index = std::type_index(typeid(void));

--- a/source/timemory/utility/filepath.hpp
+++ b/source/timemory/utility/filepath.hpp
@@ -73,8 +73,8 @@ inline string_t
 osrepr(string_t _path)
 {
     // OS-dependent representation
-    while(_path.find("/") != std::string::npos)
-        _path.replace(_path.find("/"), 1, "\\");
+    while(_path.find('/') != std::string::npos)
+        _path.replace(_path.find('/'), 1, "\\");
     return _path;
 }
 

--- a/source/timemory/utility/signals.hpp
+++ b/source/timemory/utility/signals.hpp
@@ -239,7 +239,7 @@ termination_signal_message(int sig, siginfo_t* sinfo, std::ostream& os)
     {
         auto& itr = bt.at(i);
         if(itr.length() > 0)
-            serr << prefix.str() << "[" << i << "/" << sz << "]> " << itr << "\n";
+            serr << prefix.str() << "[" << i << '/' << sz << "]> " << itr << "\n";
     }
     std::cerr << serr.str().c_str() << std::flush;
 

--- a/source/timemory/utility/testing.hpp
+++ b/source/timemory/utility/testing.hpp
@@ -112,11 +112,11 @@ rank_prefix()
         rank_sout << "#\t"                                                               \
                   << "[" << argv_0 << "] ";                                              \
         if(num_fail > 0)                                                                 \
-            rank_sout << "\e[1;31mTESTS FAILED\e[0m: " << nfail_counter << "/"           \
+            rank_sout << "\e[1;31mTESTS FAILED\e[0m: " << nfail_counter << '/'           \
                       << ntest_counter << std::endl;                                     \
         else                                                                             \
             rank_sout << "\e[1;36mTESTS PASSED\e[0m: "                                   \
-                      << (ntest_counter - nfail_counter) << "/" << ntest_counter         \
+                      << (ntest_counter - nfail_counter) << '/' << ntest_counter         \
                       << std::endl;                                                      \
         rank_sout << "#\n" << filler.str() << "\n" << std::endl;                         \
         rank_cout << rank_sout.str();                                                    \

--- a/source/timemory/utility/types.hpp
+++ b/source/timemory/utility/types.hpp
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "timemory/macros/os.hpp"
+#include "timemory/mpl/concepts.hpp"
 
 #include <array>
 #include <bitset>
@@ -224,7 +225,7 @@ using identity_t = typename identity<T>::type;
 /// \struct null_type
 /// \brief this is a placeholder type for optional type-traits. It is used as the default
 /// type for the type-traits to signify there is no specialization.
-struct null_type
+struct null_type : concepts::null_type
 {};
 //
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/variadic/auto_bundle.hpp
+++ b/source/timemory/variadic/auto_bundle.hpp
@@ -44,11 +44,20 @@
 
 namespace tim
 {
-//--------------------------------------------------------------------------------------//
-
+//
 template <typename Tag, typename... Types>
 class auto_bundle
+: public concepts::wrapper
+, public concepts::variadic
+, public concepts::auto_wrapper
+, public concepts::mixed_wrapper
+, public concepts::hybrid_wrapper
+, public concepts::tagged
 {
+    static_assert(concepts::is_api<Tag>::value,
+                  "Error! The first template parameter of an 'auto_bundle' must "
+                  "statisfy the 'is_api' concept");
+
 public:
     using this_type           = auto_bundle<Tag, Types...>;
     using base_type           = component_bundle<Tag, Types...>;

--- a/source/timemory/variadic/auto_hybrid.hpp
+++ b/source/timemory/variadic/auto_hybrid.hpp
@@ -48,6 +48,10 @@ namespace tim
 
 template <typename CompTuple, typename CompList>
 class auto_hybrid
+: public concepts::wrapper
+, public concepts::variadic
+, public concepts::auto_wrapper
+, public concepts::hybrid_wrapper
 {
     static_assert((concepts::is_stack_wrapper<CompTuple>::value &&
                    concepts::is_heap_wrapper<CompList>::value),

--- a/source/timemory/variadic/auto_list.hpp
+++ b/source/timemory/variadic/auto_list.hpp
@@ -55,6 +55,10 @@ namespace tim
 
 template <typename... Types>
 class auto_list
+: public concepts::wrapper
+, public concepts::variadic
+, public concepts::auto_wrapper
+, public concepts::heap_wrapper
 {
 public:
     using this_type           = auto_list<Types...>;

--- a/source/timemory/variadic/auto_tuple.hpp
+++ b/source/timemory/variadic/auto_tuple.hpp
@@ -55,6 +55,10 @@ namespace tim
 
 template <typename... Types>
 class auto_tuple
+: public concepts::wrapper
+, public concepts::variadic
+, public concepts::auto_wrapper
+, public concepts::stack_wrapper
 {
 public:
     using this_type           = auto_tuple<Types...>;

--- a/source/timemory/variadic/base_bundle.hpp
+++ b/source/timemory/variadic/base_bundle.hpp
@@ -55,6 +55,8 @@ namespace tim
 ///
 template <typename Tag, typename... Types>
 class base_bundle
+: public concepts::variadic
+, public concepts::wrapper
 {
 public:
     using tag_type = Tag;
@@ -338,7 +340,9 @@ public:
 //======================================================================================//
 //
 template <typename... Types>
-struct stack_bundle : public base_bundle<TIMEMORY_API, Types...>
+struct stack_bundle
+: public base_bundle<TIMEMORY_API, Types...>
+, public concepts::stack_wrapper
 {
     using data_type = std::tuple<Types...>;
 
@@ -349,7 +353,9 @@ struct stack_bundle : public base_bundle<TIMEMORY_API, Types...>
 };
 
 template <typename... Types>
-struct stack_bundle<std::tuple<Types...>> : public base_bundle<TIMEMORY_API, Types...>
+struct stack_bundle<std::tuple<Types...>>
+: public base_bundle<TIMEMORY_API, Types...>
+, public concepts::stack_wrapper
 {
     using data_type = std::tuple<Types...>;
 
@@ -360,7 +366,9 @@ struct stack_bundle<std::tuple<Types...>> : public base_bundle<TIMEMORY_API, Typ
 };
 
 template <typename... Types>
-struct stack_bundle<type_list<Types...>> : public base_bundle<TIMEMORY_API, Types...>
+struct stack_bundle<type_list<Types...>>
+: public base_bundle<TIMEMORY_API, Types...>
+, public concepts::stack_wrapper
 {
     using data_type = std::tuple<Types...>;
 
@@ -373,7 +381,9 @@ struct stack_bundle<type_list<Types...>> : public base_bundle<TIMEMORY_API, Type
 //======================================================================================//
 //
 template <typename... Types>
-struct heap_bundle : public base_bundle<TIMEMORY_API, Types...>
+struct heap_bundle
+: public base_bundle<TIMEMORY_API, Types...>
+, public concepts::heap_wrapper
 {
     using data_type = std::tuple<Types*...>;
 
@@ -384,7 +394,9 @@ struct heap_bundle : public base_bundle<TIMEMORY_API, Types...>
 };
 
 template <typename... Types>
-struct heap_bundle<std::tuple<Types...>> : public base_bundle<TIMEMORY_API, Types...>
+struct heap_bundle<std::tuple<Types...>>
+: public base_bundle<TIMEMORY_API, Types...>
+, public concepts::heap_wrapper
 {
     using data_type = std::tuple<Types*...>;
 
@@ -395,7 +407,9 @@ struct heap_bundle<std::tuple<Types...>> : public base_bundle<TIMEMORY_API, Type
 };
 
 template <typename... Types>
-struct heap_bundle<type_list<Types...>> : public base_bundle<TIMEMORY_API, Types...>
+struct heap_bundle<type_list<Types...>>
+: public base_bundle<TIMEMORY_API, Types...>
+, public concepts::heap_wrapper
 {
     using data_type = std::tuple<Types*...>;
 

--- a/source/timemory/variadic/component_bundle.hpp
+++ b/source/timemory/variadic/component_bundle.hpp
@@ -53,16 +53,19 @@
 #include <iostream>
 #include <string>
 
-//======================================================================================//
-
 namespace tim
 {
 //
 template <typename Tag, typename... Types>
-class component_bundle : public api_bundle<Tag, implemented_t<Types...>>
+class component_bundle
+: public api_bundle<Tag, implemented_t<Types...>>
+, public concepts::tagged
+, public concepts::comp_wrapper
+, public concepts::hybrid_wrapper
 {
-    // manager is friend so can use above
-    friend class manager;
+    static_assert(concepts::is_api<Tag>::value,
+                  "Error! The first template parameter of a 'component_bundle' must "
+                  "statisfy the 'is_api' concept");
 
     template <typename TagT, typename... Tp>
     friend class auto_bundle;

--- a/source/timemory/variadic/component_hybrid.hpp
+++ b/source/timemory/variadic/component_hybrid.hpp
@@ -55,7 +55,7 @@ namespace tim
 // variadic list of components
 //
 template <typename CompTuple, typename CompList>
-class component_hybrid
+class component_hybrid : public concepts::hybrid_wrapper
 {
     static_assert((concepts::is_stack_wrapper<CompTuple>::value &&
                    concepts::is_heap_wrapper<CompList>::value),

--- a/source/timemory/variadic/component_list.hpp
+++ b/source/timemory/variadic/component_list.hpp
@@ -63,7 +63,9 @@ namespace tim
 // variadic list of components
 //
 template <typename... Types>
-class component_list : public heap_bundle<available_t<concat<Types...>>>
+class component_list
+: public heap_bundle<available_t<concat<Types...>>>
+, public concepts::comp_wrapper
 {
     static const std::size_t num_elements = sizeof...(Types);
 

--- a/source/timemory/variadic/component_tuple.hpp
+++ b/source/timemory/variadic/component_tuple.hpp
@@ -62,7 +62,9 @@ namespace tim
 // variadic list of components
 //
 template <typename... Types>
-class component_tuple : public stack_bundle<available_t<concat<Types...>>>
+class component_tuple
+: public stack_bundle<available_t<concat<Types...>>>
+, public concepts::comp_wrapper
 {
     // manager is friend so can use above
     friend class manager;

--- a/source/timemory/variadic/functional.hpp
+++ b/source/timemory/variadic/functional.hpp
@@ -218,10 +218,10 @@ start(TupleT<Tp...>& obj, Args&&... args)
 {
     if(settings::enabled())
     {
-        using data_type        = std::tuple<Tp...>;
-        using priority_types_t = impl::filter_false<negative_start_priority, data_type>;
+        using data_type        = std::tuple<remove_pointer_t<decay_t<Tp>>...>;
+        using priority_types_t = filter_false_t<negative_start_priority, data_type>;
         using priority_tuple_t = mpl::sort<trait::start_priority, priority_types_t>;
-        using delayed_types_t  = impl::filter_false<positive_start_priority, data_type>;
+        using delayed_types_t  = filter_false_t<positive_start_priority, data_type>;
         using delayed_tuple_t  = mpl::sort<trait::start_priority, delayed_types_t>;
 
         // start high priority components
@@ -250,10 +250,10 @@ stop(TupleT<Tp...>& obj, Args&&... args)
 {
     if(settings::enabled())
     {
-        using data_type        = std::tuple<Tp...>;
-        using priority_types_t = impl::filter_false<negative_stop_priority, data_type>;
+        using data_type        = std::tuple<remove_pointer_t<decay_t<Tp>>...>;
+        using priority_types_t = filter_false_t<negative_stop_priority, data_type>;
         using priority_tuple_t = mpl::sort<trait::stop_priority, priority_types_t>;
-        using delayed_types_t  = impl::filter_false<positive_stop_priority, data_type>;
+        using delayed_types_t  = filter_false_t<positive_stop_priority, data_type>;
         using delayed_tuple_t  = mpl::sort<trait::stop_priority, delayed_types_t>;
 
         // stop high priority components

--- a/source/timemory/variadic/lightweight_tuple.hpp
+++ b/source/timemory/variadic/lightweight_tuple.hpp
@@ -61,13 +61,15 @@ namespace tim
 // variadic list of components
 //
 template <typename... Types>
-class lightweight_tuple : public stack_bundle<available_t<std::tuple<Types...>>>
+class lightweight_tuple
+: public stack_bundle<available_t<type_list<Types...>>>
+, public concepts::comp_wrapper
 {
     // manager is friend so can use above
     friend class manager;
 
 public:
-    using bundle_type         = stack_bundle<available_t<std::tuple<Types...>>>;
+    using bundle_type         = stack_bundle<available_t<type_list<Types...>>>;
     using this_type           = lightweight_tuple<Types...>;
     using captured_location_t = source_location::captured;
 

--- a/source/timemory/variadic/macros.hpp
+++ b/source/timemory/variadic/macros.hpp
@@ -77,13 +77,17 @@ using string = tim::apply<std::string>;
 
 //--------------------------------------------------------------------------------------//
 
-#    define _TIM_FILESTR                                                                 \
-        std::string(__FILE__).substr(                                                    \
-            std::string(__FILE__).find_last_of(_TIM_FILENAME_DELIM) + 1)
+#    if defined(__FILE_NAME__)
+#        define _TIM_FILESTR __FILE_NAME__
+#    else
+#        define _TIM_FILESTR                                                             \
+            std::string(__FILE__).substr(                                                \
+                std::string(__FILE__).find_last_of(_TIM_FILENAME_DELIM) + 1)
+#    endif
 
 //--------------------------------------------------------------------------------------//
 
-#    define _TIM_FILELINE ::tim::string::join(":", _TIM_FILESTR, _TIM_LINESTR)
+#    define _TIM_FILELINE ::tim::string::join(':', _TIM_FILESTR, _TIM_LINESTR)
 
 //--------------------------------------------------------------------------------------//
 
@@ -99,7 +103,7 @@ using string = tim::apply<std::string>;
 
 //--------------------------------------------------------------------------------------//
 
-#    define TIMEMORY_FULL_LABEL ::tim::string::join("/", _TIM_FUNC, _TIM_FILELINE)
+#    define TIMEMORY_FULL_LABEL ::tim::string::join('/', _TIM_FUNC, _TIM_FILELINE)
 
 //--------------------------------------------------------------------------------------//
 

--- a/source/timemory/variadic/types.hpp
+++ b/source/timemory/variadic/types.hpp
@@ -99,58 +99,17 @@ class auto_hybrid;
 //                                  IS VARIADIC / IS WRAPPER
 //
 //--------------------------------------------------------------------------------------//
-
 // these are variadic types used to bundle components together
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_variadic, auto_bundle, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_variadic, auto_tuple, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_variadic, auto_list, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_variadic, auto_hybrid, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_variadic, component_bundle, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_variadic, component_tuple, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_variadic, component_list, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_variadic, component_hybrid, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_variadic, lightweight_tuple, true_type, typename)
 TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_variadic, std::tuple, true_type, typename)
 TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_variadic, type_list, true_type, typename)
 
 // there are timemory-specific variadic wrappers
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_wrapper, auto_bundle, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_wrapper, auto_tuple, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_wrapper, auto_list, true_type, typename)
 TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_wrapper, auto_hybrid, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_wrapper, component_bundle, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_wrapper, component_tuple, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_wrapper, component_list, true_type, typename)
 TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_wrapper, component_hybrid, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_wrapper, lightweight_tuple, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_wrapper, type_list, false_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_wrapper, std::tuple, false_type, typename)
-
-// tuple wrappers (stack-allocated components)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_stack_wrapper, auto_tuple, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_stack_wrapper, component_tuple, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_stack_wrapper, lightweight_tuple, true_type, typename)
-
-// list wrappers (heap-allocated components)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_heap_wrapper, auto_list, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_heap_wrapper, component_list, true_type, typename)
 
 // hybrid wrappers (stack- and heap- allocated components)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_hybrid_wrapper, auto_bundle, true_type, typename)
 TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_hybrid_wrapper, auto_hybrid, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_hybrid_wrapper, component_bundle, true_type, typename)
 TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_hybrid_wrapper, component_hybrid, true_type, typename)
-
-// there are timemory-specific variadic wrappers
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_auto_wrapper, auto_bundle, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_auto_wrapper, auto_tuple, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_auto_wrapper, auto_list, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_auto_wrapper, auto_hybrid, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_comp_wrapper, component_bundle, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_comp_wrapper, component_tuple, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_comp_wrapper, component_list, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_comp_wrapper, component_hybrid, true_type, typename)
-TIMEMORY_DEFINE_VARIADIC_CONCEPT(is_comp_wrapper, lightweight_tuple, true_type, typename)
 
 // {auto,component}_bundle are empty if one template is supplied
 TIMEMORY_DEFINE_TEMPLATE_CONCEPT(is_empty, auto_bundle, true_type, typename)
@@ -160,15 +119,15 @@ TIMEMORY_DEFINE_TEMPLATE_CONCEPT(is_empty, component_bundle, true_type, typename
 
 TIMEMORY_DEFINE_VARIADIC_CONCEPT_TYPE(tuple_type, std::tuple, typename, std::tuple<T...>)
 TIMEMORY_DEFINE_VARIADIC_CONCEPT_TYPE(auto_type, std::tuple, typename,
-                                      auto_bundle<api::native_tag, T...>)
+                                      auto_bundle<project::timemory, T...>)
 TIMEMORY_DEFINE_VARIADIC_CONCEPT_TYPE(component_type, std::tuple, typename,
-                                      component_bundle<api::native_tag, T...>)
+                                      component_bundle<project::timemory, T...>)
 
 TIMEMORY_DEFINE_VARIADIC_CONCEPT_TYPE(tuple_type, type_list, typename, std::tuple<T...>)
 TIMEMORY_DEFINE_VARIADIC_CONCEPT_TYPE(auto_type, type_list, typename,
-                                      auto_bundle<api::native_tag, T...>)
+                                      auto_bundle<project::timemory, T...>)
 TIMEMORY_DEFINE_VARIADIC_CONCEPT_TYPE(component_type, type_list, typename,
-                                      component_bundle<api::native_tag, T...>)
+                                      component_bundle<project::timemory, T...>)
 
 //======================================================================================//
 

--- a/source/timemory_c.cpp
+++ b/source/timemory_c.cpp
@@ -192,12 +192,12 @@ extern "C"
         else if(_mode == 2)
         {
             auto _filestr = std::string(_file);
-            ss << _func << "/" << _filestr.substr(_filestr.find_last_of('/') + 1) << ":"
+            ss << _func << '/' << _filestr.substr(_filestr.find_last_of('/') + 1) << ":"
                << _line;
         }
 
         if(_extra && strlen(_extra) > 0)
-            ss << "/" << _extra;
+            ss << '/' << _extra;
         std::string buff = ss.str();
         free_cstr()[buff] += 1;
         return free_cstr().find(buff)->first.c_str();

--- a/source/tools/kokkos-connector/kp_timemory.cpp
+++ b/source/tools/kokkos-connector/kp_timemory.cpp
@@ -165,7 +165,7 @@ kokkosp_finalize_library()
 extern "C" void
 kokkosp_begin_parallel_for(const char* name, uint32_t devid, uint64_t* kernid)
 {
-    auto pname = TIMEMORY_JOIN("/", "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
+    auto pname = TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
     *kernid    = get_unique_id();
     create_profiler(pname, *kernid);
     start_profiler(*kernid);
@@ -183,7 +183,7 @@ kokkosp_end_parallel_for(uint64_t kernid)
 extern "C" void
 kokkosp_begin_parallel_reduce(const char* name, uint32_t devid, uint64_t* kernid)
 {
-    auto pname = TIMEMORY_JOIN("/", "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
+    auto pname = TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
     *kernid    = get_unique_id();
     create_profiler(pname, *kernid);
     start_profiler(*kernid);
@@ -201,7 +201,7 @@ kokkosp_end_parallel_reduce(uint64_t kernid)
 extern "C" void
 kokkosp_begin_parallel_scan(const char* name, uint32_t devid, uint64_t* kernid)
 {
-    auto pname = TIMEMORY_JOIN("/", "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
+    auto pname = TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
     *kernid    = get_unique_id();
     create_profiler(pname, *kernid);
     start_profiler(*kernid);
@@ -238,7 +238,7 @@ extern "C" void
 kokkosp_create_profile_section(const char* name, uint32_t* secid)
 {
     *secid     = get_unique_id();
-    auto pname = TIMEMORY_JOIN("/", "kokkos", TIMEMORY_JOIN("", "section", secid), name);
+    auto pname = TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "section", secid), name);
     create_profiler(pname, *secid);
 }
 

--- a/source/tools/kokkos-connector/kp_timemory.cpp.in
+++ b/source/tools/kokkos-connector/kp_timemory.cpp.in
@@ -187,7 +187,7 @@ kokkosp_begin_parallel_for(const char* name, uint32_t devid, uint64_t* kernid)
 {
     if_constexpr(profile_entry_t::size() > 0)
     {
-        auto pname = TIMEMORY_JOIN("/", "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
+        auto pname = TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
         *kernid    = get_unique_id();
         create_profiler(pname, *kernid);
         start_profiler(*kernid, kp_timemory_parallel_for{}, name, devid);
@@ -211,7 +211,7 @@ kokkosp_begin_parallel_reduce(const char* name, uint32_t devid, uint64_t* kernid
 {
     if_constexpr(profile_entry_t::size() > 0)
     {
-        auto pname = TIMEMORY_JOIN("/", "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
+        auto pname = TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
         *kernid    = get_unique_id();
         create_profiler(pname, *kernid);
         start_profiler(*kernid, kp_timemory_parallel_reduce{}, name, devid);
@@ -235,7 +235,7 @@ kokkosp_begin_parallel_scan(const char* name, uint32_t devid, uint64_t* kernid)
 {
     if_constexpr(profile_entry_t::size() > 0)
     {
-        auto pname = TIMEMORY_JOIN("/", "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
+        auto pname = TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
         *kernid    = get_unique_id();
         create_profiler(pname, *kernid);
         start_profiler(*kernid, kp_timemory_parallel_scan{}, name, devid);
@@ -286,7 +286,7 @@ kokkosp_create_profile_section(const char* name, uint32_t* secid)
     {
         *secid = get_unique_id();
         auto pname =
-            TIMEMORY_JOIN("/", "kokkos", TIMEMORY_JOIN("", "section", secid), name);
+            TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "section", secid), name);
         create_profiler(pname, *secid);
     }
 }

--- a/source/tools/kokkos-connector/kp_timemory_filter.cpp
+++ b/source/tools/kokkos-connector/kp_timemory_filter.cpp
@@ -231,7 +231,7 @@ kokkosp_begin_parallel_for(const char* name, uint32_t devid, uint64_t* kernid)
         return;
     }
 
-    auto pname = TIMEMORY_JOIN("/", "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
+    auto pname = TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
     *kernid    = get_unique_id();
     create_profiler(pname, *kernid);
     start_profiler(*kernid);
@@ -258,7 +258,7 @@ kokkosp_begin_parallel_reduce(const char* name, uint32_t devid, uint64_t* kernid
         return;
     }
 
-    auto pname = TIMEMORY_JOIN("/", "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
+    auto pname = TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
     *kernid    = get_unique_id();
     create_profiler(pname, *kernid);
     start_profiler(*kernid);
@@ -285,7 +285,7 @@ kokkosp_begin_parallel_scan(const char* name, uint32_t devid, uint64_t* kernid)
         return;
     }
 
-    auto pname = TIMEMORY_JOIN("/", "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
+    auto pname = TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
     *kernid    = get_unique_id();
     create_profiler(pname, *kernid);
     start_profiler(*kernid);
@@ -347,7 +347,7 @@ kokkosp_create_profile_section(const char* name, uint32_t* secid)
     }
 
     *secid     = get_unique_id();
-    auto pname = TIMEMORY_JOIN("/", "kokkos", TIMEMORY_JOIN("", "section", secid), name);
+    auto pname = TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "section", secid), name);
     create_profiler(pname, *secid);
 }
 

--- a/source/tools/kokkos-connector/sample/sample.cpp
+++ b/source/tools/kokkos-connector/sample/sample.cpp
@@ -49,8 +49,8 @@ main(int argc, char** argv)
     kokkosp_init_library(0, 0, 0, nullptr);
 
     std::string exe = argv[0];
-    if(exe.find("/") != std::string::npos)
-        exe = exe.substr(exe.find_last_of("/") + 1);
+    if(exe.find('/') != std::string::npos)
+        exe = exe.substr(exe.find_last_of('/') + 1);
 
     // start recording application
     kokkosp_push_profile_region(exe.c_str());

--- a/source/tools/timemory-mpip/timemory-mpip.cpp
+++ b/source/tools/timemory-mpip/timemory-mpip.cpp
@@ -149,8 +149,8 @@ struct mpi_comm_data : base<mpi_comm_data, void>
         MPI_Type_size(datatype, &size);
         tracker_t _t(_name);
         add(_t, count * size);
-        add_secondary(_t, TIMEMORY_JOIN("_", _name, "dst", dst), count * size,
-                      TIMEMORY_JOIN("_", _name, "dst", dst, "tag", tag));
+        add_secondary(_t, TIMEMORY_JOIN('_', _name, "dst", dst), count * size,
+                      TIMEMORY_JOIN('_', _name, "dst", dst, "tag", tag));
     }
 
     // MPI_Recv
@@ -161,8 +161,8 @@ struct mpi_comm_data : base<mpi_comm_data, void>
         MPI_Type_size(datatype, &size);
         tracker_t _t(_name);
         add(_t, count * size);
-        add_secondary(_t, TIMEMORY_JOIN("_", _name, "dst", dst), count * size,
-                      TIMEMORY_JOIN("_", _name, "dst", dst, "tag", tag));
+        add_secondary(_t, TIMEMORY_JOIN('_', _name, "dst", dst), count * size,
+                      TIMEMORY_JOIN('_', _name, "dst", dst, "tag", tag));
     }
 
     // MPI_Isend
@@ -173,8 +173,8 @@ struct mpi_comm_data : base<mpi_comm_data, void>
         MPI_Type_size(datatype, &size);
         tracker_t _t(_name);
         add(_t, count * size);
-        add_secondary(_t, TIMEMORY_JOIN("_", _name, "dst", dst), count * size,
-                      TIMEMORY_JOIN("_", _name, "dst", dst, "tag", tag));
+        add_secondary(_t, TIMEMORY_JOIN('_', _name, "dst", dst), count * size,
+                      TIMEMORY_JOIN('_', _name, "dst", dst, "tag", tag));
     }
 
     // MPI_Irecv
@@ -185,8 +185,8 @@ struct mpi_comm_data : base<mpi_comm_data, void>
         MPI_Type_size(datatype, &size);
         tracker_t _t(_name);
         add(_t, count * size);
-        add_secondary(_t, TIMEMORY_JOIN("_", _name, "dst", dst), count * size,
-                      TIMEMORY_JOIN("_", _name, "dst", dst, "tag", tag));
+        add_secondary(_t, TIMEMORY_JOIN('_', _name, "dst", dst), count * size,
+                      TIMEMORY_JOIN('_', _name, "dst", dst, "tag", tag));
     }
 
     // MPI_Bcast
@@ -195,7 +195,7 @@ struct mpi_comm_data : base<mpi_comm_data, void>
     {
         int size = 0;
         MPI_Type_size(datatype, &size);
-        add(_name, count * size, TIMEMORY_JOIN("_", _name, "root", root));
+        add(_name, count * size, TIMEMORY_JOIN('_', _name, "root", root));
     }
 
     // MPI_Allreduce
@@ -218,10 +218,10 @@ struct mpi_comm_data : base<mpi_comm_data, void>
         MPI_Type_size(recvtype, &recv_size);
         tracker_t _t(_name);
         add(_t, sendcount * send_size + recvcount * recv_size);
-        add_secondary(_t, TIMEMORY_JOIN("_", _name, "send"), sendcount * send_size,
-                      TIMEMORY_JOIN("_", _name, "send", "tag", sendtag));
-        add_secondary(_t, TIMEMORY_JOIN("_", _name, "recv"), recvcount * recv_size,
-                      TIMEMORY_JOIN("_", _name, "recv", "tag", recvtag));
+        add_secondary(_t, TIMEMORY_JOIN('_', _name, "send"), sendcount * send_size,
+                      TIMEMORY_JOIN('_', _name, "send", "tag", sendtag));
+        add_secondary(_t, TIMEMORY_JOIN('_', _name, "recv"), recvcount * recv_size,
+                      TIMEMORY_JOIN('_', _name, "recv", "tag", recvtag));
     }
 
     // MPI_Gather
@@ -235,11 +235,11 @@ struct mpi_comm_data : base<mpi_comm_data, void>
         MPI_Type_size(recvtype, &recv_size);
         tracker_t _t(_name);
         add(_t, sendcount * send_size + recvcount * recv_size);
-        tracker_t _r(TIMEMORY_JOIN("_", _name, "root", root));
+        tracker_t _r(TIMEMORY_JOIN('_', _name, "root", root));
         add(_r, sendcount * send_size + recvcount * recv_size);
-        add_secondary(_r, TIMEMORY_JOIN("_", _name, "root", root, "send"),
+        add_secondary(_r, TIMEMORY_JOIN('_', _name, "root", root, "send"),
                       sendcount * send_size);
-        add_secondary(_r, TIMEMORY_JOIN("_", _name, "root", root, "recv"),
+        add_secondary(_r, TIMEMORY_JOIN('_', _name, "root", root, "recv"),
                       recvcount * recv_size);
     }
 
@@ -253,11 +253,11 @@ struct mpi_comm_data : base<mpi_comm_data, void>
         MPI_Type_size(recvtype, &recv_size);
         tracker_t _t(_name);
         add(_t, sendcount * send_size + recvcount * recv_size);
-        tracker_t _r(TIMEMORY_JOIN("_", _name, "root", root));
+        tracker_t _r(TIMEMORY_JOIN('_', _name, "root", root));
         add(_r, sendcount * send_size + recvcount * recv_size);
-        add_secondary(_r, TIMEMORY_JOIN("_", _name, "root", root, "send"),
+        add_secondary(_r, TIMEMORY_JOIN('_', _name, "root", root, "send"),
                       sendcount * send_size);
-        add_secondary(_r, TIMEMORY_JOIN("_", _name, "root", root, "recv"),
+        add_secondary(_r, TIMEMORY_JOIN('_', _name, "root", root, "recv"),
                       recvcount * recv_size);
     }
 
@@ -271,8 +271,8 @@ struct mpi_comm_data : base<mpi_comm_data, void>
         MPI_Type_size(recvtype, &recv_size);
         tracker_t _t(_name);
         add(_t, sendcount * send_size + recvcount * recv_size);
-        add_secondary(_t, TIMEMORY_JOIN("_", _name, "send"), sendcount * send_size);
-        add_secondary(_t, TIMEMORY_JOIN("_", _name, "recv"), recvcount * recv_size);
+        add_secondary(_t, TIMEMORY_JOIN('_', _name, "send"), sendcount * send_size);
+        add_secondary(_t, TIMEMORY_JOIN('_', _name, "recv"), recvcount * recv_size);
     }
 
 private:

--- a/source/tools/timemory-ncclp/timemory-ncclp.cpp
+++ b/source/tools/timemory-ncclp/timemory-ncclp.cpp
@@ -168,7 +168,7 @@ struct nccl_comm_data : base<nccl_comm_data, void>
                ncclDataType_t datatype, ncclRedOp_t, int root, ncclComm_t, cudaStream_t)
     {
         int size = NCCL_Type_size(datatype);
-        add(_name, count * size, TIMEMORY_JOIN("_", _name, "root", root));
+        add(_name, count * size, TIMEMORY_JOIN('_', _name, "root", root));
     }
 
     // ncclSend
@@ -176,7 +176,7 @@ struct nccl_comm_data : base<nccl_comm_data, void>
                ncclDataType_t datatype, int peer, ncclComm_t, cudaStream_t)
     {
         int size = NCCL_Type_size(datatype);
-        add(_name, count * size, TIMEMORY_JOIN("_", _name, "root", peer));
+        add(_name, count * size, TIMEMORY_JOIN('_', _name, "root", peer));
     }
 
     // ncclBcast
@@ -185,7 +185,7 @@ struct nccl_comm_data : base<nccl_comm_data, void>
                int root, ncclComm_t, cudaStream_t)
     {
         int size = NCCL_Type_size(datatype);
-        add(_name, count * size, TIMEMORY_JOIN("_", _name, "root", root));
+        add(_name, count * size, TIMEMORY_JOIN('_', _name, "root", root));
     }
 
     // ncclBroadcast
@@ -193,7 +193,7 @@ struct nccl_comm_data : base<nccl_comm_data, void>
                ncclDataType_t datatype, int root, ncclComm_t, cudaStream_t)
     {
         int size = NCCL_Type_size(datatype);
-        add(_name, count * size, TIMEMORY_JOIN("_", _name, "root", root));
+        add(_name, count * size, TIMEMORY_JOIN('_', _name, "root", root));
     }
 
     // ncclAllReduce

--- a/source/tools/timemory-run/timemory-run.cpp
+++ b/source/tools/timemory-run/timemory-run.cpp
@@ -1473,10 +1473,10 @@ read_collection(const string_t& fname, strset_t& collection_set)
     {
         for(auto itr : collection_paths)
         {
-            itr = TIMEMORY_JOIN("/", pitr, itr);
+            itr = TIMEMORY_JOIN('/', pitr, itr);
             searched_paths += itr;
             searched_paths += ", ";
-            auto fpath = TIMEMORY_JOIN("/", itr, fname);
+            auto fpath = TIMEMORY_JOIN('/', itr, fname);
 
             verbprintf(0, "trying to read collection file @ %s...", fpath.c_str());
             std::ifstream ifs(fpath.c_str());
@@ -1484,7 +1484,7 @@ read_collection(const string_t& fname, strset_t& collection_set)
             if(!ifs)
             {
                 verbprintf(0, "trying to read collection file @ %s...", fpath.c_str());
-                fpath = TIMEMORY_JOIN("/", itr, to_lower(fname));
+                fpath = TIMEMORY_JOIN('/', itr, to_lower(fname));
                 ifs.open(fpath.c_str());
             }
 

--- a/source/tools/timemory-run/timemory-run.hpp
+++ b/source/tools/timemory-run/timemory-run.hpp
@@ -360,9 +360,8 @@ struct function_signature
         {
             if(m_info_end)
             {
-                ss << "/"
-                   << "[{" << m_row.first << "," << m_col.first << "}-{" << m_row.second
-                   << "," << m_col.second << "}]";
+                ss << '/' << "[{" << m_row.first << "," << m_col.first << "}-{"
+                   << m_row.second << "," << m_col.second << "}]";
             }
             else
             {
@@ -372,7 +371,7 @@ struct function_signature
         else
         {
             if(use_file_info && m_file.length() > 0)
-                ss << "/" << m_file;
+                ss << '/' << m_file;
             if(use_line_info && m_row.first > 0)
                 ss << ":" << m_row.first;
         }

--- a/timemory/profiler/profiler.py
+++ b/timemory/profiler/profiler.py
@@ -39,7 +39,7 @@ from ..libpytimemory import settings
 from ..libpytimemory import component_bundle
 
 
-__all__ = ["profile", "Profiler", "FakeProfiler", "Config"]
+__all__ = ["profile", "config", "Profiler", "FakeProfiler", "Config"]
 
 
 #
@@ -73,6 +73,7 @@ else:
 
 
 #
+config = _profiler_config
 Config = _profiler_config
 
 
@@ -182,8 +183,6 @@ class Profiler:
         self._use = (
             not _profiler_config._is_running and Profiler.is_enabled() is True
         )
-        # print("[__call__:beg]> use: {}, _is_running: {}".format(self._use,
-        #      _profiler_config._is_running))
 
         if self._use and not _profiler_config._is_running:
             self.configure()
@@ -196,8 +195,6 @@ class Profiler:
 
         ret = function_wrapper
 
-        # print("[__call__:end]> use: {}, _is_running: {}".format(self._use,
-        #      _profiler_config._is_running))
         self.stop()
 
         return ret
@@ -217,7 +214,9 @@ class Profiler:
         Context manager stop function
         """
 
-        self.stop()
+        if self._use and _profiler_config._is_running:
+            sys.setprofile(self._original_profiler_function)
+            _profiler_fini()
         if (
             exec_type is not None
             and exec_value is not None

--- a/timemory/test/test_throttle.py
+++ b/timemory/test/test_throttle.py
@@ -120,11 +120,6 @@ class TimemoryThrottleTests(unittest.TestCase):
         # unset environment variables
         del os.environ["TIMEMORY_VERBOSE"]
         del os.environ["TIMEMORY_COLLAPSE_THREADS"]
-
-        # tim.trace.finalize()
-        # timemory finalize
-        # tim.finalize()
-        # tim.dmp.finalize()
         pass
 
     # ---------------------------------------------------------------------------------- #
@@ -248,62 +243,6 @@ class TimemoryThrottleTests(unittest.TestCase):
             _answer = False if (i % 2 == 1) else True
             print("thread " + str(i) + " throttling: " + str(is_throttled[i]))
             self.assertTrue(is_throttled[i] == _answer)
-
-    # ---------------------------------------------------------------------------------- #
-    # test tuple_serial
-    def test_tuple_serial(self):
-        """tuple_serial"""
-
-        @marker(components=("wall_clock"), key="thread")
-        def _run(name):
-            with auto_tuple(
-                get_config(["wall_clock"]), key="auto_tuple_serial"
-            ):
-                n = 8 * settings.throttle_count
-                for i in range(n):
-                    with marker(
-                        components=("wall_clock"), key=self.shortDescription()
-                    ):
-                        pass
-            self.assertFalse(tim.trace.is_throttled("thread"))
-            self.assertFalse(tim.trace.is_throttled(self.shortDescription()))
-
-        # run with auto tuple (wall_clock)
-        for i in range(self.nthreads):
-            _run(self.shortDescription())
-
-    # ---------------------------------------------------------------------------------- #
-    # test tuple_multithreaded
-    def test_tuple_multithreaded(self):
-        """tuple_multithreaded"""
-
-        @marker(components=("wall_clock"), key="thread")
-        def _run(name):
-            with auto_tuple(
-                get_config(["wall_clock"]), key="auto_tuple_multithreaded"
-            ):
-                n = 8 * settings.throttle_count
-                for i in range(n):
-                    with marker(
-                        components=("wall_clock"), key=self.shortDescription()
-                    ):
-                        pass
-
-            self.assertFalse(tim.trace.is_throttled(self.shortDescription()))
-            self.assertFalse(tim.trace.is_throttled("thread"))
-
-        # thread handles
-        threads = []
-
-        # make new threads
-        for i in range(self.nthreads):
-            thd = threading.Thread(target=_run, args=(self.shortDescription(),))
-            thd.start()
-            threads.append(thd)
-
-        # wait for join
-        for itr in threads:
-            itr.join()
 
 
 # ----------------------------- main test runner ---------------------------------------- #

--- a/timemory/test/test_throttle.py
+++ b/timemory/test/test_throttle.py
@@ -112,7 +112,7 @@ class TimemoryThrottleTests(unittest.TestCase):
 
         tim.trace.init("wall_clock", False, "throttle_tests")
 
-        self.nthreads = 4
+        self.nthreads = min(4, os.cpu_count())
 
     # Tear down class: finalize
     @classmethod


### PR DESCRIPTION
- created `project`, `category`, `tpls`, and `os` categories
  - e.g. `project::timemory`, `category::timing`, `category::external`, `tpls::caliper`, etc.
  - these support runtime disabling, e.g. `tim::trait::runtime_enabled<category::timing>::set(false)`
- new `tim::settings::config_file()` which reads a text or json file with initial settings configuration
  - defaults to trying to read `~/.timemory.cfg`, `~/.timemory.json`, `~/.config/timemory.cfg`, and `~/.config/timemory.json`
