### PR TITLE
Added timemory_argparse routines

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,7 +50,7 @@ matrix:
             - google-perftools
             - lcov
       env:
-        - MATRIX_EVAL="CC=$(which gcc-7) && CXX=$(which g++-7) && COVERAGE=1 && BUILD_ARGS='--build-libs shared --mpi --papi --caliper --mpip --python --gotcha --stats --cxx-standard=17'"
+        - MATRIX_EVAL="CC=$(which gcc-7) && CXX=$(which g++-7) && COVERAGE=1 && BUILD_ARGS='--build-libs shared --mpi --papi --caliper --mpip --gotcha --stats --cxx-standard=17'"
     #
     # GCC 8
     - os: linux

--- a/examples/ex-cxx-basic/ex_cxx_basic.cpp
+++ b/examples/ex-cxx-basic/ex_cxx_basic.cpp
@@ -27,34 +27,51 @@
 #include "timemory/utility/signals.hpp"
 
 #include <chrono>
+#include <random>
 #include <thread>
+#include <vector>
 
 using namespace tim::component;
 
-using real_tuple_t = tim::auto_tuple_t<wall_clock, papi_vector, caliper, tau_marker>;
+// a bundle of components which starts via ctor and stops via dtor
 using auto_tuple_t = tim::auto_tuple_t<wall_clock, cpu_clock, cpu_util, peak_rss,
                                        papi_vector, caliper, tau_marker>;
+// the component_tuple equivalent (requires explicit start/stop)
 using comp_tuple_t = typename auto_tuple_t::component_type;
-using auto_list_t =
-    tim::auto_list_t<wall_clock, cpu_clock, cpu_util, peak_rss, caliper, tau_marker>;
+// a bundle of components which are optional at runtime
+using auto_list_t = tim::auto_list_t<wall_clock, cpu_clock, cpu_util, peak_rss, caliper,
+                                     tau_marker, papi_vector>;
+// a pre-configured auto_bundle
 using auto_timer_t = tim::auto_timer;
 
+// forward declaration
 void
-some_func();
+foo();
 void
-another_func();
+bar();
+void
+raz();
 intmax_t
 fibonacci(intmax_t n);
 
-//======================================================================================//
-
+//
+// Usage example:
+//
+//  ./ex_cxx_basic 10 15 20
+//  ./ex_cxx_basic --timemory-enabled=no -- 10 15
+//  ./ex_cxx_basic --timemory-enabled=no 10 15
+//  ./ex_cxx_basic --timemory-option components="wall_clock,page_rss" precision=12 -- 10
+//
 int
 main(int argc, char** argv)
 {
+    // default settings for PAPI
     if(tim::settings::papi_events().empty())
         tim::settings::papi_events() = "PAPI_TOT_CYC,PAPI_TOT_INS,PAPI_LST_INS";
 
-    const std::string default_env = "wall_clock,cpu_clock,cpu_util,caliper";
+    // it is recommended to do this outside of the initializer (or make variables static).
+    // If done inside the initializer, this will result in unnecessary overhead
+    const std::string default_env = "wall_clock,cpu_clock,cpu_util,caliper,papi_vector";
     auto              env         = tim::get_env("TIMEMORY_COMPONENTS", default_env);
     auto              env_enum    = tim::enumerate_components(tim::delimit(env));
 
@@ -64,17 +81,37 @@ main(int argc, char** argv)
         al.report_at_exit(true);
     };
 
+    // default settings which can be overridden by environment
+    tim::settings::width()                 = 16;
     tim::settings::timing_units()          = "sec";
-    tim::settings::timing_width()          = 12;
+    tim::settings::timing_width()          = 16;
     tim::settings::timing_precision()      = 6;
     tim::settings::timing_scientific()     = false;
     tim::settings::memory_units()          = "KB";
-    tim::settings::memory_width()          = 12;
+    tim::settings::memory_width()          = 16;
     tim::settings::memory_precision()      = 3;
     tim::settings::memory_scientific()     = false;
     tim::settings::enable_signal_handler() = true;
+
+    // initialize timemory
     tim::timemory_init(argc, argv);
 
+    // parse the timemory-specific command line options (if any)
+    // to distinguish timemory arguments from user arguments, use the syntax:
+    //    ./<exe> <timemory-options> -- <user-options>
+    // after the function before, argc and argv will result in:
+    //    ./<exe> <user-options>
+    // Using the syntaxes:
+    //    ./<exe> <user-options>
+    //    ./<exe> <timemory-options>
+    //    ./<exe> <timemory-options> <user-options> (intermixed)
+    // will not remove any timemory options.
+    // In other words, only timemory_argparse will remove all arguments after
+    // <exe> until the first "--" if reached and everything after the "--"
+    // will be placed in argv[1:]
+    tim::timemory_argparse(&argc, &argv);
+
+    // print out the signal handler settings
     std::cout << tim::signal_settings::str() << std::endl;
 
     //
@@ -82,11 +119,14 @@ main(int argc, char** argv)
     //
     std::vector<long> fibvalues;
     for(int i = 1; i < argc; ++i)
-        fibvalues.push_back(atol(argv[i]));
+    {
+        if(std::string(argv[i]).find_first_not_of("0123456789") == std::string::npos)
+            fibvalues.push_back(atol(argv[i]));
+    }
     if(fibvalues.empty())
-        fibvalues = { 15, 20, 25 };
+        fibvalues = { 10, 15, 20 };
 
-    // create a component tuple (does not auto-start)
+    // use the auto-timer
     auto_timer_t main(argv[0]);
     for(auto n : fibvalues)
     {
@@ -97,20 +137,40 @@ main(int argc, char** argv)
         auto ret = fibonacci(n);
         // manually stop the auto_tuple_t
         TIMEMORY_CALIPER_APPLY(fib, stop);
+        // this is necessary to avoid optimizing away the fibonacci call
         printf("\nfibonacci(%li) = %li\n", n, (long int) ret);
     }
     // stop and print
     main.stop();
     std::cout << "\n" << main << std::endl;
 
-    some_func();
-    another_func();
+    foo();
+    bar();
+    raz();
 
+    // finalize timemory (produces output)
     tim::timemory_finalize();
+
+    std::stringstream cmd;
+    std::stringstream filler;
+    std::stringstream breaker;
+
+    cmd << "#  Command executed: \"";
+    for(int i = 0; i < argc; ++i)
+        cmd << argv[i] << ((i + 1 < argc) ? " " : "");
+    cmd << "\"  #" << std::flush;
+    breaker << "#" << std::setw(cmd.str().length() - 2) << ""
+            << "#";
+    filler.fill('#');
+    filler << std::setw(cmd.str().length()) << "";
+    std::cout << "\n\t" << filler.str() << "\n\t" << breaker.str() << "\n\t" << cmd.str()
+              << "\n\t" << breaker.str() << "\n\t" << filler.str() << "\n\n"
+              << std::flush;
+
+    return 0;
 }
 
-//======================================================================================//
-
+// recursive instrumentation
 intmax_t
 fibonacci(intmax_t n)
 {
@@ -119,15 +179,51 @@ fibonacci(intmax_t n)
 }
 
 void
-some_func()
+foo()
 {
-    auto_tuple_t at("some_func");
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    // use the component tuple (does not auto-start/stop)
+    comp_tuple_t ct("foo");
+    ct.start();
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+    ct.stop();
 }
 
 void
-another_func()
+bar()
 {
-    auto_list_t al("another_func");
-    std::this_thread::sleep_for(std::chrono::milliseconds(10));
+    auto_list_t al("bar");
+    std::this_thread::sleep_for(std::chrono::milliseconds(500));
+}
+
+void
+raz()
+{
+    using int_dist_t = std::uniform_int_distribution<std::mt19937::result_type>;
+
+    // convert the component tuple into a lightweight_tuple
+    // the lightweight tuple is designed to provide as little implicit overhead
+    // as possible. For example, it does not automatically, push and pop from
+    // storage, thus start/stop will not show up in the report unless push/pop are called
+    using lw_tuple_t = tim::convert_t<comp_tuple_t, tim::lightweight_tuple<>>;
+
+    lw_tuple_t lw("raz");
+    lw.push();
+    lw.start();
+
+    // consume some memory
+    auto v   = std::vector<double>(100000);
+    auto rng = std::mt19937{};
+    rng.seed(std::random_device()());
+    // consume some cpu-time
+    std::generate(v.begin(), v.end(),
+                  [&]() { return (std::generate_canonical<double, 10>(rng)); });
+    // get a random index
+    auto idx = v.at(int_dist_t(0, v.size() - 1)(rng));
+    // scale up the random value to [100, 600) milliseconds
+    auto val = static_cast<size_t>(v.at(idx) * 500 + 100);
+    // consume some wall-time
+    std::this_thread::sleep_for(std::chrono::milliseconds(val));
+
+    lw.stop();
+    lw.pop();
 }

--- a/examples/ex-python/ex_general.py
+++ b/examples/ex-python/ex_general.py
@@ -1,5 +1,24 @@
 #!@PYTHON_EXECUTABLE@
 
+"""
+Display help:
+
+    @PYTHON_EXECUTABLE@ ./@FILENAME@ -h
+    @PYTHON_EXECUTABLE@ ./@FILENAME@ timemory-config -h
+
+Usage:
+
+    @PYTHON_EXECUTABLE@ ./@FILENAME@
+    @PYTHON_EXECUTABLE@ ./@FILENAME@ -n 10
+    @PYTHON_EXECUTABLE@ ./@FILENAME@ -f text
+    @PYTHON_EXECUTABLE@ ./@FILENAME@ -f json_flat
+    @PYTHON_EXECUTABLE@ ./@FILENAME@ -f json_tree
+    @PYTHON_EXECUTABLE@ ./@FILENAME@ timemory-config --enabled=n
+    @PYTHON_EXECUTABLE@ ./@FILENAME@ timemory-config --auto-output=y --cout-output=n
+
+"""
+
+import os
 import sys
 import json
 import argparse
@@ -44,6 +63,27 @@ if __name__ == "__main__":
     parser.add_argument(
         "-n", "--nfib", type=int, default=10, help="Fibonacci depth"
     )
+    parser.add_argument(
+        "-o", "--output-name", type=str, default=None, help="Output filename"
+    )
+    parser.add_argument(
+        "-f",
+        "--formats",
+        type=str,
+        nargs="*",
+        choices=("text", "json_flat", "json_tree"),
+        default=["json_tree"],
+        help=(
+            'Data reporting format. In a "flat" json, all entries are in a 1D array'
+            'and labels are modified with indentation to reflect hierarchy. In a "tree" json'
+            ", entries are arranged in a hierarchical and the labels are unmodified."
+        ),
+    )
+
+    # disable output in timemory_finalize by default
+    # can override with command-line:
+    #   '... timemory-config --auto-output=y ...'
+    timemory.settings.auto_output = False
 
     # demonstrate how to add command-line support
     # The subparser stuff is not strictly necessary: if a
