### PR TITLE
Work-around to fixes anonymous structs errors with tim::os::linux and tim::os::unix

### DIFF
--- a/source/timemory/macros/os.hpp
+++ b/source/timemory/macros/os.hpp
@@ -76,6 +76,31 @@
 #endif
 
 //--------------------------------------------------------------------------------------//
+// Work-around below fixes anonymous structs compiler errors in namespace tim::os
+//
+//      struct unix  : public concepts::api {};
+//      struct linux : public concepts::api {};
+//
+// resolving to:
+//
+//      struct       : public concepts::api {};
+//      struct       : public concepts::api {};
+//
+// This work-around just re-defines the macros to perform a text-substitution of the
+// name of the macro. Thus, the text-substitution does not change anything but
+// all "#ifdef unix" and "#ifdef linux" pre-processor checks are still valid.
+//
+#if defined(unix)
+#    undef unix
+#    define unix unix
+#endif
+
+#if defined(linux)
+#    undef linux
+#    define linux linux
+#endif
+
+//--------------------------------------------------------------------------------------//
 // this ensures that winnt.h never causes a 64-bit build to fail
 // also solves issue with ws2def.h and winsock2.h:
 //  https://www.zachburlingame.com/2011/05/


### PR DESCRIPTION
- `tim::os::unix` and `tim::os::linux` are used in timemory's template meta-programming to provide metadata info and enable/disable components/features which are only available on certain OSes
- if "unix" and/or "linux are defined for pre-processor checks (even though they really shouldn't be, these macros are *very* non-posix-compliant), this results in anonymous struct declaration/definitions.
- This fix redefines those macros to perform a self-text-substitution of the macro's name, e.g. `#define unix unix`
  - Since macros are not recursively expanded, this should not result in any issues unless someone is doing something _very_ strange like `#define unix something_else` and relying on the contents of the macro to be `"something_else"`. 