@@ -56,7 +96,7 @@ if __name__ == "__main__":
         parser,
         subparser=subparser.add_parser(
             "timemory-config",
-            parents=[parser],
+            parents=[],
             conflict_handler="resolve",
             description="Configure settings for timemory",
             formatter_class=argparse.ArgumentDefaultsHelpFormatter,
@@ -70,9 +110,39 @@ if __name__ == "__main__":
     run_auto_timer(n)
     run_marker(n)
 
-    # Get the results as dictionary
-    data = timemory.get()
+    # write the output
+    def write(output_name, data, ext):
+        if not data:
+            return
+        if output_name is not None:
+            fname = os.path.join(timemory.settings.output_path, "{}.{}".format(output_name, ext))
+            with open(fname, 'w') as f:
+                print("[timemory]> Outputting {}...".format(fname))
+                f.write(data)
+        else:
+            print("\n{}".format(data))
 
-    print("\n{}".format(json.dumps(data, indent=4, sort_keys=True)))
-    # Generate output
+    # Get the results as text table
+    if "text" in args.formats:
+        data = timemory.get_text()
+        write(args.output_name, data, "txt")
+
+    # Get the results as a JSON where all entries are
+    # in a 1D JSON array and the labels (i.e. prefix)
+    # are modified with indentation to reflect hierarchy
+    if "json_flat" in args.formats:
+        data = timemory.get(hierarchy=False)
+        write(args.output_name, "{}".format(json.dumps(data, indent=2, sort_keys=True)), "json")
+
+    # Get the results as a JSON where all entries are
+    # in a hierarchical JSON and the labels (i.e. prefix)
+    # are unmodified. This data layout includes inclusive
+    # and exclusive values
+    if "json_tree" in args.formats:
+        data = timemory.get(hierarchy=True)
+        write(args.output_name, "{}".format(json.dumps(data, indent=2, sort_keys=False)), "tree.json")
+
+    print("")
+
+    # Generate output (potentially)
     timemory.finalize()

--- a/examples/ex-python/ex_general.py
+++ b/examples/ex-python/ex_general.py
@@ -2,6 +2,7 @@
 
 import sys
 import json
+import argparse
 import timemory
 from timemory.profiler import profile
 from timemory.bundle import auto_timer, auto_tuple, marker
@@ -38,7 +39,32 @@ def run_marker(n):
 
 
 if __name__ == "__main__":
-    n = int(sys.argv[1] if len(sys.argv) > 1 else 10)
+
+    parser = argparse.ArgumentParser()
+    parser.add_argument(
+        "-n", "--nfib", type=int, default=10, help="Fibonacci depth"
+    )
+
+    # demonstrate how to add command-line support
+    # The subparser stuff is not strictly necessary: if a
+    # subparser is not provided, the default behavior is
+    # to do this internally. If you want to disable the
+    # subparser behavior, pass 'subparser=None' or
+    # subparser=False
+    subparser = parser.add_subparsers()
+    timemory.settings.add_arguments(
+        parser,
+        subparser=subparser.add_parser(
+            "timemory-config",
+            parents=[parser],
+            conflict_handler="resolve",
+            description="Configure settings for timemory",
+            formatter_class=argparse.ArgumentDefaultsHelpFormatter,
+        ),
+    )
+
+    args = parser.parse_args()
+    n = args.nfib
 
     run_profile(n)
     run_auto_timer(n)

--- a/source/python/libpytimemory-profile.cpp
+++ b/source/python/libpytimemory-profile.cpp
@@ -107,6 +107,9 @@ get_depth(PyFrameObject* frame)
 void
 profiler_function(py::object pframe, const char* swhat, py::object arg)
 {
+    if(!tim::settings::enabled())
+        return;
+
     if(user_profiler_bundle::bundle_size() == 0)
     {
         if(tim::settings::debug())

--- a/source/python/libpytimemory-settings.cpp
+++ b/source/python/libpytimemory-settings.cpp
@@ -128,10 +128,65 @@ add_property(py::class_<tim::settings>& _class, std::shared_ptr<tim::vsettings> 
 py::class_<tim::settings>
 generate(py::module& _pymod)
 {
-    // auto pyargparse = py::module::import("argparse");
     py::class_<tim::settings> settings(_pymod, "settings",
                                        "Global configuration settings for timemory");
 
+    auto _argparse = [](std::shared_ptr<tim::vsettings> obj, py::object argp,
+                        bool _strip) {
+        if(!obj || obj->get_command_line().empty())
+            return;
+        py::cpp_function parse = [=](std::string val) { obj->parse(val); };
+        std::string      tidx  = tim::demangle(obj->get_type_index().name());
+        if(tidx.find("basic_string") != std::string::npos)
+            tidx = "std::string";
+        auto locals =
+            py::dict("parser"_a = argp, "args"_a = obj->get_command_line(),
+                     "desc"_a = obj->get_description(), "cnt"_a = obj->get_count(),
+                     "max_cnt"_a = obj->get_max_count(), "name"_a = obj->get_name(),
+                     "env_name"_a = obj->get_env_name(), "type_index"_a = tidx,
+                     "value"_a = obj->as_string(), "parse_action"_a = parse,
+                     "strip_timemory_prefix"_a = _strip);
+        py::exec(R"(
+             def make_action(func):
+                 class customAction(argparse.Action):
+                     def __call__(self, parser, args, values, option_string=None):
+                         if type(values) is list:
+                             func(",".join(values))
+                         else:
+                             func("{}".format(values))
+                         setattr(args, self.dest, values)
+                 return customAction
+
+             _args = []
+             _kwargs = {}
+             for itr in args:
+                if strip_timemory_prefix:
+                    _args.append(itr.replace("--timemory-", "--"))
+                else:
+                    _args.append(itr)
+
+             _kwargs["help"] = "{}\n\n[env: {}, type: {}]".format(desc, env_name.upper(),
+                                                                  type_index)
+             _kwargs["required"] = False
+
+             if cnt > 1:
+                _kwargs["nargs"] = cnt
+ 
+             if (max_cnt == 0):
+                 if value == "true":
+                     _kwargs["action"] = "store_true"
+                 else:
+                     _kwargs["action"] = "store_false"
+             else:
+                 _kwargs["action"] = make_action(parse_action)
+                 _kwargs["metavar"] = "VALUE"
+                 _kwargs["default"] = value
+                 _kwargs["type"] = str
+
+             parser.add_argument(*_args, **_kwargs)
+             )",
+                 py::globals(), locals);
+    };
     auto _init = []() {
         auto ret = new tim::settings{};
         *ret     = *tim::settings::instance<tim::api::native_tag>();
@@ -151,6 +206,63 @@ generate(py::module& _pymod)
         else
             _obj->read(inp);
     };
+    auto _args = [&](py::object parser, py::object _instance, py::object subparser) {
+        auto pyargparse = py::module::import("argparse");
+
+        if(parser.is_none())
+            parser = pyargparse.attr("ArgumentParser")();
+
+        using settings_t = tim::settings;
+        auto* _obj       = (_instance.is_none()) ? settings_t::instance()
+                                           : _instance.cast<settings_t*>();
+        if(_obj == nullptr)
+            return;
+
+        py::object _parser        = parser;
+        bool       _use_subparser = !subparser.is_none();
+
+        if(_use_subparser)
+        {
+            try
+            {
+                auto _use      = subparser.cast<bool>();
+                _use_subparser = _use;
+                if(_use_subparser)
+                {
+                    auto _parents         = py::list{};
+                    auto _subcommand_args = py::kwargs{};
+                    auto _subparser_args  = py::kwargs{};
+
+                    _subcommand_args["help"] = "sub-command help";
+                    auto _subparser = parser.attr("add_subparsers")(**_subcommand_args);
+
+                    _parents.append(parser);
+                    _subparser_args["description"] = "Configure settings for timemory";
+                    _subparser_args["conflict_handler"] = "resolve";
+                    _subparser_args["parents"]          = _parents;
+                    _subparser_args["formatter_class"] =
+                        pyargparse.attr("ArgumentDefaultsHelpFormatter");
+                    _parser = _subparser.attr("add_parser")("timemory-config",
+                                                            **_subparser_args);
+                }
+            } catch(py::cast_error&)
+            {
+                _parser = subparser;
+            }
+        }
+
+        DEBUG_PRINT_HERE("%s", "starting loop");
+        for(const auto& itr : _obj->ordering())
+        {
+            DEBUG_PRINT_HERE("searching for %s", itr.c_str());
+            auto sitr = _obj->find(itr);
+            if(sitr != _obj->end() && sitr->second)
+            {
+                DEBUG_PRINT_HERE("adding args for %s", sitr->first.c_str());
+                _argparse(sitr->second, _parser, _use_subparser);
+            }
+        }
+    };
 
     // create an instance
     settings.def(py::init(_init), "Create a copy of the global settings");
@@ -159,6 +271,12 @@ generate(py::module& _pymod)
                         "Update the values of the settings from the current environment",
                         py::arg("instance") = py::none{});
     settings.def_static("read", _read, "Read the settings from JSON or text file");
+    settings.def_static("add_argparse", _args, "Add command-line argument support",
+                        py::arg("parser"), py::arg("instance") = py::none{},
+                        py::arg("subparser") = true);
+    settings.def_static("add_arguments", _args, "Add command-line argument support",
+                        py::arg("parser"), py::arg("instance") = py::none{},
+                        py::arg("subparser") = true);
 
     std::set<std::string> names;
     auto                  _settings = tim::settings::instance<tim::api::native_tag>();

--- a/source/python/libpytimemory-settings.cpp
+++ b/source/python/libpytimemory-settings.cpp
@@ -229,17 +229,17 @@ generate(py::module& _pymod)
                 _use_subparser = _use;
                 if(_use_subparser)
                 {
-                    auto _parents         = py::list{};
+                    // auto _parents         = py::list{};
                     auto _subcommand_args = py::kwargs{};
                     auto _subparser_args  = py::kwargs{};
 
                     _subcommand_args["help"] = "sub-command help";
                     auto _subparser = parser.attr("add_subparsers")(**_subcommand_args);
 
-                    _parents.append(parser);
+                    // _parents.append(parser);
                     _subparser_args["description"] = "Configure settings for timemory";
                     _subparser_args["conflict_handler"] = "resolve";
-                    _subparser_args["parents"]          = _parents;
+                    // _subparser_args["parents"]          = _parents;
                     _subparser_args["formatter_class"] =
                         pyargparse.attr("ArgumentDefaultsHelpFormatter");
                     _parser = _subparser.attr("add_parser")("timemory-config",

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -153,6 +153,13 @@ add_timemory_google_test(socket_tests
                     timemory::timemory-core
                     test-werror-flags)
 
+add_timemory_google_test(settings_tests
+    DISCOVER_TESTS
+    SOURCES         settings_tests.cpp
+    LINK_LIBRARIES  common-test-libs
+                    timemory::timemory-core
+                    timemory::timemory-config)
+
 add_timemory_google_test(argparse_tests
     SOURCES         argparse_tests.cpp
     LINK_LIBRARIES  common-test-libs

--- a/source/tests/argparse_tests.cpp
+++ b/source/tests/argparse_tests.cpp
@@ -165,7 +165,7 @@ parse(argparse_t& parser, Args&&... args)
         .names({ "-S", "--stdlib" })
         .description("Enable instrumentation of C++ standard library functions. Use with "
                      "caution because timemory uses the STL internally!")
-        .count(0);
+        .max_count(1);
     parser.add_argument()
         .names({ "-p", "--pid" })
         .description("Connect to running process")

--- a/source/tests/argparse_tests.cpp
+++ b/source/tests/argparse_tests.cpp
@@ -32,12 +32,16 @@
 #include <thread>
 #include <vector>
 
+#include "timemory/config.hpp"
+#include "timemory/manager.hpp"
 #include "timemory/mpl/apply.hpp"
 #include "timemory/utility/argparse.hpp"
 #include "timemory/variadic/macros.hpp"
 
 static int         _argc     = 0;
 static char**      _argv     = nullptr;
+static int         _margc    = 0;
+static char**      _margv    = nullptr;
 static int         _log_once = 0;
 static const char* _arg0     = "./test";
 
@@ -228,6 +232,9 @@ class argparse_tests : public ::testing::Test
 protected:
     void        SetUp() override {}
     std::string extra_help = "-- <CMD> <ARGS>";
+
+    static void SetUpTestSuite() { tim::timemory_init(_margc, _margv); }
+    static void TearDownTestSuite() { tim::timemory_finalize(); }
 };
 
 //--------------------------------------------------------------------------------------//
@@ -616,9 +623,97 @@ TEST_F(argparse_tests, parse_known_options_without_options)
 
 //--------------------------------------------------------------------------------------//
 
+TEST_F(argparse_tests, timemory_argparse_vec)
+{
+    auto _enabled = tim::settings::enabled();
+    auto _verbose = tim::settings::verbose();
+    auto _debug   = tim::settings::debug();
+    auto _python  = tim::settings::python_exe();
+
+    std::vector<std::string> args = {
+        _margv[0], "--timemory-enabled=false", "--timemory-verbose",
+        "10",      "--timemory-debug",         "--timemory-python-exe",
+        "python",
+    };
+
+    std::cout << "Argument: ";
+    for(size_t i = 0; i < args.size(); ++i)
+        std::cout << args[i] << " ";
+    std::cout << std::endl;
+
+    tim::timemory_argparse(args);
+
+    EXPECT_EQ(tim::settings::verbose(), 10);
+    EXPECT_NE(_enabled, tim::settings::enabled());
+    EXPECT_NE(_verbose, tim::settings::verbose());
+    EXPECT_NE(_debug, tim::settings::debug());
+    EXPECT_NE(_python, tim::settings::python_exe());
+
+    tim::settings::enabled()    = _enabled;
+    tim::settings::verbose()    = _verbose;
+    tim::settings::debug()      = _debug;
+    tim::settings::python_exe() = _python;
+}
+
+//--------------------------------------------------------------------------------------//
+
+TEST_F(argparse_tests, timemory_argparse_ptr)
+{
+    auto _enabled = tim::settings::enabled();
+    auto _verbose = tim::settings::verbose();
+    auto _debug   = tim::settings::debug();
+    auto _python  = tim::settings::python_exe();
+
+    std::vector<std::string> args = { _margv[0],
+                                      "--timemory-enabled=false",
+                                      "--timemory-verbose",
+                                      "10",
+                                      "--timemory-debug",
+                                      "--timemory-python-exe",
+                                      "python",
+                                      "--",
+                                      "some-argument" };
+
+    int    argc = args.size();
+    char** argv = new char*[argc];
+
+    for(int i = 0; i < argc; ++i)
+    {
+        argv[i] = new char[args.at(i).length() + 1];
+        strcpy(argv[i], args.at(i).c_str());
+        argv[i][args.at(i).length()] = '\0';
+    }
+
+    std::cout << "Argument: ";
+    for(int i = 0; i < argc; ++i)
+        std::cout << argv[i] << " ";
+    std::cout << std::endl;
+
+    tim::timemory_argparse(&argc, &argv);
+
+    EXPECT_EQ(argc, 2);
+    EXPECT_EQ(std::string(argv[0]), args.front());
+    EXPECT_EQ(std::string(argv[1]), args.back());
+    EXPECT_EQ(tim::settings::python_exe(), std::string("python"));
+
+    EXPECT_NE(_enabled, tim::settings::enabled());
+    EXPECT_NE(_verbose, tim::settings::verbose());
+    EXPECT_NE(_debug, tim::settings::debug());
+    EXPECT_NE(_python, tim::settings::python_exe());
+
+    tim::settings::enabled()    = _enabled;
+    tim::settings::verbose()    = _verbose;
+    tim::settings::debug()      = _debug;
+    tim::settings::python_exe() = _python;
+}
+
+//--------------------------------------------------------------------------------------//
+
 int
 main(int argc, char** argv)
 {
+    _margc = argc;
+    _margv = argv;
     ::testing::InitGoogleTest(&argc, argv);
     auto ret = RUN_ALL_TESTS();
     return ret;

--- a/source/tests/flat_tests.cpp
+++ b/source/tests/flat_tests.cpp
@@ -126,24 +126,25 @@ random_entry(const std::vector<Tp>& v)
 class flat_tests : public ::testing::Test
 {
 protected:
-    void SetUp() override
+    static void SetUpTestSuite()
     {
         tim::set_env("TIMEMORY_FLAT_PROFILE", "ON", 1);
-        static bool configured = false;
-        if(!configured)
-        {
-            configured                   = true;
-            tim::settings::verbose()     = 0;
-            tim::settings::debug()       = false;
-            tim::settings::json_output() = true;
-            tim::settings::mpi_thread()  = false;
-            tim::dmp::initialize(_argc, _argv);
-            tim::timemory_init(_argc, _argv);
-            tim::settings::dart_output() = true;
-            tim::settings::dart_count()  = 1;
-            tim::settings::banner()      = false;
-        }
+        tim::settings::verbose()     = 0;
+        tim::settings::debug()       = false;
+        tim::settings::json_output() = true;
+        tim::settings::mpi_thread()  = false;
+        tim::dmp::initialize(_argc, _argv);
+        tim::timemory_init(_argc, _argv);
+        tim::settings::dart_output() = true;
+        tim::settings::dart_count()  = 1;
+        tim::settings::banner()      = false;
         tim::settings::parse();
+    }
+
+    static void TearDownTestSuite()
+    {
+        tim::timemory_finalize();
+        tim::dmp::finalize();
     }
 };
 
@@ -271,12 +272,7 @@ main(int argc, char** argv)
     ::testing::InitGoogleTest(&argc, argv);
     _argc = argc;
     _argv = argv;
-
-    auto ret = RUN_ALL_TESTS();
-
-    tim::timemory_finalize();
-    tim::dmp::finalize();
-    return ret;
+    return RUN_ALL_TESTS();
 }
 
 //--------------------------------------------------------------------------------------//

--- a/source/tests/settings_tests.cpp
+++ b/source/tests/settings_tests.cpp
@@ -1,0 +1,311 @@
+// MIT License
+//
+// Copyright (c) 2020, The Regents of the University of California,
+// through Lawrence Berkeley National Laboratory (subject to receipt of any
+// required approvals from the U.S. Dept. of Energy).  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#include "test_macros.hpp"
+
+TIMEMORY_TEST_DEFAULT_MAIN
+
+#include "timemory/timemory.hpp"
+
+//--------------------------------------------------------------------------------------//
+
+static uint64_t reference_value = 10;
+static uint64_t copied_value    = 10;
+
+//--------------------------------------------------------------------------------------//
+
+namespace details
+{
+//  Get the current tests name
+inline std::string
+get_test_name()
+{
+    return ::testing::UnitTest::GetInstance()->current_test_info()->name();
+}
+
+// this function consumes approximately "n" milliseconds of real time
+inline void
+do_sleep(long n)
+{
+    std::this_thread::sleep_for(std::chrono::milliseconds(n));
+}
+
+// this function consumes an unknown number of cpu resources
+inline long
+fibonacci(long n)
+{
+    return (n < 2) ? n : (fibonacci(n - 1) + fibonacci(n - 2));
+}
+
+// this function consumes approximately "t" milliseconds of cpu time
+void
+consume(long n)
+{
+    // a mutex held by one lock
+    mutex_t mutex;
+    // acquire lock
+    lock_t hold_lk(mutex);
+    // associate but defer
+    lock_t try_lk(mutex, std::defer_lock);
+    // get current time
+    auto now = std::chrono::steady_clock::now();
+    // try until time point
+    while(std::chrono::steady_clock::now() < (now + std::chrono::milliseconds(n)))
+        try_lk.try_lock();
+}
+
+// get a random entry from vector
+template <typename Tp>
+size_t
+random_entry(const std::vector<Tp>& v)
+{
+    std::mt19937 rng;
+    rng.seed(std::random_device()());
+    std::uniform_int_distribution<std::mt19937::result_type> dist(0, v.size() - 1);
+    return v.at(dist(rng));
+}
+
+}  // namespace details
+
+//--------------------------------------------------------------------------------------//
+
+class settings_tests : public ::testing::Test
+{
+protected:
+    TIMEMORY_TEST_DEFAULT_SUITE_SETUP
+    TIMEMORY_TEST_DEFAULT_SUITE_TEARDOWN
+
+    TIMEMORY_TEST_DEFAULT_SETUP
+    TIMEMORY_TEST_DEFAULT_TEARDOWN
+};
+
+//--------------------------------------------------------------------------------------//
+
+TEST_F(settings_tests, insert_via_args)
+{
+    using settings_t = tim::settings;
+    using strvec_t   = std::vector<std::string>;
+
+    reference_value = 10;
+    copied_value    = 10;
+
+    settings_t* _settings = settings_t::instance();
+
+    std::string _ref_env  = "SETTINGS_TEST_REFERENCE";
+    std::string _ref_name = "test_reference";
+    std::string _ref_cmd  = "--test-reference";
+    std::string _ref_desc = TIMEMORY_JOIN("", "Reference value for settings_tests.",
+                                          details::get_test_name());
+
+    auto _ins = _settings->insert<uint64_t, uint64_t&>(
+        _ref_env, _ref_name, _ref_desc, reference_value, strvec_t({ _ref_cmd }), 1, -2);
+
+    EXPECT_TRUE(_ins.second);
+
+    auto tidx_check = std::type_index(typeid(uint64_t));
+    auto vidx_check = std::type_index(typeid(uint64_t&));
+    auto _env_check = tim::get_env<uint64_t>(_ref_env, 0);
+    auto _odr_check = _settings->ordering().back();
+    auto _itr_check = _settings->find(_ref_env);
+
+    EXPECT_EQ(_env_check, reference_value);
+    EXPECT_EQ(_odr_check, _ref_env);
+    ASSERT_NE(_itr_check, _settings->end());
+    EXPECT_EQ(_itr_check->first, _ref_env);
+
+    auto itr = _itr_check->second;
+
+    EXPECT_EQ(itr->get_type_index(), tidx_check);
+    EXPECT_EQ(itr->get_value_index(), vidx_check);
+
+    EXPECT_EQ(itr->get_count(), 1);
+    EXPECT_EQ(itr->get_max_count(), -2);
+
+    EXPECT_EQ(itr->get_name(), _ref_name);
+    EXPECT_EQ(itr->get_env_name(), _ref_env);
+    EXPECT_EQ(itr->get_command_line().front(), _ref_cmd);
+
+    EXPECT_TRUE(itr->matches(_ref_env, true));
+    EXPECT_TRUE(itr->matches(_ref_name, true));
+    EXPECT_TRUE(itr->matches(_ref_cmd, true));
+
+    EXPECT_TRUE(itr->matches(_ref_env, false));
+    EXPECT_TRUE(itr->matches(_ref_name, false));
+    EXPECT_TRUE(itr->matches(_ref_cmd, false));
+
+    uint64_t _tmp = 0;
+    EXPECT_TRUE(itr->get(_tmp));
+    EXPECT_EQ(itr->get<uint64_t>().second, reference_value);
+    EXPECT_EQ(_tmp, reference_value);
+    EXPECT_EQ(itr->as_string(), std::to_string(reference_value));
+
+    auto _disp = itr->get_display();
+    EXPECT_EQ(_disp["name"], _ref_name);
+    EXPECT_EQ(_disp["count"], "1");
+    EXPECT_EQ(_disp["max_count"], "-2");
+    EXPECT_EQ(_disp["env_name"], _ref_env);
+    EXPECT_EQ(_disp["description"], _ref_desc);
+    EXPECT_EQ(_disp["command_line"], _ref_cmd);
+
+    reference_value = 5;
+    EXPECT_TRUE(itr->get(_tmp));
+    EXPECT_EQ(_tmp, reference_value);
+    EXPECT_EQ(itr->get<uint64_t>().second, reference_value);
+    EXPECT_EQ(itr->as_string(), std::to_string(reference_value));
+
+    itr->set<uint64_t>(4);
+    EXPECT_EQ(reference_value, 4);
+    EXPECT_TRUE(itr->get(_tmp));
+    EXPECT_EQ(_tmp, reference_value);
+    EXPECT_EQ(itr->get<uint64_t>().second, reference_value);
+    EXPECT_EQ(itr->as_string(), std::to_string(reference_value));
+
+    itr->set("3");
+    EXPECT_EQ(reference_value, 3);
+    EXPECT_TRUE(itr->get(_tmp));
+    EXPECT_EQ(_tmp, reference_value);
+    EXPECT_EQ(itr->get<uint64_t>().second, reference_value);
+    EXPECT_EQ(itr->as_string(), std::to_string(reference_value));
+
+    auto citr = itr->clone();
+    EXPECT_EQ(citr->get<uint64_t>().second, reference_value);
+    EXPECT_EQ(citr->as_string(), std::to_string(reference_value));
+
+    reference_value = 2;
+    EXPECT_NE(reference_value, citr->get<uint64_t>().second);
+    EXPECT_TRUE(itr->get(_tmp));
+    EXPECT_EQ(_tmp, reference_value);
+    EXPECT_EQ(itr->get<uint64_t>().second, reference_value);
+    EXPECT_EQ(itr->as_string(), std::to_string(reference_value));
+    EXPECT_NE(citr->get<uint64_t>().second, reference_value);
+    EXPECT_NE(citr->as_string(), std::to_string(reference_value));
+
+    citr->set<uint64_t>(1);
+    copied_value = citr->get<uint64_t>().second;
+    EXPECT_TRUE(citr->get(_tmp));
+    EXPECT_EQ(reference_value, 2);
+    EXPECT_EQ(citr->get<uint64_t>().second, 1);
+    EXPECT_EQ(copied_value, 1);
+    EXPECT_EQ(_tmp, 1);
+    EXPECT_EQ(_tmp, copied_value);
+    EXPECT_EQ(citr->as_string(), std::to_string(copied_value));
+}
+
+//--------------------------------------------------------------------------------------//
+
+TEST_F(settings_tests, insert_via_pointer)
+{
+    using settings_t = tim::settings;
+    using strvec_t   = std::vector<std::string>;
+
+    reference_value = 10;
+    copied_value    = 10;
+
+    settings_t* _settings = settings_t::instance();
+
+    std::string _ref_env  = "SETTINGS_TEST_COPY";
+    std::string _ref_name = "test_copy";
+    std::string _ref_cmd  = "--test-copy";
+    std::string _ref_desc =
+        TIMEMORY_JOIN("", "Copied value for settings_tests.", details::get_test_name());
+
+    auto _ptr = std::make_shared<tim::tsettings<uint64_t>>(
+        reference_value, _ref_name, _ref_env, _ref_desc, strvec_t({ _ref_cmd }), 1, -2);
+    auto _ins = _settings->insert(_ptr);
+
+    EXPECT_TRUE(_ins.second);
+
+    auto tidx_check = std::type_index(typeid(uint64_t));
+    auto vidx_check = std::type_index(typeid(uint64_t));
+    auto _env_check = tim::get_env<uint64_t>(_ref_env, 0);
+    auto _odr_check = _settings->ordering().back();
+    auto _itr_check = _settings->find(_ref_env);
+
+    EXPECT_EQ(_env_check, reference_value);
+    EXPECT_EQ(_odr_check, _ref_env);
+    ASSERT_NE(_itr_check, _settings->end());
+    EXPECT_EQ(_itr_check->first, _ref_env);
+
+    auto itr = _itr_check->second;
+
+    EXPECT_EQ(itr->get_type_index(), tidx_check);
+    EXPECT_EQ(itr->get_value_index(), vidx_check);
+
+    EXPECT_EQ(itr->get_count(), 1);
+    EXPECT_EQ(itr->get_max_count(), -2);
+
+    EXPECT_EQ(itr->get_name(), _ref_name);
+    EXPECT_EQ(itr->get_env_name(), _ref_env);
+    EXPECT_EQ(itr->get_command_line().front(), _ref_cmd);
+
+    EXPECT_TRUE(itr->matches(_ref_env, true));
+    EXPECT_TRUE(itr->matches(_ref_name, true));
+    EXPECT_TRUE(itr->matches(_ref_cmd, true));
+
+    EXPECT_TRUE(itr->matches(_ref_env, false));
+    EXPECT_TRUE(itr->matches(_ref_name, false));
+    EXPECT_TRUE(itr->matches(_ref_cmd, false));
+
+    uint64_t _tmp = 0;
+    EXPECT_TRUE(itr->get(_tmp));
+    EXPECT_EQ(itr->get<uint64_t>().second, reference_value);
+    EXPECT_EQ(_tmp, reference_value);
+    EXPECT_EQ(itr->as_string(), std::to_string(reference_value));
+
+    auto _disp = itr->get_display();
+    EXPECT_EQ(_disp["name"], _ref_name);
+    EXPECT_EQ(_disp["count"], "1");
+    EXPECT_EQ(_disp["max_count"], "-2");
+    EXPECT_EQ(_disp["env_name"], _ref_env);
+    EXPECT_EQ(_disp["description"], _ref_desc);
+    EXPECT_EQ(_disp["command_line"], _ref_cmd);
+
+    reference_value = 5;
+    EXPECT_TRUE(itr->get(_tmp));
+    EXPECT_NE(_tmp, reference_value);
+    EXPECT_NE(itr->get<uint64_t>().second, reference_value);
+    EXPECT_NE(itr->as_string(), std::to_string(reference_value));
+
+    EXPECT_TRUE(itr->set<uint64_t>(2));
+    EXPECT_TRUE(itr->get(reference_value));
+    EXPECT_EQ(reference_value, 2);
+
+    auto citr = itr->clone();
+    EXPECT_EQ(citr->get<uint64_t>().second, reference_value);
+    EXPECT_EQ(citr->as_string(), std::to_string(reference_value));
+
+    EXPECT_TRUE(citr->set<uint64_t>(1));
+    EXPECT_NE(reference_value, citr->get<uint64_t>().second);
+
+    copied_value = citr->get<uint64_t>().second;
+    EXPECT_TRUE(citr->get(_tmp));
+    EXPECT_EQ(reference_value, 2);
+    EXPECT_EQ(citr->get<uint64_t>().second, 1);
+    EXPECT_EQ(copied_value, 1);
+    EXPECT_EQ(_tmp, 1);
+    EXPECT_EQ(_tmp, copied_value);
+    EXPECT_EQ(citr->as_string(), std::to_string(copied_value));
+}
+
+//--------------------------------------------------------------------------------------//

--- a/source/timemory/config/types.hpp
+++ b/source/timemory/config/types.hpp
@@ -38,6 +38,13 @@
 namespace tim
 {
 //
+struct settings;
+//
+namespace argparse
+{
+struct argument_parser;
+}
+//
 //--------------------------------------------------------------------------------------//
 //
 //                              config
@@ -66,9 +73,35 @@ timemory_init(int* argc, char*** argv, const std::string& _prefix = "timemory-",
 //
 //--------------------------------------------------------------------------------------//
 //
+void
+timemory_init(int* argc, char*** argv, argparse::argument_parser& parser,
+              const std::string& _prefix = "timemory-",
+              const std::string& _suffix = "-output");
+//
+//--------------------------------------------------------------------------------------//
+//
+void
+timemory_init(std::vector<std::string>&, argparse::argument_parser& parser,
+              const std::string& _prefix = "timemory-",
+              const std::string& _suffix = "-output");
+//
+//--------------------------------------------------------------------------------------//
+//
 /// finalization of the specified types
 void
 timemory_finalize();
+//
+//--------------------------------------------------------------------------------------//
+//
+void
+timemory_argparse(int* argc, char*** argv, argparse::argument_parser* parser = nullptr,
+                  settings* _settings = nullptr);
+//
+//--------------------------------------------------------------------------------------//
+//
+void
+timemory_argparse(std::vector<std::string>&, argparse::argument_parser* parser = nullptr,
+                  settings* _settings = nullptr);
 //
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/data/stream.hpp
+++ b/source/timemory/data/stream.hpp
@@ -22,8 +22,8 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-/** \file utility/stream.hpp
- * \headerfile utility/stream.hpp "timemory/utility/stream.hpp"
+/** \file data/stream.hpp
+ * \headerfile data/stream.hpp "timemory/data/stream.hpp"
  * Provides a simple stream type that generates a vector of strings for column alignment
  *
  */
@@ -46,7 +46,7 @@
 
 namespace tim
 {
-namespace utility
+namespace data
 {
 namespace base
 {
@@ -959,6 +959,35 @@ write_entry(stream& _os, const std::vector<std::string>& _labels,
 
 //--------------------------------------------------------------------------------------//
 
+}  // namespace data
+
+//--------------------------------------------------------------------------------------//
+namespace utility
+{
+//
+// backwards-compatibility
+//
+using entry  = data::entry;
+using header = data::header;
+using stream = data::stream;
+//
+template <typename Tp>
+using header_stream = data::header_stream<Tp>;
+//
+template <typename... Args>
+auto
+write_header(Args&&... args)
+{
+    return data::write_header(std::forward<Args>(args)...);
+}
+//
+template <typename... Args>
+auto
+write_entry(Args&&... args)
+{
+    return data::write_entry(std::forward<Args>(args)...);
+}
+//
 }  // namespace utility
 
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/operations/types.hpp
+++ b/source/timemory/operations/types.hpp
@@ -80,11 +80,15 @@ struct basic_tree;
 //
 //--------------------------------------------------------------------------------------//
 //
-namespace utility
+namespace data
 {
 struct stream;
 }
 //
+namespace utility
+{
+using stream = data::stream;
+}
 //--------------------------------------------------------------------------------------//
 //
 template <typename T>
@@ -575,6 +579,10 @@ struct print
     using this_type   = print;
     using stream_type = std::shared_ptr<utility::stream>;
 
+    explicit print(bool _forced_json = false)
+    : json_forced(_forced_json)
+    {}
+
     print(const std::string& _label, bool _forced_json)
     : json_forced(_forced_json)
     , label(_label)
@@ -679,6 +687,8 @@ struct print<Tp, true> : public base::print
         static callback_type _instance = [](this_type*) {};
         return _instance;
     }
+
+    explicit print(storage_type* _data);
 
     print(const std::string& _label, storage_type* _data)
     : base_type(_label, trait::requires_json<Tp>::value)
@@ -803,11 +813,9 @@ protected:
 template <typename Tp>
 struct print<Tp, false> : base::print
 {
-    static constexpr bool has_data = false;
-    using this_type                = print<Tp, has_data>;
-    using storage_type             = impl::storage<Tp, has_data>;
-
-    print(storage_type&);
+    template <typename... Args>
+    print(Args&&...)
+    {}
 };
 //
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/settings/settings.cpp
+++ b/source/timemory/settings/settings.cpp
@@ -774,19 +774,19 @@ settings::initialize_roofline()
     TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         string_t, roofline_mode, "TIMEMORY_ROOFLINE_MODE",
         "Configure the roofline collection mode. Options: 'op' 'ai'.", "op",
-        strvector_t({ "--timemory-roofline-mode" }), 1);
+        strvector_t({ "--timemory-roofline-mode" }), 1, 1, strvector_t({ "op", "ai" }));
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         string_t, cpu_roofline_mode, "TIMEMORY_ROOFLINE_MODE_CPU",
         "Configure the roofline collection mode for CPU specifically. Options: 'op' "
         "'ai'",
-        get<string_t>("roofline_mode"));
+        static_cast<tsettings<string_t>*>(m_data["TIMEMORY_ROOFLINE_MODE"].get())->get());
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         string_t, gpu_roofline_mode, "TIMEMORY_ROOFLINE_MODE_GPU",
         "Configure the roofline collection mode for GPU specifically. Options: 'op' "
         "'ai'.",
-        get<string_t>("roofline_mode"));
+        static_cast<tsettings<string_t>*>(m_data["TIMEMORY_ROOFLINE_MODE"].get())->get());
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         string_t, cpu_roofline_events, "TIMEMORY_ROOFLINE_EVENTS_CPU",

--- a/source/timemory/settings/settings.cpp
+++ b/source/timemory/settings/settings.cpp
@@ -337,522 +337,651 @@ settings::operator=(const settings& rhs)
 //
 TIMEMORY_SETTINGS_INLINE
 void
-settings::initialize()
+settings::initialize_core()
 {
     auto homedir = get_env<string_t>("HOME");
+
     TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         string_t, config_file, "TIMEMORY_CONFIG_FILE", "Configuration file for timemory",
         TIMEMORY_JOIN(';', TIMEMORY_JOIN('/', homedir, ".timemory.cfg"),
                       TIMEMORY_JOIN('/', homedir, ".timemory.json"),
                       TIMEMORY_JOIN('/', homedir, ".config", "timemory.cfg"),
                       TIMEMORY_JOIN('/', homedir, ".config", "timemory.json")),
-        strvector_t({ "-C", "--timemory-config" }))
+        strvector_t({ "-C", "--timemory-config" }));
 
-    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, suppress_config, "TIMEMORY_SUPPRESS_CONFIG",
-                                      "Disable processing of setting configuration files",
-                                      false, strvector_t({ "--timemory-no-config" }))
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        bool, suppress_config, "TIMEMORY_SUPPRESS_CONFIG",
+        "Disable processing of setting configuration files", false,
+        strvector_t({ "--timemory-suppress-config", "--timemory-no-config" }));
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, suppress_parsing, "TIMEMORY_SUPPRESS_PARSING",
+                                      "Disable parsing environment", false,
+                                      strvector_t({ "--timemory-suppress-parsing" }), -1,
+                                      1);
 
     TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         bool, enabled, "TIMEMORY_ENABLED", "Activation state of timemory",
-        TIMEMORY_DEFAULT_ENABLED, strvector_t({ "--timemory-enabled" }))
+        TIMEMORY_DEFAULT_ENABLED, strvector_t({ "--timemory-enabled" }), -1, 1);
 
     TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(int, verbose, "TIMEMORY_VERBOSE", "Verbosity level",
-                                      0, strvector_t({ "--timemory-verbose" }), 1)
+                                      0, strvector_t({ "--timemory-verbose" }), 1);
 
     TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, debug, "TIMEMORY_DEBUG",
                                       "Enable debug output", false,
-                                      strvector_t({ "--timemory-debug" }))
-
-    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, auto_output, "TIMEMORY_AUTO_OUTPUT",
-                                      "Generate output at application termination", true,
-                                      strvector_t({ "--timemory-auto-output" }))
-
-    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, cout_output, "TIMEMORY_COUT_OUTPUT",
-                                      "Write output to stdout", true,
-                                      strvector_t({ "--timemory-cout-output" }))
-
-    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, file_output, "TIMEMORY_FILE_OUTPUT",
-                                      "Write output to files", true,
-                                      strvector_t({ "--timemory-file-output" }))
-
-    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, text_output, "TIMEMORY_TEXT_OUTPUT",
-                                      "Write text output files", true,
-                                      strvector_t({ "--timemory-text-output" }))
-
-    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, json_output, "TIMEMORY_JSON_OUTPUT",
-                                      "Write json output files", true,
-                                      strvector_t({ "--timemory-json-output" }))
-
-    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, dart_output, "TIMEMORY_DART_OUTPUT",
-                                      "Write dart measurements for CDash", false,
-                                      strvector_t({ "--timemory-dart-output" }))
-
-    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
-        bool, time_output, "TIMEMORY_TIME_OUTPUT",
-        "Output data to subfolder w/ a timestamp (see also: TIMEMORY_TIME_FORMAT)", false,
-        strvector_t({ "--timemory-time-output" }))
-
-    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, plot_output, "TIMEMORY_PLOT_OUTPUT",
-                                      "Generate plot outputs from json outputs",
-                                      TIMEMORY_DEFAULT_PLOTTING,
-                                      strvector_t({ "--timemory-plot-output" }))
-
-    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
-        bool, diff_output, "TIMEMORY_DIFF_OUTPUT",
-        "Generate a difference output vs. a pre-existing output (see also: "
-        "TIMEMORY_INPUT_PATH and TIMEMORY_INPUT_PREFIX)",
-        false, strvector_t({ "--timemory-diff-output" }))
-
-    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
-        bool, flamegraph_output, "TIMEMORY_FLAMEGRAPH_OUTPUT",
-        "Write a json output for flamegraph visualization (use chrome://tracing)", true,
-        strvector_t({ "--timemory-flamegraph-output" }))
-
-    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, ctest_notes, "TIMEMORY_CTEST_NOTES",
-                                      "Write a CTestNotes.txt for each text output",
-                                      false, strvector_t({ "--timemory-ctest-notes" }))
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(bool, banner, "TIMEMORY_BANNER",
-                                  "Notify about tim::manager creation and destruction",
-                                  (get_env<bool>("TIMEMORY_LIBRARY_CTOR", false)))
+                                      strvector_t({ "--timemory-debug" }), -1, 1);
 
     TIMEMORY_SETTINGS_REFERENCE_ARG_IMPL(
         bool, flat_profile, "TIMEMORY_FLAT_PROFILE",
         "Set the label hierarchy mode to default to flat",
         scope::get_fields()[scope::flat::value],
-        strvector_t({ "--timemory-flat-profile" }))
+        strvector_t({ "--timemory-flat-profile" }), -1, 1);
 
     TIMEMORY_SETTINGS_REFERENCE_ARG_IMPL(
         bool, timeline_profile, "TIMEMORY_TIMELINE_PROFILE",
         "Set the label hierarchy mode to default to timeline",
         scope::get_fields()[scope::timeline::value],
-        strvector_t({ "--timemory-timeline-profile" }))
+        strvector_t({ "--timemory-timeline-profile" }), -1, 1);
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(bool, collapse_threads, "TIMEMORY_COLLAPSE_THREADS",
-                                  "Enable/disable combining thread-specific data", true)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(bool, collapse_processes, "TIMEMORY_COLLAPSE_PROCESSES",
-                                  "Enable/disable combining process-specific data", true)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(uint16_t, max_depth, "TIMEMORY_MAX_DEPTH",
-                                  "Set the maximum depth of label hierarchy reporting",
-                                  std::numeric_limits<uint16_t>::max())
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        string_t, time_format, "TIMEMORY_TIME_FORMAT",
-        "Customize the folder generation when TIMEMORY_TIME_OUTPUT is enabled (see also: "
-        "strftime)",
-        "%F_%I.%M_%p")
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(int16_t, precision, "TIMEMORY_PRECISION",
-                                  "Set the global output precision for components", -1)
-    TIMEMORY_SETTINGS_MEMBER_IMPL(int16_t, width, "TIMEMORY_WIDTH",
-                                  "Set the global output width for components", -1)
-    TIMEMORY_SETTINGS_MEMBER_IMPL(int32_t, max_width, "TIMEMORY_MAX_WIDTH",
-                                  "Set the maximum width for component label outputs",
-                                  120)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        bool, scientific, "TIMEMORY_SCIENTIFIC",
-        "Set the global numerical reporting to scientific format", false)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        int16_t, timing_precision, "TIMEMORY_TIMING_PRECISION",
-        "Set the precision for components with 'is_timing_category' type-trait", -1)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        int16_t, timing_width, "TIMEMORY_TIMING_WIDTH",
-        "Set the output width for components with 'is_timing_category' type-trait", -1)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        string_t, timing_units, "TIMEMORY_TIMING_UNITS",
-        "Set the units for components with 'uses_timing_units' type-trait", "")
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(bool, timing_scientific, "TIMEMORY_TIMING_SCIENTIFIC",
-                                  "Set the numerical reporting format for components "
-                                  "with 'is_timing_category' type-trait",
-                                  false)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        int16_t, memory_precision, "TIMEMORY_MEMORY_PRECISION",
-        "Set the precision for components with 'is_memory_category' type-trait", -1)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        int16_t, memory_width, "TIMEMORY_MEMORY_WIDTH",
-        "Set the output width for components with 'is_memory_category' type-trait", -1)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        string_t, memory_units, "TIMEMORY_MEMORY_UNITS",
-        "Set the units for components with 'uses_memory_units' type-trait", "")
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(bool, memory_scientific, "TIMEMORY_MEMORY_SCIENTIFIC",
-                                  "Set the numerical reporting format for components "
-                                  "with 'is_memory_category' type-trait",
-                                  false)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(string_t, output_path, "TIMEMORY_OUTPUT_PATH",
-                                  "Explicitly specify the output folder for results",
-                                  "timemory-output")  // folder
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(string_t, output_prefix, "TIMEMORY_OUTPUT_PREFIX",
-                                  "Explicitly specify a prefix for all output files",
-                                  "")  // file prefix
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(string_t, input_path, "TIMEMORY_INPUT_PATH",
-                                  "Explicitly specify the input folder for difference "
-                                  "comparisons (see also: TIMEMORY_DIFF_OUTPUT)",
-                                  "")  // folder
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        string_t, input_prefix, "TIMEMORY_INPUT_PREFIX",
-        "Explicitly specify the prefix for input files used in difference comparisons "
-        "(see also: TIMEMORY_DIFF_OUTPUT)",
-        "")  // file prefix
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        string_t, input_extensions, "TIMEMORY_INPUT_EXTENSIONS",
-        "File extensions used when searching for input files used in difference "
-        "comparisons (see also: TIMEMORY_DIFF_OUTPUT)",
-        "json,xml")  // extensions
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        string_t, dart_type, "TIMEMORY_DART_TYPE",
-        "Only echo this measurement type (see also: TIMEMORY_DART_OUTPUT)", "")
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        uint64_t, dart_count, "TIMEMORY_DART_COUNT",
-        "Only echo this number of dart tags (see also: TIMEMORY_DART_OUTPUT)", 1)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        bool, dart_label, "TIMEMORY_DART_LABEL",
-        "Echo the category instead of the label (see also: TIMEMORY_DART_OUTPUT)", true)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        size_t, max_thread_bookmarks, "TIMEMORY_MAX_THREAD_BOOKMARKS",
-        "Maximum number of times a worker thread bookmarks the call-graph location w.r.t."
-        " the master thread. Higher values tend to increase the finalization merge time",
-        50)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(bool, cpu_affinity, "TIMEMORY_CPU_AFFINITY",
-                                  "Enable pinning threads to CPUs (Linux-only)", false)
-
-    TIMEMORY_SETTINGS_REFERENCE_IMPL(process::id_t, target_pid, "TIMEMORY_TARGET_PID",
-                                     "Process ID for the components which require this",
-                                     process::get_target_id());
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        bool, stack_clearing, "TIMEMORY_STACK_CLEARING",
-        "Enable/disable stopping any markers still running during finalization", true)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        bool, add_secondary, "TIMEMORY_ADD_SECONDARY",
-        "Enable/disable components adding secondary (child) entries", true)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(size_t, throttle_count, "TIMEMORY_THROTTLE_COUNT",
-                                  "Minimum number of laps before throttling", 10000)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        size_t, throttle_value, "TIMEMORY_THROTTLE_VALUE",
-        "Average call time in nanoseconds when # laps > throttle_count that triggers "
-        "throttling",
-        10000)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        uint16_t, max_depth, "TIMEMORY_MAX_DEPTH",
+        "Set the maximum depth of label hierarchy reporting",
+        std::numeric_limits<uint16_t>::max(), strvector_t({ "--timemory-max-depth" }), 1);
+}
+//
+//--------------------------------------------------------------------------------------//
+//
+TIMEMORY_SETTINGS_INLINE
+void
+settings::initialize_components()
+{
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         string_t, global_components, "TIMEMORY_GLOBAL_COMPONENTS",
         "A specification of components which is used by multiple variadic bundlers and "
         "user_bundles as the fall-back set of components if their specific variable is "
         "not set. E.g. user_mpip_bundle will use this if TIMEMORY_MPIP_COMPONENTS is not "
         "specified",
-        "")
+        "", strvector_t({ "--timemory-global-components" }));
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         string_t, tuple_components, "TIMEMORY_TUPLE_COMPONENTS",
         "A specification of components which will be added to component_tuple structures "
         "containing the 'user_tuple_bundle'. These components will automatically be "
         "activated",
-        "")
+        "", strvector_t({ "--timemory-tuple-components" }));
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         string_t, list_components, "TIMEMORY_LIST_COMPONENTS",
         "A specification of components which will be added to component_list structures "
         "containing the 'user_list_bundle'. These components will only be activated if "
         "the 'user_list_bundle' is activated.",
-        "")
+        "", strvector_t({ "--timemory-list-components" }));
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         string_t, ompt_components, "TIMEMORY_OMPT_COMPONENTS",
         "A specification of components which will be added "
         "to structures containing the 'user_ompt_bundle'. Priority: TRACE_COMPONENTS -> "
         "PROFILER_COMPONENTS -> COMPONENTS -> GLOBAL_COMPONENTS",
-        "")
+        "", strvector_t({ "--timemory-ompt-components" }));
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         string_t, mpip_components, "TIMEMORY_MPIP_COMPONENTS",
         "A specification of components which will be added "
         "to structures containing the 'user_mpip_bundle'. Priority: TRACE_COMPONENTS -> "
         "PROFILER_COMPONENTS -> COMPONENTS -> GLOBAL_COMPONENTS",
-        "")
+        "", strvector_t({ "--timemory-mpip-components" }));
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         string_t, ncclp_components, "TIMEMORY_NCCLP_COMPONENTS",
         "A specification of components which will be added "
         "to structures containing the 'user_ncclp_bundle'. Priority: MPIP_COMPONENTS -> "
         "TRACE_COMPONENTS -> PROFILER_COMPONENTS -> COMPONENTS -> GLOBAL_COMPONENTS",
-        "")
+        "", strvector_t({ "--timemory-ncclp-components" }));
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         string_t, trace_components, "TIMEMORY_TRACE_COMPONENTS",
         "A specification of components which will be used by the interfaces which are "
         "designed for full profiling. These components will be subjected to throttling. "
         "Priority: COMPONENTS -> GLOBAL_COMPONENTS",
-        "")
+        "", strvector_t({ "--timemory-trace-components" }));
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         string_t, profiler_components, "TIMEMORY_PROFILER_COMPONENTS",
         "A specification of components which will be used by the interfaces which are "
         "designed for full python profiling. This specification will be overridden by a "
         "trace_components specification. Priority: COMPONENTS -> GLOBAL_COMPONENTS",
-        "")
+        "", strvector_t({ "--timemory-profiler-components" }));
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         string_t, components, "TIMEMORY_COMPONENTS",
         "A specification of components which is used by the library interface. This "
         "falls back to TIMEMORY_GLOBAL_COMPONENTS.",
-        "")
+        "", strvector_t({ "--timemory-components" }));
+}
+//
+//--------------------------------------------------------------------------------------//
+//
+TIMEMORY_SETTINGS_INLINE
+void
+settings::initialize_io()
+{
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, auto_output, "TIMEMORY_AUTO_OUTPUT",
+                                      "Generate output at application termination", true,
+                                      strvector_t({ "--timemory-auto-output" }), -1, 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, cout_output, "TIMEMORY_COUT_OUTPUT",
+                                      "Write output to stdout", true,
+                                      strvector_t({ "--timemory-cout-output" }), -1, 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, file_output, "TIMEMORY_FILE_OUTPUT",
+                                      "Write output to files", true,
+                                      strvector_t({ "--timemory-file-output" }), -1, 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, text_output, "TIMEMORY_TEXT_OUTPUT",
+                                      "Write text output files", true,
+                                      strvector_t({ "--timemory-text-output" }), -1, 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, json_output, "TIMEMORY_JSON_OUTPUT",
+                                      "Write json output files", true,
+                                      strvector_t({ "--timemory-json-output" }), -1, 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, dart_output, "TIMEMORY_DART_OUTPUT",
+                                      "Write dart measurements for CDash", false,
+                                      strvector_t({ "--timemory-dart-output" }), -1, 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        bool, time_output, "TIMEMORY_TIME_OUTPUT",
+        "Output data to subfolder w/ a timestamp (see also: TIMEMORY_TIME_FORMAT)", false,
+        strvector_t({ "--timemory-time-output" }), -1, 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, plot_output, "TIMEMORY_PLOT_OUTPUT",
+                                      "Generate plot outputs from json outputs",
+                                      TIMEMORY_DEFAULT_PLOTTING,
+                                      strvector_t({ "--timemory-plot-output" }), -1, 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        bool, diff_output, "TIMEMORY_DIFF_OUTPUT",
+        "Generate a difference output vs. a pre-existing output (see also: "
+        "TIMEMORY_INPUT_PATH and TIMEMORY_INPUT_PREFIX)",
+        false, strvector_t({ "--timemory-diff-output" }), -1, 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        bool, flamegraph_output, "TIMEMORY_FLAMEGRAPH_OUTPUT",
+        "Write a json output for flamegraph visualization (use chrome://tracing)", true,
+        strvector_t({ "--timemory-flamegraph-output" }), -1, 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, ctest_notes, "TIMEMORY_CTEST_NOTES",
+                                      "Write a CTestNotes.txt for each text output",
+                                      false, strvector_t({ "--timemory-ctest-notes" }),
+                                      -1, 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        string_t, output_path, "TIMEMORY_OUTPUT_PATH",
+        "Explicitly specify the output folder for results", "timemory-output",
+        strvector_t({ "--timemory-output-path" }), 1);  // folder
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(string_t, output_prefix, "TIMEMORY_OUTPUT_PREFIX",
+                                      "Explicitly specify a prefix for all output files",
+                                      "", strvector_t({ "--timemory-output-prefix" }),
+                                      1);  // file prefix
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        string_t, input_path, "TIMEMORY_INPUT_PATH",
+        "Explicitly specify the input folder for difference "
+        "comparisons (see also: TIMEMORY_DIFF_OUTPUT)",
+        "", strvector_t({ "--timemory-input-path" }), 1);  // folder
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        string_t, input_prefix, "TIMEMORY_INPUT_PREFIX",
+        "Explicitly specify the prefix for input files used in difference comparisons "
+        "(see also: TIMEMORY_DIFF_OUTPUT)",
+        "", strvector_t({ "--timemory-input-prefix" }), 1);  // file prefix
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        string_t, input_extensions, "TIMEMORY_INPUT_EXTENSIONS",
+        "File extensions used when searching for input files used in difference "
+        "comparisons (see also: TIMEMORY_DIFF_OUTPUT)",
+        "json,xml", strvector_t({ "--timemory-input-extensions" }));  // extensions
+}
+//
+//--------------------------------------------------------------------------------------//
+//
+TIMEMORY_SETTINGS_INLINE
+void
+settings::initialize_format()
+{
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        string_t, time_format, "TIMEMORY_TIME_FORMAT",
+        "Customize the folder generation when TIMEMORY_TIME_OUTPUT is enabled (see also: "
+        "strftime)",
+        "%F_%I.%M_%p", strvector_t({ "--timemory-time-format" }), 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(int16_t, precision, "TIMEMORY_PRECISION",
+                                      "Set the global output precision for components",
+                                      -1, strvector_t({ "--timemory-precision" }), 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(int16_t, width, "TIMEMORY_WIDTH",
+                                      "Set the global output width for components", -1,
+                                      strvector_t({ "--timemory-width" }), 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(int32_t, max_width, "TIMEMORY_MAX_WIDTH",
+                                      "Set the maximum width for component label outputs",
+                                      120, strvector_t({ "--timemory-max-width" }), 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        bool, scientific, "TIMEMORY_SCIENTIFIC",
+        "Set the global numerical reporting to scientific format", false,
+        strvector_t({ "--timemory-scientific" }), -1, 1);
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
+        int16_t, timing_precision, "TIMEMORY_TIMING_PRECISION",
+        "Set the precision for components with 'is_timing_category' type-trait", -1);
+
+    TIMEMORY_SETTINGS_MEMBER_IMPL(
+        int16_t, timing_width, "TIMEMORY_TIMING_WIDTH",
+        "Set the output width for components with 'is_timing_category' type-trait", -1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        string_t, timing_units, "TIMEMORY_TIMING_UNITS",
+        "Set the units for components with 'uses_timing_units' type-trait", "",
+        strvector_t({ "--timemory-timing-units" }), 1);
+
+    TIMEMORY_SETTINGS_MEMBER_IMPL(bool, timing_scientific, "TIMEMORY_TIMING_SCIENTIFIC",
+                                  "Set the numerical reporting format for components "
+                                  "with 'is_timing_category' type-trait",
+                                  false);
+
+    TIMEMORY_SETTINGS_MEMBER_IMPL(
+        int16_t, memory_precision, "TIMEMORY_MEMORY_PRECISION",
+        "Set the precision for components with 'is_memory_category' type-trait", -1);
+
+    TIMEMORY_SETTINGS_MEMBER_IMPL(
+        int16_t, memory_width, "TIMEMORY_MEMORY_WIDTH",
+        "Set the output width for components with 'is_memory_category' type-trait", -1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        string_t, memory_units, "TIMEMORY_MEMORY_UNITS",
+        "Set the units for components with 'uses_memory_units' type-trait", "",
+        strvector_t({ "--timemory-memory-units" }), 1);
+
+    TIMEMORY_SETTINGS_MEMBER_IMPL(bool, memory_scientific, "TIMEMORY_MEMORY_SCIENTIFIC",
+                                  "Set the numerical reporting format for components "
+                                  "with 'is_memory_category' type-trait",
+                                  false);
+
+    TIMEMORY_SETTINGS_MEMBER_IMPL(int64_t, separator_frequency, "TIMEMORY_SEPARATOR_FREQ",
+                                  "Frequency of dashed separator lines in text output",
+                                  0);
+}
+//
+//--------------------------------------------------------------------------------------//
+//
+TIMEMORY_SETTINGS_INLINE
+void
+settings::initialize_parallel()
+{
+    TIMEMORY_SETTINGS_MEMBER_IMPL(
+        size_t, max_thread_bookmarks, "TIMEMORY_MAX_THREAD_BOOKMARKS",
+        "Maximum number of times a worker thread bookmarks the call-graph location w.r.t."
+        " the master thread. Higher values tend to increase the finalization merge time",
+        50);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        bool, collapse_threads, "TIMEMORY_COLLAPSE_THREADS",
+        "Enable/disable combining thread-specific data", true,
+        strvector_t({ "--timemory-collapse-threads" }), -1, 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        bool, collapse_processes, "TIMEMORY_COLLAPSE_PROCESSES",
+        "Enable/disable combining process-specific data", true,
+        strvector_t({ "--timemory-collapse-processes" }), -1, 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(bool, cpu_affinity, "TIMEMORY_CPU_AFFINITY",
+                                      "Enable pinning threads to CPUs (Linux-only)",
+                                      false, strvector_t({ "--timemory-cpu-affinity" }),
+                                      -1, 1);
+
+    TIMEMORY_SETTINGS_REFERENCE_IMPL(process::id_t, target_pid, "TIMEMORY_TARGET_PID",
+                                     "Process ID for the components which require this",
+                                     process::get_target_id());
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         bool, mpi_init, "TIMEMORY_MPI_INIT",
         "Enable/disable timemory calling MPI_Init / MPI_Init_thread during certain "
         "timemory_init(...) invocations",
-        false)
+        false, strvector_t({ "--timemory-mpi-init" }), -1, 1);
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(bool, mpi_finalize, "TIMEMORY_MPI_FINALIZE",
-                                  "Enable/disable timemory calling MPI_Finalize during "
-                                  "timemory_finalize(...) invocations",
-                                  false)
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        bool, mpi_finalize, "TIMEMORY_MPI_FINALIZE",
+        "Enable/disable timemory calling MPI_Finalize during "
+        "timemory_finalize(...) invocations",
+        false, strvector_t({ "--timemory-mpi-finalize" }), -1, 1);
 
-    TIMEMORY_SETTINGS_REFERENCE_IMPL(
+    TIMEMORY_SETTINGS_REFERENCE_ARG_IMPL(
         bool, mpi_thread, "TIMEMORY_MPI_THREAD",
         "Call MPI_Init_thread instead of MPI_Init (see also: TIMEMORY_MPI_INIT)",
-        mpi::use_mpi_thread())
+        mpi::use_mpi_thread(), strvector_t({ "--timemory-mpi-thread" }), -1, 1);
 
-    TIMEMORY_SETTINGS_REFERENCE_IMPL(string_t, mpi_thread_type,
-                                     "TIMEMORY_MPI_THREAD_TYPE",
-                                     "MPI_Init_thread mode: 'single', 'serialized', "
-                                     "'funneled', or 'multiple' (see also: "
-                                     "TIMEMORY_MPI_INIT and TIMEMORY_MPI_THREAD)",
-                                     mpi::use_mpi_thread_type())
+    TIMEMORY_SETTINGS_REFERENCE_ARG_IMPL(
+        string_t, mpi_thread_type, "TIMEMORY_MPI_THREAD_TYPE",
+        "MPI_Init_thread mode: 'single', 'serialized', "
+        "'funneled', or 'multiple' (see also: "
+        "TIMEMORY_MPI_INIT and TIMEMORY_MPI_THREAD)",
+        mpi::use_mpi_thread_type(), strvector_t({ "--timemory-mpi-thread-type" }), 1);
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         bool, upcxx_init, "TIMEMORY_UPCXX_INIT",
         "Enable/disable timemory calling upcxx::init() during certain "
         "timemory_init(...) invocations",
-        false)
+        false, strvector_t({ "--timemory-upcxx-init" }), -1, 1);
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         bool, upcxx_finalize, "TIMEMORY_UPCXX_FINALIZE",
         "Enable/disable timemory calling upcxx::finalize() during "
         "timemory_finalize()",
-        false)
+        false, strvector_t({ "--timemory-upcxx-finalize" }), -1, 1);
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(bool, papi_multiplexing, "TIMEMORY_PAPI_MULTIPLEXING",
-                                  "Enable multiplexing when using PAPI", true)
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        int32_t, node_count, "TIMEMORY_NODE_COUNT",
+        "Total number of nodes used in application. Setting this value > 1 will result "
+        "in aggregating N processes into groups of N / NODE_COUNT",
+        0, strvector_t({ "--timemory-node-count" }), 1);
+}
+//
+//--------------------------------------------------------------------------------------//
+//
+TIMEMORY_SETTINGS_INLINE
+void
+settings::initialize_tpls()
+{
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        bool, papi_multiplexing, "TIMEMORY_PAPI_MULTIPLEXING",
+        "Enable multiplexing when using PAPI", true,
+        strvector_t({ "--timemory-papi-multiplexing" }), -1, 1);
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(bool, papi_fail_on_error, "TIMEMORY_PAPI_FAIL_ON_ERROR",
-                                  "Configure PAPI errors to trigger a runtime error",
-                                  false)
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        bool, papi_fail_on_error, "TIMEMORY_PAPI_FAIL_ON_ERROR",
+        "Configure PAPI errors to trigger a runtime error", false,
+        strvector_t({ "--timemory-papi-fail-on-error" }), -1, 1);
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         bool, papi_quiet, "TIMEMORY_PAPI_QUIET",
-        "Configure suppression of reporting PAPI errors/warnings", false)
+        "Configure suppression of reporting PAPI errors/warnings", false,
+        strvector_t({ "--timemory-papi-quiet" }), -1, 1);
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         string_t, papi_events, "TIMEMORY_PAPI_EVENTS",
-        "PAPI presets and events to collect (see also: papi_avail)", "")
+        "PAPI presets and events to collect (see also: papi_avail)", "",
+        strvector_t({ "--timemory-papi-events" }));
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         bool, papi_attach, "TIMEMORY_PAPI_ATTACH",
         "Configure PAPI to attach to another process (see also: TIMEMORY_TARGET_PID)",
-        false)
+        false);
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         int, papi_overflow, "TIMEMORY_PAPI_OVERFLOW",
-        "Value at which PAPI hw counters trigger an overflow callback", 0)
+        "Value at which PAPI hw counters trigger an overflow callback", 0,
+        strvector_t({ "--timemory-papi-overflow" }), 1);
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         uint64_t, cuda_event_batch_size, "TIMEMORY_CUDA_EVENT_BATCH_SIZE",
-        "Batch size for create cudaEvent_t in cuda_event components", 5)
+        "Batch size for create cudaEvent_t in cuda_event components", 5);
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         bool, nvtx_marker_device_sync, "TIMEMORY_NVTX_MARKER_DEVICE_SYNC",
-        "Use cudaDeviceSync when stopping NVTX marker (vs. cudaStreamSychronize)", true)
+        "Use cudaDeviceSync when stopping NVTX marker (vs. cudaStreamSychronize)", true);
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         int32_t, cupti_activity_level, "TIMEMORY_CUPTI_ACTIVITY_LEVEL",
-        "Default group of kinds tracked via CUpti Activity API", 1)
+        "Default group of kinds tracked via CUpti Activity API", 1,
+        strvector_t({ "--timemory-cupti-activity-level" }), 1);
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(string_t, cupti_activity_kinds,
-                                  "TIMEMORY_CUPTI_ACTIVITY_KINDS",
-                                  "Specific cupti activity kinds to track", "")
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(string_t, cupti_activity_kinds,
+                                      "TIMEMORY_CUPTI_ACTIVITY_KINDS",
+                                      "Specific cupti activity kinds to track", "",
+                                      strvector_t({ "--timemory-cupti-activity-kinds" }));
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         string_t, cupti_events, "TIMEMORY_CUPTI_EVENTS",
-        "Hardware counter event types to collect on NVIDIA GPUs", "")
+        "Hardware counter event types to collect on NVIDIA GPUs", "",
+        strvector_t({ "--timemory-cupti-events" }));
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         string_t, cupti_metrics, "TIMEMORY_CUPTI_METRICS",
-        "Hardware counter metric types to collect on NVIDIA GPUs", "")
+        "Hardware counter metric types to collect on NVIDIA GPUs", "",
+        strvector_t({ "--timemory-cupti-metrics" }));
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(int, cupti_device, "TIMEMORY_CUPTI_DEVICE",
-                                  "Target device for CUPTI hw counter collection", 0)
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(int, cupti_device, "TIMEMORY_CUPTI_DEVICE",
+                                      "Target device for CUPTI hw counter collection", 0,
+                                      strvector_t({ "--timemory-cupti-device" }), 1);
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
+    TIMEMORY_SETTINGS_MEMBER_IMPL(string_t, craypat_categories, "TIMEMORY_CRAYPAT",
+                                  "Configure the CrayPAT categories to collect",
+                                  get_env<std::string>("PAT_RT_PERFCTR", ""))
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(string_t, python_exe, "TIMEMORY_PYTHON_EXE",
+                                      "Configure the python executable to use",
+                                      TIMEMORY_PYTHON_PLOTTER,
+                                      strvector_t({ "--timemory-python-exe" }));
+}
+//
+//--------------------------------------------------------------------------------------//
+//
+TIMEMORY_SETTINGS_INLINE
+void
+settings::initialize_roofline()
+{
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
         string_t, roofline_mode, "TIMEMORY_ROOFLINE_MODE",
-        "Configure the roofline collection mode. Options: 'op' 'ai'.", "op")
+        "Configure the roofline collection mode. Options: 'op' 'ai'.", "op",
+        strvector_t({ "--timemory-roofline-mode" }), 1);
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         string_t, cpu_roofline_mode, "TIMEMORY_ROOFLINE_MODE_CPU",
         "Configure the roofline collection mode for CPU specifically. Options: 'op' "
         "'ai'",
-        get<string_t>("roofline_mode"))
+        get<string_t>("roofline_mode"));
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         string_t, gpu_roofline_mode, "TIMEMORY_ROOFLINE_MODE_GPU",
         "Configure the roofline collection mode for GPU specifically. Options: 'op' "
         "'ai'.",
-        get<string_t>("roofline_mode"))
+        get<string_t>("roofline_mode"));
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         string_t, cpu_roofline_events, "TIMEMORY_ROOFLINE_EVENTS_CPU",
-        "Configure custom hw counters to add to the cpu roofline", "")
+        "Configure custom hw counters to add to the cpu roofline", "");
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         string_t, gpu_roofline_events, "TIMEMORY_ROOFLINE_EVENTS_GPU",
-        "Configure custom hw counters to add to the gpu roofline", "")
+        "Configure custom hw counters to add to the gpu roofline", "");
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(bool, roofline_type_labels,
                                   "TIMEMORY_ROOFLINE_TYPE_LABELS",
                                   "Configure roofline labels/descriptions/output-files "
                                   "encode the list of data types",
-                                  false)
+                                  false);
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         bool, roofline_type_labels_cpu, "TIMEMORY_ROOFLINE_TYPE_LABELS_CPU",
         "Configure labels, etc. for the roofline components "
         "for CPU (see also: TIMEMORY_ROOFLINE_TYPE_LABELS)",
         static_cast<tsettings<bool>*>(m_data["TIMEMORY_ROOFLINE_TYPE_LABELS"].get())
-            ->get())
+            ->get());
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         bool, roofline_type_labels_gpu, "TIMEMORY_ROOFLINE_TYPE_LABELS_GPU",
         "Configure labels, etc. for the roofline components "
         "for GPU (see also: TIMEMORY_ROOFLINE_TYPE_LABELS)",
         static_cast<tsettings<bool>*>(m_data["TIMEMORY_ROOFLINE_TYPE_LABELS"].get())
-            ->get())
+            ->get());
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(bool, instruction_roofline,
                                   "TIMEMORY_INSTRUCTION_ROOFLINE",
                                   "Configure the roofline to include the hw counters "
                                   "required for generating an instruction roofline",
-                                  false)
+                                  false);
+}
+//
+//--------------------------------------------------------------------------------------//
+//
+TIMEMORY_SETTINGS_INLINE void
+settings::initialize_miscellaneous()
+{
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        bool, add_secondary, "TIMEMORY_ADD_SECONDARY",
+        "Enable/disable components adding secondary (child) entries when available. E.g. "
+        "suppress individual CUDA kernels, etc. when using Cupti components",
+        true, strvector_t({ "--timemory-add-secondary" }), -1, 1);
 
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        size_t, throttle_count, "TIMEMORY_THROTTLE_COUNT",
+        "Minimum number of laps before checking whether a key should be throttled", 10000,
+        strvector_t({ "--timemory-throttle-count" }), 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        size_t, throttle_value, "TIMEMORY_THROTTLE_VALUE",
+        "Average call time in nanoseconds when # laps > throttle_count that triggers "
+        "throttling",
+        10000, strvector_t({ "--timemory-throttle-value" }), 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        bool, enable_signal_handler, "TIMEMORY_ENABLE_SIGNAL_HANDLER",
+        "Enable signals in timemory_init", false,
+        strvector_t({ "--timemory-enable-signal-handler" }), -1, 1)
+
+    TIMEMORY_SETTINGS_REFERENCE_ARG_IMPL(
+        bool, allow_signal_handler, "TIMEMORY_ALLOW_SIGNAL_HANDLER",
+        "Allow signal handling to be activated", signal_settings::allow(),
+        strvector_t({ "--timemory-allow-signal-handler" }), -1, 1);
+
+    TIMEMORY_SETTINGS_REFERENCE_IMPL(
+        bool, enable_all_signals, "TIMEMORY_ENABLE_ALL_SIGNALS",
+        "Enable catching all signals", signal_settings::enable_all());
+
+    TIMEMORY_SETTINGS_REFERENCE_IMPL(
+        bool, disable_all_signals, "TIMEMORY_DISABLE_ALL_SIGNALS",
+        "Disable catching any signals", signal_settings::disable_all());
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        bool, destructor_report, "TIMEMORY_DESTRUCTOR_REPORT",
+        "Configure default setting for auto_{list,tuple,hybrid} to write to stdout during"
+        " destruction of the bundle",
+        false, strvector_t({ "--timemory-destructor-report" }), -1, 1);
+
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        bool, stack_clearing, "TIMEMORY_STACK_CLEARING",
+        "Enable/disable stopping any markers still running during finalization", true,
+        strvector_t({ "--timemory-stack-clearing" }), -1, 1);
+
+    TIMEMORY_SETTINGS_MEMBER_IMPL(bool, banner, "TIMEMORY_BANNER",
+                                  "Notify about tim::manager creation and destruction",
+                                  (get_env<bool>("TIMEMORY_LIBRARY_CTOR", false)));
+}
+//
+//--------------------------------------------------------------------------------------//
+//
+TIMEMORY_SETTINGS_INLINE
+void
+settings::initialize_ert()
+{
     TIMEMORY_SETTINGS_MEMBER_IMPL(uint64_t, ert_num_threads, "TIMEMORY_ERT_NUM_THREADS",
-                                  "Number of threads to use when running ERT", 0)
+                                  "Number of threads to use when running ERT", 0);
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(uint64_t, ert_num_threads_cpu,
                                   "TIMEMORY_ERT_NUM_THREADS_CPU",
                                   "Number of threads to use when running ERT on CPU",
-                                  std::thread::hardware_concurrency())
+                                  std::thread::hardware_concurrency());
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         uint64_t, ert_num_threads_gpu, "TIMEMORY_ERT_NUM_THREADS_GPU",
-        "Number of threads which launch kernels when running ERT on the GPU", 1)
+        "Number of threads which launch kernels when running ERT on the GPU", 1);
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         uint64_t, ert_num_streams, "TIMEMORY_ERT_NUM_STREAMS",
-        "Number of streams to use when launching kernels in ERT on the GPU", 1)
+        "Number of streams to use when launching kernels in ERT on the GPU", 1);
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         uint64_t, ert_grid_size, "TIMEMORY_ERT_GRID_SIZE",
         "Configure the grid size (number of blocks) for ERT on GPU (0 == auto-compute)",
-        0)
+        0);
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         uint64_t, ert_block_size, "TIMEMORY_ERT_BLOCK_SIZE",
-        "Configure the block size (number of threads per block) for ERT on GPU", 1024)
+        "Configure the block size (number of threads per block) for ERT on GPU", 1024);
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         uint64_t, ert_alignment, "TIMEMORY_ERT_ALIGNMENT",
         "Configure the alignment (in bits) when running ERT on CPU (0 == 8 * sizeof(T))",
-        0)
+        0);
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         uint64_t, ert_min_working_size, "TIMEMORY_ERT_MIN_WORKING_SIZE",
-        "Configure the minimum working size when running ERT (0 == device specific)", 0)
+        "Configure the minimum working size when running ERT (0 == device specific)", 0);
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         uint64_t, ert_min_working_size_cpu, "TIMEMORY_ERT_MIN_WORKING_SIZE_CPU",
-        "Configure the minimum working size when running ERT on CPU", 64)
+        "Configure the minimum working size when running ERT on CPU", 64);
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         uint64_t, ert_min_working_size_gpu, "TIMEMORY_ERT_MIN_WORKING_SIZE_GPU",
-        "Configure the minimum working size when running ERT on GPU", 10 * 1000 * 1000)
+        "Configure the minimum working size when running ERT on GPU", 10 * 1000 * 1000);
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         uint64_t, ert_max_data_size, "TIMEMORY_ERT_MAX_DATA_SIZE",
-        "Configure the max data size when running ERT on CPU", 0)
+        "Configure the max data size when running ERT on CPU", 0);
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         uint64_t, ert_max_data_size_cpu, "TIMEMORY_ERT_MAX_DATA_SIZE_CPU",
-        "Configure the max data size when running ERT on CPU", 0)
+        "Configure the max data size when running ERT on CPU", 0);
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         uint64_t, ert_max_data_size_gpu, "TIMEMORY_ERT_MAX_DATA_SIZE_GPU",
-        "Configure the max data size when running ERT on GPU", 500 * 1000 * 1000)
+        "Configure the max data size when running ERT on GPU", 500 * 1000 * 1000);
 
     TIMEMORY_SETTINGS_MEMBER_IMPL(
         string_t, ert_skip_ops, "TIMEMORY_ERT_SKIP_OPS",
-        "Skip these number of ops (i.e. ERT_FLOPS) when were set at compile time", "")
+        "Skip these number of ops (i.e. ERT_FLOPS) when were set at compile time", "");
+}
+//
+//--------------------------------------------------------------------------------------//
+//
+TIMEMORY_SETTINGS_INLINE
+void
+settings::initialize_dart()
+{
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        string_t, dart_type, "TIMEMORY_DART_TYPE",
+        "Only echo this measurement type (see also: TIMEMORY_DART_OUTPUT)", "",
+        strvector_t({ "--timemory-dart-type" }));
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(string_t, craypat_categories, "TIMEMORY_CRAYPAT",
-                                  "Configure the CrayPAT categories to collect",
-                                  get_env<std::string>("PAT_RT_PERFCTR", ""))
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        uint64_t, dart_count, "TIMEMORY_DART_COUNT",
+        "Only echo this number of dart tags (see also: TIMEMORY_DART_OUTPUT)", 1,
+        strvector_t({ "--timemory-dart-count" }), 1);
 
-    TIMEMORY_SETTINGS_MEMBER_IMPL(bool, enable_signal_handler,
-                                  "TIMEMORY_ENABLE_SIGNAL_HANDLER",
-                                  "Enable signals in timemory_init", false)
-
-    TIMEMORY_SETTINGS_REFERENCE_IMPL(
-        bool, allow_signal_handler, "TIMEMORY_ALLOW_SIGNAL_HANDLER",
-        "Allow signal handling to be activated", signal_settings::allow())
-
-    TIMEMORY_SETTINGS_REFERENCE_IMPL(
-        bool, enable_all_signals, "TIMEMORY_ENABLE_ALL_SIGNALS",
-        "Enable catching all signals", signal_settings::enable_all())
-
-    TIMEMORY_SETTINGS_REFERENCE_IMPL(
-        bool, disable_all_signals, "TIMEMORY_DISABLE_ALL_SIGNALS",
-        "Disable catching any signals", signal_settings::disable_all())
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(int32_t, node_count, "TIMEMORY_NODE_COUNT",
-                                  "Total number of nodes used in application", 0)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(
-        bool, destructor_report, "TIMEMORY_DESTRUCTOR_REPORT",
-        "Configure default setting for auto_{list,tuple,hybrid} to write to stdout during"
-        " destruction of the bundle",
-        false)
-
-    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(string_t, python_exe, "TIMEMORY_PYTHON_EXE",
-                                      "Configure the python executable to use",
-                                      TIMEMORY_PYTHON_PLOTTER,
-                                      strvector_t({ "--timemory-python-exe" }))
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(int64_t, separator_frequency, "TIMEMORY_SEPARATOR_FREQ",
-                                  "Frequency of dashed separator lines in text output", 0)
-
-    TIMEMORY_SETTINGS_MEMBER_IMPL(bool, suppress_parsing, "TIMEMORY_SUPPRESS_PARSING",
-                                  "Disable parsing environment", false)
+    TIMEMORY_SETTINGS_MEMBER_ARG_IMPL(
+        bool, dart_label, "TIMEMORY_DART_LABEL",
+        "Echo the category instead of the label (see also: TIMEMORY_DART_OUTPUT)", true,
+        strvector_t({ "--timemory-dart-label" }), -1, 1);
+}
+//
+//--------------------------------------------------------------------------------------//
+//
+TIMEMORY_SETTINGS_INLINE
+void
+settings::initialize()
+{
+    initialize_core();
+    initialize_components();
+    initialize_io();
+    initialize_format();
+    initialize_parallel();
+    initialize_tpls();
+    initialize_roofline();
+    initialize_miscellaneous();
+    initialize_ert();
+    initialize_dart();
 }
 //
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/settings/tsettings.hpp
+++ b/source/timemory/settings/tsettings.hpp
@@ -99,7 +99,8 @@ struct tsettings : public vsettings
             p.add_argument(m_cmdline, m_description)
                 .action(get_action())
                 .count(m_count)
-                .max_count(m_max_count);
+                .max_count(m_max_count)
+                .choices(m_choices);
         }
     }
 

--- a/source/timemory/settings/vsettings.hpp
+++ b/source/timemory/settings/vsettings.hpp
@@ -56,13 +56,15 @@ struct vsettings
 
     vsettings(const std::string& _name = "", const std::string& _env_name = "",
               const std::string& _descript = "", std::vector<std::string> _cmdline = {},
-              int32_t _count = -1, int32_t _max_count = -1)
+              int32_t _count = -1, int32_t _max_count = -1,
+              std::vector<std::string> _choices = {})
     : m_count(_count)
     , m_max_count(_max_count)
     , m_name(_name)
     , m_env_name(_env_name)
     , m_description(_descript)
     , m_cmdline(_cmdline)
+    , m_choices(_choices)
     {}
 
     virtual ~vsettings() = default;
@@ -104,6 +106,7 @@ struct vsettings
         _data["env_name"]     = _as_str(m_env_name);
         _data["description"]  = _as_str(m_description);
         _data["command_line"] = _arr_as_str(m_cmdline);
+        _data["choices"]      = _arr_as_str(m_choices);
         return _data;
     }
 
@@ -111,11 +114,14 @@ struct vsettings
     const auto& get_env_name() const { return m_env_name; }
     const auto& get_description() const { return m_description; }
     const auto& get_command_line() const { return m_cmdline; }
+    const auto& get_choices() const { return m_choices; }
     const auto& get_count() const { return m_count; }
     const auto& get_max_count() const { return m_max_count; }
 
     void set_count(int32_t v) { m_count = v; }
     void set_max_count(int32_t v) { m_max_count = v; }
+    void set_choices(const std::vector<std::string>& v) { m_choices = v; }
+    void set_command_line(const std::vector<std::string>& v) { m_cmdline = v; }
 
     auto get_type_index() const { return m_type_index; }
     auto get_value_index() const { return m_value_index; }
@@ -180,6 +186,7 @@ protected:
     std::string              m_env_name    = "";
     std::string              m_description = "";
     std::vector<std::string> m_cmdline     = {};
+    std::vector<std::string> m_choices     = {};
 };
 //
 }  // namespace tim

--- a/source/timemory/utility/bits/signals.hpp
+++ b/source/timemory/utility/bits/signals.hpp
@@ -76,6 +76,8 @@ insert_and_remove(const sys_signal&              _type,  // signal type
                   signal_settings::signal_set_t* _rem)   // set to remove from
 
 {
+    if(!_ins || !_rem)
+        return;
     _ins->insert(_type);
     auto itr = _rem->find(_type);
     if(itr != _rem->end())

--- a/source/timemory/utility/utility.hpp
+++ b/source/timemory/utility/utility.hpp
@@ -340,14 +340,50 @@ static inline auto
 get_demangled_backtrace()
 {
     auto demangle_bt = [](const char* cstr) {
+        auto _trim = [](std::string& _sub, size_t& _len) {
+            size_t _pos = 0;
+            while((_pos = _sub.find_first_of(' ')) == 0)
+            {
+                _sub = _sub.erase(_pos, 1);
+                --_len;
+            }
+            while((_pos = _sub.find_last_of(' ')) == _sub.length() - 1)
+            {
+                _sub = _sub.substr(0, _sub.length() - 1);
+                --_len;
+            }
+            return _sub;
+        };
+
         auto str = demangle(std::string(cstr));
-        auto beg = str.find("(_Z");
-        auto end = str.find("+0x", beg);
+        auto beg = str.find("(");
+        if(beg == std::string::npos)
+        {
+            beg = str.find("_Z");
+            if(beg != std::string::npos)
+                beg -= 1;
+        }
+        auto end = str.find("+", beg);
         if(beg != std::string::npos && end != std::string::npos)
         {
             auto len = end - (beg + 1);
-            auto dem = demangle(str.substr(beg + 1, len));
+            auto sub = str.substr(beg + 1, len);
+            auto dem = demangle(_trim(sub, len));
             str      = str.replace(beg + 1, len, dem);
+        }
+        else if(beg != std::string::npos)
+        {
+            auto len = str.length() - (beg + 1);
+            auto sub = str.substr(beg + 1, len);
+            auto dem = demangle(_trim(sub, len));
+            str      = str.replace(beg + 1, len, dem);
+        }
+        else if(end != std::string::npos)
+        {
+            auto len = end;
+            auto sub = str.substr(beg, len);
+            auto dem = demangle(_trim(sub, len));
+            str      = str.replace(beg, len, dem);
         }
         return str;
     };


### PR DESCRIPTION
- Configuring settings via command-line are now extensively available in C++ and Python
- minor migration of utility::stream to data::stream
- python get_text routine
- additional virtual functions in vsettings
- fixes/improvements to argparse
- fixes to backtrace from signal-handler

## C++ Command Line Options

### C++ Implementation Example

```cpp
#include <timemory/timemory.hpp>

int main(int argc, char** argv)
{
    // [OPTIONAL] Custom settings
    tim::settings::instance()->insert<int64_t>(
        "CUSTOM_SETTING",                                                     // environment variable
        "custom_setting_name",                                                 // name of setting
       "Configures int64_t value for a custom component",   // description
       10,                                                                                      // initial value 
       std::vector<std::string>({ "-c", "--custom-setting" }), // command-line args
       1,                                                                                        // exact number of values required, use -1 for any
       -1                                                                                       // maximum number of values supported, only relevant if exact is -1
    );

    // Option #1
    tim::timemory_init(&argc, &argv); // removes timemory options from argc/argv

    // Option #2
    tim::timemory_init(argc, argv);  // standard init
    tim::timemory_argparse(&argc, &argv); // removes timemory options from argc/argv

    int64_t custom_value = tim::settings::instance()->get<int64_t>("CUSTOM_SETTING");
}
```

### C++ Output Example

```console
$ ./ex_cxx_basic -h
[timemory_argparse]> Error! help requested
Usage: ./ex_cxx_basic [tim::argparse::argument_parser arguments...] -- <NON_TIMEMORY_ARGS>

Options:
    -h, --help                     Shows this page               
    -C, --timemory-config          Configuration file for timemory
    --timemory-suppress-config, --timemory-no-config Disable processing of setting configuration files
    --timemory-suppress-parsing    Disable parsing environment   
    --timemory-enabled             Activation state of timemory  
    --timemory-verbose             Verbosity level               
    --timemory-debug               Enable debug output           
    --timemory-flat-profile        Set the label hierarchy mode to default to flat
    --timemory-timeline-profile    Set the label hierarchy mode to default to timeline
    --timemory-max-depth           Set the maximum depth of label hierarchy reporting
    --timemory-global-components   A specification of components which is used by multiple variadic bundlers and user_bundles as the fall-back set of components if their specific variable is not set. E.g. user_mpip_bundle will use this if TIMEMORY_MPIP_COMPONENTS is not specified
    --timemory-tuple-components    A specification of components which will be added to component_tuple structures containing the 'user_tuple_bundle'. These components will automatically be activated
    --timemory-list-components     A specification of components which will be added to component_list structures containing the 'user_list_bundle'. These components will only be activated if the 'user_list_bundle' is activated.
    --timemory-ompt-components     A specification of components which will be added to structures containing the 'user_ompt_bundle'. Priority: TRACE_COMPONENTS -> PROFILER_COMPONENTS -> COMPONENTS -> GLOBAL_COMPONENTS
    --timemory-mpip-components     A specification of components which will be added to structures containing the 'user_mpip_bundle'. Priority: TRACE_COMPONENTS -> PROFILER_COMPONENTS -> COMPONENTS -> GLOBAL_COMPONENTS
    --timemory-ncclp-components    A specification of components which will be added to structures containing the 'user_ncclp_bundle'. Priority: MPIP_COMPONENTS -> TRACE_COMPONENTS -> PROFILER_COMPONENTS -> COMPONENTS -> GLOBAL_COMPONENTS
    --timemory-trace-components    A specification of components which will be used by the interfaces which are designed for full profiling. These components will be subjected to throttling. Priority: COMPONENTS -> GLOBAL_COMPONENTS
    --timemory-profiler-components A specification of components which will be used by the interfaces which are designed for full python profiling. This specification will be overridden by a trace_components specification. Priority: COMPONENTS -> GLOBAL_COMPONENTS
    --timemory-components          A specification of components which is used by the library interface. This falls back to TIMEMORY_GLOBAL_COMPONENTS.
    --timemory-auto-output         Generate output at application termination
    --timemory-cout-output         Write output to stdout        
    --timemory-file-output         Write output to files         
    --timemory-text-output         Write text output files       
    --timemory-json-output         Write json output files       
    --timemory-dart-output         Write dart measurements for CDash
    --timemory-time-output         Output data to subfolder w/ a timestamp (see also: TIMEMORY_TIME_FORMAT)
    --timemory-plot-output         Generate plot outputs from json outputs
    --timemory-diff-output         Generate a difference output vs. a pre-existing output (see also: TIMEMORY_INPUT_PATH and TIMEMORY_INPUT_PREFIX)
    --timemory-flamegraph-output   Write a json output for flamegraph visualization (use chrome://tracing)
    --timemory-ctest-notes         Write a CTestNotes.txt for each text output
    --timemory-output-path         Explicitly specify the output folder for results
    --timemory-output-prefix       Explicitly specify a prefix for all output files
    --timemory-input-path          Explicitly specify the input folder for difference comparisons (see also: TIMEMORY_DIFF_OUTPUT)
    --timemory-input-prefix        Explicitly specify the prefix for input files used in difference comparisons (see also: TIMEMORY_DIFF_OUTPUT)
    --timemory-input-extensions    File extensions used when searching for input files used in difference comparisons (see also: TIMEMORY_DIFF_OUTPUT)
    --timemory-time-format         Customize the folder generation when TIMEMORY_TIME_OUTPUT is enabled (see also: strftime)
    --timemory-precision           Set the global output precision for components
    --timemory-width               Set the global output width for components
    --timemory-max-width           Set the maximum width for component label outputs
    --timemory-scientific          Set the global numerical reporting to scientific format
    --timemory-timing-units        Set the units for components with 'uses_timing_units' type-trait
    --timemory-memory-units        Set the units for components with 'uses_memory_units' type-trait
    --timemory-collapse-threads    Enable/disable combining thread-specific data
    --timemory-collapse-processes  Enable/disable combining process-specific data
    --timemory-cpu-affinity        Enable pinning threads to CPUs (Linux-only)
    --timemory-mpi-init            Enable/disable timemory calling MPI_Init / MPI_Init_thread during certain timemory_init(...) invocations
    --timemory-mpi-finalize        Enable/disable timemory calling MPI_Finalize during timemory_finalize(...) invocations
    --timemory-mpi-thread          Call MPI_Init_thread instead of MPI_Init (see also: TIMEMORY_MPI_INIT)
    --timemory-mpi-thread-type     MPI_Init_thread mode: 'single', 'serialized', 'funneled', or 'multiple' (see also: TIMEMORY_MPI_INIT and TIMEMORY_MPI_THREAD)
    --timemory-upcxx-init          Enable/disable timemory calling upcxx::init() during certain timemory_init(...) invocations
    --timemory-upcxx-finalize      Enable/disable timemory calling upcxx::finalize() during timemory_finalize()
    --timemory-node-count          Total number of nodes used in application. Setting this value > 1 will result in aggregating N processes into groups of N / NODE_COUNT
    --timemory-papi-multiplexing   Enable multiplexing when using PAPI
    --timemory-papi-fail-on-error  Configure PAPI errors to trigger a runtime error
    --timemory-papi-quiet          Configure suppression of reporting PAPI errors/warnings
    --timemory-papi-events         PAPI presets and events to collect (see also: papi_avail)
    --timemory-papi-overflow       Value at which PAPI hw counters trigger an overflow callback
    --timemory-cupti-activity-level Default group of kinds tracked via CUpti Activity API
    --timemory-cupti-activity-kinds Specific cupti activity kinds to track
    --timemory-cupti-events        Hardware counter event types to collect on NVIDIA GPUs
    --timemory-cupti-metrics       Hardware counter metric types to collect on NVIDIA GPUs
    --timemory-cupti-device        Target device for CUPTI hw counter collection
    --timemory-python-exe          Configure the python executable to use
    --timemory-roofline-mode [ ai | op ]  Configure the roofline collection mode. Options: 'op' 'ai'.
    --timemory-add-secondary       Enable/disable components adding secondary (child) entries when available. E.g. suppress individual CUDA kernels, etc. when using Cupti components
    --timemory-throttle-count      Minimum number of laps before checking whether a key should be throttled
    --timemory-throttle-value      Average call time in nanoseconds when # laps > throttle_count that triggers throttling
    --timemory-enable-signal-handler Enable signals in timemory_init
    --timemory-allow-signal-handler Allow signal handling to be activated
    --timemory-destructor-report   Configure default setting for auto_{list,tuple,hybrid} to write to stdout during destruction of the bundle
    --timemory-stack-clearing      Enable/disable stopping any markers still running during finalization
    --timemory-dart-type           Only echo this measurement type (see also: TIMEMORY_DART_OUTPUT)
    --timemory-dart-count          Only echo this number of dart tags (see also: TIMEMORY_DART_OUTPUT)
    --timemory-dart-label          Echo the category instead of the label (see also: TIMEMORY_DART_OUTPUT)
    --timemory-args                A generic option for any setting. Each argument MUST be passed in form: 'NAME=VALUE'. E.g. --timemory-args "papi_events=PAPI_TOT_INS,PAPI_TOT_CYC" text_output=off
```

## Python Command Line Options

### Python Implementation Example

```python
if __name__ == "__main__":

    parser = argparse.ArgumentParser()
    parser.add_argument(...)

    # Option #1: creates a subparser "timemory-config"
    timemory.settings.add_arguments(parser)

    # Option #2: provide own subparser:   
    subparser = parser.add_subparsers()
    timemory.settings.add_arguments(
        parser,
        subparser=subparser.add_parser("timemory-config"))

    # Option #3: disable subparser (replicates C++ usage)
    timemory.settings.add_arguments(
        parser,
        subparser=None)

    # standard argparse.ArgumentParser usage
    # timemory settings are automatically updated via action parameter
    args = parser.parse_args()

```

### Python Output Example

```console
# display help
python ./ex_python_general timemory-config -h

# usage
python ./ex_python_general
python ./ex_python_general -n 10
python ./ex_python_general -f text
python ./ex_python_general -f json_flat
python ./ex_python_general -f json_tree
python ./ex_python_general timemory-config --enabled=n
python ./ex_python_general timemory-config --auto-output=y --cout-output=n
```

```console
$ ./ex_python_general timemory-config -h
usage: ex_python_general timemory-config [-h] [-C VALUE]
                                         [--suppress-config VALUE]
                                         [--suppress-parsing VALUE]
                                         [--enabled VALUE] [--verbose VALUE]
                                         [--debug VALUE]
                                         [--flat-profile VALUE]
                                         [--timeline-profile VALUE]
                                         [--max-depth VALUE]
                                         [--global-components VALUE]
                                         [--tuple-components VALUE]
                                         [--list-components VALUE]
                                         [--ompt-components VALUE]
                                         [--mpip-components VALUE]
                                         [--ncclp-components VALUE]
                                         [--trace-components VALUE]
                                         [--profiler-components VALUE]
                                         [--components VALUE]
                                         [--auto-output VALUE]
                                         [--cout-output VALUE]
                                         [--file-output VALUE]
                                         [--text-output VALUE]
                                         [--json-output VALUE]
                                         [--dart-output VALUE]
                                         [--time-output VALUE]
                                         [--plot-output VALUE]
                                         [--diff-output VALUE]
                                         [--flamegraph-output VALUE]
                                         [--ctest-notes VALUE]
                                         [--output-path VALUE]
                                         [--output-prefix VALUE]
                                         [--input-path VALUE]
                                         [--input-prefix VALUE]
                                         [--input-extensions VALUE]
                                         [--time-format VALUE]
                                         [--precision VALUE] [--width VALUE]
                                         [--max-width VALUE]
                                         [--scientific VALUE]
                                         [--timing-units VALUE]
                                         [--memory-units VALUE]
                                         [--collapse-threads VALUE]
                                         [--collapse-processes VALUE]
                                         [--cpu-affinity VALUE]
                                         [--mpi-init VALUE]
                                         [--mpi-finalize VALUE]
                                         [--mpi-thread VALUE]
                                         [--mpi-thread-type VALUE]
                                         [--upcxx-init VALUE]
                                         [--upcxx-finalize VALUE]
                                         [--node-count VALUE]
                                         [--papi-multiplexing VALUE]
                                         [--papi-fail-on-error VALUE]
                                         [--papi-quiet VALUE]
                                         [--papi-events VALUE]
                                         [--papi-overflow VALUE]
                                         [--cupti-activity-level VALUE]
                                         [--cupti-activity-kinds VALUE]
                                         [--cupti-events VALUE]
                                         [--cupti-metrics VALUE]
                                         [--cupti-device VALUE]
                                         [--python-exe VALUE]
                                         [--roofline-mode VALUE]
                                         [--add-secondary VALUE]
                                         [--throttle-count VALUE]
                                         [--throttle-value VALUE]
                                         [--enable-signal-handler VALUE]
                                         [--allow-signal-handler VALUE]
                                         [--destructor-report VALUE]
                                         [--stack-clearing VALUE]
                                         [--dart-type VALUE]
                                         [--dart-count VALUE]
                                         [--dart-label VALUE]

Configure settings for timemory

optional arguments:
  -h, --help            show this help message and exit
  -C VALUE, --config VALUE
                        Configuration file for timemory [env:
                        TIMEMORY_CONFIG_FILE, type: std::string] (default: /Us
                        ers/jrmadsen/.timemory.cfg;/Users/jrmadsen/.timemory.j
                        son;/Users/jrmadsen/.config/timemory.cfg;/Users/jrmads
                        en/.config/timemory.json)
  --suppress-config VALUE, --no-config VALUE
                        Disable processing of setting configuration files
                        [env: TIMEMORY_SUPPRESS_CONFIG, type: bool] (default:
                        false)
  --suppress-parsing VALUE
                        Disable parsing environment [env:
                        TIMEMORY_SUPPRESS_PARSING, type: bool] (default:
                        false)
  --enabled VALUE       Activation state of timemory [env: TIMEMORY_ENABLED,
                        type: bool] (default: true)
  --verbose VALUE       Verbosity level [env: TIMEMORY_VERBOSE, type: int]
                        (default: 0)
  --debug VALUE         Enable debug output [env: TIMEMORY_DEBUG, type: bool]
                        (default: false)
  --flat-profile VALUE  Set the label hierarchy mode to default to flat [env:
                        TIMEMORY_FLAT_PROFILE, type: bool] (default: false)
  --timeline-profile VALUE
                        Set the label hierarchy mode to default to timeline
                        [env: TIMEMORY_TIMELINE_PROFILE, type: bool] (default:
                        false)
  --max-depth VALUE     Set the maximum depth of label hierarchy reporting
                        [env: TIMEMORY_MAX_DEPTH, type: unsigned short]
                        (default: 65535)
  --global-components VALUE
                        A specification of components which is used by
                        multiple variadic bundlers and user_bundles as the
                        fall-back set of components if their specific variable
                        is not set. E.g. user_mpip_bundle will use this if
                        TIMEMORY_MPIP_COMPONENTS is not specified [env:
                        TIMEMORY_GLOBAL_COMPONENTS, type: std::string]
                        (default: )
  --tuple-components VALUE
                        A specification of components which will be added to
                        component_tuple structures containing the
                        'user_tuple_bundle'. These components will
                        automatically be activated [env:
                        TIMEMORY_TUPLE_COMPONENTS, type: std::string]
                        (default: )
  --list-components VALUE
                        A specification of components which will be added to
                        component_list structures containing the
                        'user_list_bundle'. These components will only be
                        activated if the 'user_list_bundle' is activated.
                        [env: TIMEMORY_LIST_COMPONENTS, type: std::string]
                        (default: )
  --ompt-components VALUE
                        A specification of components which will be added to
                        structures containing the 'user_ompt_bundle'.
                        Priority: TRACE_COMPONENTS -> PROFILER_COMPONENTS ->
                        COMPONENTS -> GLOBAL_COMPONENTS [env:
                        TIMEMORY_OMPT_COMPONENTS, type: std::string] (default:
                        )
  --mpip-components VALUE
                        A specification of components which will be added to
                        structures containing the 'user_mpip_bundle'.
                        Priority: TRACE_COMPONENTS -> PROFILER_COMPONENTS ->
                        COMPONENTS -> GLOBAL_COMPONENTS [env:
                        TIMEMORY_MPIP_COMPONENTS, type: std::string] (default:
                        )
  --ncclp-components VALUE
                        A specification of components which will be added to
                        structures containing the 'user_ncclp_bundle'.
                        Priority: MPIP_COMPONENTS -> TRACE_COMPONENTS ->
                        PROFILER_COMPONENTS -> COMPONENTS -> GLOBAL_COMPONENTS
                        [env: TIMEMORY_NCCLP_COMPONENTS, type: std::string]
                        (default: )
  --trace-components VALUE
                        A specification of components which will be used by
                        the interfaces which are designed for full profiling.
                        These components will be subjected to throttling.
                        Priority: COMPONENTS -> GLOBAL_COMPONENTS [env:
                        TIMEMORY_TRACE_COMPONENTS, type: std::string]
                        (default: )
  --profiler-components VALUE
                        A specification of components which will be used by
                        the interfaces which are designed for full python
                        profiling. This specification will be overridden by a
                        trace_components specification. Priority: COMPONENTS
                        -> GLOBAL_COMPONENTS [env:
                        TIMEMORY_PROFILER_COMPONENTS, type: std::string]
                        (default: wall_clock,peak_rss,)
  --components VALUE    A specification of components which is used by the
                        library interface. This falls back to
                        TIMEMORY_GLOBAL_COMPONENTS. [env: TIMEMORY_COMPONENTS,
                        type: std::string] (default: )
  --auto-output VALUE   Generate output at application termination [env:
                        TIMEMORY_AUTO_OUTPUT, type: bool] (default: false)
  --cout-output VALUE   Write output to stdout [env: TIMEMORY_COUT_OUTPUT,
                        type: bool] (default: true)
  --file-output VALUE   Write output to files [env: TIMEMORY_FILE_OUTPUT,
                        type: bool] (default: true)
  --text-output VALUE   Write text output files [env: TIMEMORY_TEXT_OUTPUT,
                        type: bool] (default: true)
  --json-output VALUE   Write json output files [env: TIMEMORY_JSON_OUTPUT,
                        type: bool] (default: true)
  --dart-output VALUE   Write dart measurements for CDash [env:
                        TIMEMORY_DART_OUTPUT, type: bool] (default: false)
  --time-output VALUE   Output data to subfolder w/ a timestamp (see also:
                        TIMEMORY_TIME_FORMAT) [env: TIMEMORY_TIME_OUTPUT,
                        type: bool] (default: false)
  --plot-output VALUE   Generate plot outputs from json outputs [env:
                        TIMEMORY_PLOT_OUTPUT, type: bool] (default: false)
  --diff-output VALUE   Generate a difference output vs. a pre-existing output
                        (see also: TIMEMORY_INPUT_PATH and
                        TIMEMORY_INPUT_PREFIX) [env: TIMEMORY_DIFF_OUTPUT,
                        type: bool] (default: false)
  --flamegraph-output VALUE
                        Write a json output for flamegraph visualization (use
                        chrome://tracing) [env: TIMEMORY_FLAMEGRAPH_OUTPUT,
                        type: bool] (default: true)
  --ctest-notes VALUE   Write a CTestNotes.txt for each text output [env:
                        TIMEMORY_CTEST_NOTES, type: bool] (default: false)
  --output-path VALUE   Explicitly specify the output folder for results [env:
                        TIMEMORY_OUTPUT_PATH, type: std::string] (default:
                        timemory-ex-python-general-output)
  --output-prefix VALUE
                        Explicitly specify a prefix for all output files [env:
                        TIMEMORY_OUTPUT_PREFIX, type: std::string] (default: )
  --input-path VALUE    Explicitly specify the input folder for difference
                        comparisons (see also: TIMEMORY_DIFF_OUTPUT) [env:
                        TIMEMORY_INPUT_PATH, type: std::string] (default: )
  --input-prefix VALUE  Explicitly specify the prefix for input files used in
                        difference comparisons (see also:
                        TIMEMORY_DIFF_OUTPUT) [env: TIMEMORY_INPUT_PREFIX,
                        type: std::string] (default: )
  --input-extensions VALUE
                        File extensions used when searching for input files
                        used in difference comparisons (see also:
                        TIMEMORY_DIFF_OUTPUT) [env: TIMEMORY_INPUT_EXTENSIONS,
                        type: std::string] (default: json,xml)
  --time-format VALUE   Customize the folder generation when
                        TIMEMORY_TIME_OUTPUT is enabled (see also: strftime)
                        [env: TIMEMORY_TIME_FORMAT, type: std::string]
                        (default: %F_%I.%M_%p)
  --precision VALUE     Set the global output precision for components [env:
                        TIMEMORY_PRECISION, type: short] (default: -1)
  --width VALUE         Set the global output width for components [env:
                        TIMEMORY_WIDTH, type: short] (default: -1)
  --max-width VALUE     Set the maximum width for component label outputs
                        [env: TIMEMORY_MAX_WIDTH, type: int] (default: 120)
  --scientific VALUE    Set the global numerical reporting to scientific
                        format [env: TIMEMORY_SCIENTIFIC, type: bool]
                        (default: false)
  --timing-units VALUE  Set the units for components with 'uses_timing_units'
                        type-trait [env: TIMEMORY_TIMING_UNITS, type:
                        std::string] (default: )
  --memory-units VALUE  Set the units for components with 'uses_memory_units'
                        type-trait [env: TIMEMORY_MEMORY_UNITS, type:
                        std::string] (default: )
  --collapse-threads VALUE
                        Enable/disable combining thread-specific data [env:
                        TIMEMORY_COLLAPSE_THREADS, type: bool] (default: true)
  --collapse-processes VALUE
                        Enable/disable combining process-specific data [env:
                        TIMEMORY_COLLAPSE_PROCESSES, type: bool] (default:
                        true)
  --cpu-affinity VALUE  Enable pinning threads to CPUs (Linux-only) [env:
                        TIMEMORY_CPU_AFFINITY, type: bool] (default: false)
  --mpi-init VALUE      Enable/disable timemory calling MPI_Init /
                        MPI_Init_thread during certain timemory_init(...)
                        invocations [env: TIMEMORY_MPI_INIT, type: bool]
                        (default: false)
  --mpi-finalize VALUE  Enable/disable timemory calling MPI_Finalize during
                        timemory_finalize(...) invocations [env:
                        TIMEMORY_MPI_FINALIZE, type: bool] (default: false)
  --mpi-thread VALUE    Call MPI_Init_thread instead of MPI_Init (see also:
                        TIMEMORY_MPI_INIT) [env: TIMEMORY_MPI_THREAD, type:
                        bool] (default: true)
  --mpi-thread-type VALUE
                        MPI_Init_thread mode: 'single', 'serialized',
                        'funneled', or 'multiple' (see also: TIMEMORY_MPI_INIT
                        and TIMEMORY_MPI_THREAD) [env:
                        TIMEMORY_MPI_THREAD_TYPE, type: std::string] (default:
                        )
  --upcxx-init VALUE    Enable/disable timemory calling upcxx::init() during
                        certain timemory_init(...) invocations [env:
                        TIMEMORY_UPCXX_INIT, type: bool] (default: false)
  --upcxx-finalize VALUE
                        Enable/disable timemory calling upcxx::finalize()
                        during timemory_finalize() [env:
                        TIMEMORY_UPCXX_FINALIZE, type: bool] (default: false)
  --node-count VALUE    Total number of nodes used in application. Setting
                        this value > 1 will result in aggregating N processes
                        into groups of N / NODE_COUNT [env:
                        TIMEMORY_NODE_COUNT, type: int] (default: 0)
  --papi-multiplexing VALUE
                        Enable multiplexing when using PAPI [env:
                        TIMEMORY_PAPI_MULTIPLEXING, type: bool] (default:
                        true)
  --papi-fail-on-error VALUE
                        Configure PAPI errors to trigger a runtime error [env:
                        TIMEMORY_PAPI_FAIL_ON_ERROR, type: bool] (default:
                        false)
  --papi-quiet VALUE    Configure suppression of reporting PAPI
                        errors/warnings [env: TIMEMORY_PAPI_QUIET, type: bool]
                        (default: false)
  --papi-events VALUE   PAPI presets and events to collect (see also:
                        papi_avail) [env: TIMEMORY_PAPI_EVENTS, type:
                        std::string] (default: )
  --papi-overflow VALUE
                        Value at which PAPI hw counters trigger an overflow
                        callback [env: TIMEMORY_PAPI_OVERFLOW, type: int]
                        (default: 0)
  --cupti-activity-level VALUE
                        Default group of kinds tracked via CUpti Activity API
                        [env: TIMEMORY_CUPTI_ACTIVITY_LEVEL, type: int]
                        (default: 1)
  --cupti-activity-kinds VALUE
                        Specific cupti activity kinds to track [env:
                        TIMEMORY_CUPTI_ACTIVITY_KINDS, type: std::string]
                        (default: )
  --cupti-events VALUE  Hardware counter event types to collect on NVIDIA GPUs
                        [env: TIMEMORY_CUPTI_EVENTS, type: std::string]
                        (default: )
  --cupti-metrics VALUE
                        Hardware counter metric types to collect on NVIDIA
                        GPUs [env: TIMEMORY_CUPTI_METRICS, type: std::string]
                        (default: )
  --cupti-device VALUE  Target device for CUPTI hw counter collection [env:
                        TIMEMORY_CUPTI_DEVICE, type: int] (default: 0)
  --python-exe VALUE    Configure the python executable to use [env:
                        TIMEMORY_PYTHON_EXE, type: std::string] (default:
                        /opt/local/bin/python)
  --roofline-mode VALUE
                        Configure the roofline collection mode. Options: 'op'
                        'ai'. [env: TIMEMORY_ROOFLINE_MODE, type: std::string]
                        (default: op)
  --add-secondary VALUE
                        Enable/disable components adding secondary (child)
                        entries when available. E.g. suppress individual CUDA
                        kernels, etc. when using Cupti components [env:
                        TIMEMORY_ADD_SECONDARY, type: bool] (default: true)
  --throttle-count VALUE
                        Minimum number of laps before checking whether a key
                        should be throttled [env: TIMEMORY_THROTTLE_COUNT,
                        type: unsigned long] (default: 10000)
  --throttle-value VALUE
                        Average call time in nanoseconds when # laps >
                        throttle_count that triggers throttling [env:
                        TIMEMORY_THROTTLE_VALUE, type: unsigned long]
                        (default: 10000)
  --enable-signal-handler VALUE
                        Enable signals in timemory_init [env:
                        TIMEMORY_ENABLE_SIGNAL_HANDLER, type: bool] (default:
                        false)
  --allow-signal-handler VALUE
                        Allow signal handling to be activated [env:
                        TIMEMORY_ALLOW_SIGNAL_HANDLER, type: bool] (default:
                        true)
  --destructor-report VALUE
                        Configure default setting for auto_{list,tuple,hybrid}
                        to write to stdout during destruction of the bundle
                        [env: TIMEMORY_DESTRUCTOR_REPORT, type: bool]
                        (default: false)
  --stack-clearing VALUE
                        Enable/disable stopping any markers still running
                        during finalization [env: TIMEMORY_STACK_CLEARING,
                        type: bool] (default: true)
  --dart-type VALUE     Only echo this measurement type (see also:
                        TIMEMORY_DART_OUTPUT) [env: TIMEMORY_DART_TYPE, type:
                        std::string] (default: )
  --dart-count VALUE    Only echo this number of dart tags (see also:
                        TIMEMORY_DART_OUTPUT) [env: TIMEMORY_DART_COUNT, type:
                        unsigned long long] (default: 1)
  --dart-label VALUE    Echo the category instead of the label (see also:
                        TIMEMORY_DART_OUTPUT) [env: TIMEMORY_DART_LABEL, type:
                        bool] (default: true)
```