### PR TITLE
os::unix and os::linux caused problems. renamed to os::supports_*

### DIFF
--- a/source/timemory/api.hpp
+++ b/source/timemory/api.hpp
@@ -122,10 +122,10 @@ TIMEMORY_DEFINE_NS_API(tpls, tau)
 // OS-specific APIs
 //
 TIMEMORY_DEFINE_NS_API(os, agnostic)
-TIMEMORY_DEFINE_NS_API(os, unix)
-TIMEMORY_DEFINE_NS_API(os, linux)
-TIMEMORY_DEFINE_NS_API(os, darwin)
-TIMEMORY_DEFINE_NS_API(os, windows)
+TIMEMORY_DEFINE_NS_API(os, supports_unix)
+TIMEMORY_DEFINE_NS_API(os, supports_linux)
+TIMEMORY_DEFINE_NS_API(os, supports_darwin)
+TIMEMORY_DEFINE_NS_API(os, supports_windows)
 //
 //--------------------------------------------------------------------------------------//
 //
@@ -169,25 +169,25 @@ namespace trait
 //
 #if !defined(_UNIX)
 template <>
-struct is_available<os::unix> : false_type
+struct is_available<os::supports_unix> : false_type
 {};
 #endif
 //
 #if !defined(_LINUX)
 template <>
-struct is_available<os::linux> : false_type
+struct is_available<os::supports_linux> : false_type
 {};
 #endif
 //
 #if !defined(_MACOS)
 template <>
-struct is_available<os::darwin> : false_type
+struct is_available<os::supports_darwin> : false_type
 {};
 #endif
 //
 #if !defined(_WINDOWS)
 template <>
-struct is_available<os::windows> : false_type
+struct is_available<os::supports_windows> : false_type
 {};
 #endif
 //

--- a/source/timemory/components/allinea/types.hpp
+++ b/source/timemory/components/allinea/types.hpp
@@ -39,7 +39,7 @@
 TIMEMORY_DECLARE_COMPONENT(allinea_map)
 //
 TIMEMORY_SET_COMPONENT_API(component::allinea_map, tpls::allinea, category::external,
-                           os::linux)
+                           os::supports_linux)
 //
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/components/caliper/types.hpp
+++ b/source/timemory/components/caliper/types.hpp
@@ -45,11 +45,11 @@ TIMEMORY_DECLARE_COMPONENT(caliper_loop_marker)
 TIMEMORY_COMPONENT_ALIAS(caliper, caliper_marker)
 //
 TIMEMORY_SET_COMPONENT_API(component::caliper_config, tpls::caliper, category::external,
-                           os::unix)
+                           os::supports_unix)
 TIMEMORY_SET_COMPONENT_API(component::caliper_marker, tpls::caliper, category::external,
-                           os::unix)
+                           os::supports_unix)
 TIMEMORY_SET_COMPONENT_API(component::caliper_loop_marker, tpls::caliper,
-                           category::external, os::unix)
+                           category::external, os::supports_unix)
 //
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/components/craypat/types.hpp
+++ b/source/timemory/components/craypat/types.hpp
@@ -48,15 +48,15 @@ TIMEMORY_DECLARE_COMPONENT(craypat_flush_buffer)
 //--------------------------------------------------------------------------------------//
 //
 TIMEMORY_SET_COMPONENT_API(component::craypat_record, tpls::craypat, category::external,
-                           os::linux)
+                           os::supports_linux)
 TIMEMORY_SET_COMPONENT_API(component::craypat_region, tpls::craypat, category::external,
-                           category::decorator, os::linux)
+                           category::decorator, os::supports_linux)
 TIMEMORY_SET_COMPONENT_API(component::craypat_counters, tpls::craypat, category::external,
-                           os::linux)
+                           os::supports_linux)
 TIMEMORY_SET_COMPONENT_API(component::craypat_heap_stats, tpls::craypat,
-                           category::external, os::linux)
+                           category::external, os::supports_linux)
 TIMEMORY_SET_COMPONENT_API(component::craypat_flush_buffer, tpls::craypat,
-                           category::external, os::linux)
+                           category::external, os::supports_linux)
 //
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/components/gotcha/types.hpp
+++ b/source/timemory/components/gotcha/types.hpp
@@ -58,13 +58,13 @@ namespace trait
 template <size_t Nt, typename ComponentsT, typename DiffT>
 struct component_apis<component::gotcha<Nt, ComponentsT, DiffT>>
 {
-    using type = type_list<tpls::gotcha, category::external, os::linux>;
+    using type = type_list<tpls::gotcha, category::external, os::supports_linux>;
 };
 }  // namespace trait
 }  // namespace tim
 //
 TIMEMORY_SET_COMPONENT_API(component::malloc_gotcha, tpls::gotcha, category::external,
-                           category::memory, os::linux)
+                           category::memory, os::supports_linux)
 //
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/components/gperftools/types.hpp
+++ b/source/timemory/components/gperftools/types.hpp
@@ -49,9 +49,9 @@ TIMEMORY_COMPONENT_ALIAS(gperf_heap_profiler, gperftools_heap_profiler)
 //--------------------------------------------------------------------------------------//
 //
 TIMEMORY_SET_COMPONENT_API(component::gperftools_cpu_profiler, tpls::gperftools,
-                           category::external, category::timing, os::unix)
+                           category::external, category::timing, os::supports_unix)
 TIMEMORY_SET_COMPONENT_API(component::gperftools_heap_profiler, tpls::gperftools,
-                           category::external, category::memory, os::unix)
+                           category::external, category::memory, os::supports_unix)
 //
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/components/io/types.hpp
+++ b/source/timemory/components/io/types.hpp
@@ -60,13 +60,13 @@ using pair_dd_t = std::pair<double, double>;
 //--------------------------------------------------------------------------------------//
 //
 TIMEMORY_SET_COMPONENT_API(component::read_char, project::timemory, category::io,
-                           os::linux)
+                           os::supports_linux)
 TIMEMORY_SET_COMPONENT_API(component::written_char, project::timemory, category::io,
-                           os::linux)
+                           os::supports_linux)
 TIMEMORY_SET_COMPONENT_API(component::read_bytes, project::timemory, category::io,
-                           os::linux)
+                           os::supports_linux)
 TIMEMORY_SET_COMPONENT_API(component::written_bytes, project::timemory, category::io,
-                           os::linux)
+                           os::supports_linux)
 //
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/components/likwid/types.hpp
+++ b/source/timemory/components/likwid/types.hpp
@@ -70,10 +70,10 @@ TIMEMORY_DECLARE_COMPONENT(likwid_nvmarker)
 //--------------------------------------------------------------------------------------//
 //
 TIMEMORY_SET_COMPONENT_API(component::likwid_marker, tpls::likwid, category::external,
-                           category::decorator, category::hardware_counter, os::linux)
+                           category::decorator, category::hardware_counter, os::supports_linux)
 TIMEMORY_SET_COMPONENT_API(component::likwid_nvmarker, tpls::likwid, device::gpu,
                            category::external, category::decorator,
-                           category::hardware_counter, os::linux)
+                           category::hardware_counter, os::supports_linux)
 
 namespace tim
 {

--- a/source/timemory/components/papi/types.hpp
+++ b/source/timemory/components/papi/types.hpp
@@ -51,23 +51,23 @@ TIMEMORY_COMPONENT_ALIAS(papi_array32_t, papi_array<32>)
 TIMEMORY_COMPONENT_ALIAS(papi_array_t, papi_array<TIMEMORY_PAPI_ARRAY_SIZE>)
 //
 TIMEMORY_SET_COMPONENT_API(component::papi_vector, tpls::papi, category::external,
-                           category::hardware_counter, os::linux)
+                           category::hardware_counter, os::supports_linux)
 //
 TIMEMORY_SET_TEMPLATE_COMPONENT_API(TIMEMORY_ESC(size_t MaxNumEvents),
                                     TIMEMORY_ESC(component::papi_array<MaxNumEvents>),
                                     tpls::papi, category::external,
-                                    category::hardware_counter, os::linux)
+                                    category::hardware_counter, os::supports_linux)
 //
 TIMEMORY_SET_TEMPLATE_COMPONENT_API(TIMEMORY_ESC(int... Evts),
                                     TIMEMORY_ESC(component::papi_tuple<Evts...>),
                                     tpls::papi, category::external,
-                                    category::hardware_counter, os::linux)
+                                    category::hardware_counter, os::supports_linux)
 //
 TIMEMORY_SET_TEMPLATE_COMPONENT_API(TIMEMORY_ESC(int... Evts),
                                     TIMEMORY_ESC(component::papi_rate_tuple<Evts...>),
                                     tpls::papi, category::external,
                                     category::hardware_counter, category::timing,
-                                    os::linux)
+                                    os::supports_linux)
 //
 //======================================================================================//
 //

--- a/source/timemory/components/roofline/types.hpp
+++ b/source/timemory/components/roofline/types.hpp
@@ -64,7 +64,7 @@ TIMEMORY_SET_TEMPLATE_COMPONENT_API(TIMEMORY_ESC(typename... Types),
                                     TIMEMORY_ESC(component::cpu_roofline<Types...>),
                                     tpls::papi, category::external,
                                     category::hardware_counter, category::timing,
-                                    os::linux)
+                                    os::supports_linux)
 
 TIMEMORY_SET_TEMPLATE_COMPONENT_API(TIMEMORY_ESC(typename... Types),
                                     TIMEMORY_ESC(component::gpu_roofline<Types...>),

--- a/source/timemory/components/rusage/types.hpp
+++ b/source/timemory/components/rusage/types.hpp
@@ -84,28 +84,28 @@ TIMEMORY_SET_COMPONENT_API(component::page_rss, project::timemory, category::mem
                            category::resource_usage, os::agnostic)
 
 TIMEMORY_SET_COMPONENT_API(component::virtual_memory, project::timemory, category::memory,
-                           category::resource_usage, os::linux)
+                           category::resource_usage, os::supports_linux)
 
 TIMEMORY_SET_COMPONENT_API(component::num_io_in, project::timemory, category::io,
-                           category::resource_usage, os::unix)
+                           category::resource_usage, os::supports_unix)
 
 TIMEMORY_SET_COMPONENT_API(component::num_io_out, project::timemory, category::io,
-                           category::resource_usage, os::unix)
+                           category::resource_usage, os::supports_unix)
 
 TIMEMORY_SET_COMPONENT_API(component::num_minor_page_faults, project::timemory,
-                           category::resource_usage, os::unix)
+                           category::resource_usage, os::supports_unix)
 
 TIMEMORY_SET_COMPONENT_API(component::voluntary_context_switch, project::timemory,
-                           category::resource_usage, os::unix)
+                           category::resource_usage, os::supports_unix)
 
 TIMEMORY_SET_COMPONENT_API(component::priority_context_switch, project::timemory,
-                           category::resource_usage, os::unix)
+                           category::resource_usage, os::supports_unix)
 
 TIMEMORY_SET_COMPONENT_API(component::user_mode_time, project::timemory, category::timing,
-                           os::unix)
+                           os::supports_unix)
 
 TIMEMORY_SET_COMPONENT_API(component::kernel_mode_time, project::timemory,
-                           category::timing, os::unix)
+                           category::timing, os::supports_unix)
 
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/components/timing/types.hpp
+++ b/source/timemory/components/timing/types.hpp
@@ -120,17 +120,17 @@ TIMEMORY_SET_COMPONENT_API(component::cpu_util, project::timemory, category::tim
                            os::agnostic)
 // Available on Unix
 TIMEMORY_SET_COMPONENT_API(component::monotonic_clock, project::timemory,
-                           category::timing, os::unix)
+                           category::timing, os::supports_unix)
 TIMEMORY_SET_COMPONENT_API(component::monotonic_raw_clock, project::timemory,
-                           category::timing, os::unix)
+                           category::timing, os::supports_unix)
 TIMEMORY_SET_COMPONENT_API(component::thread_cpu_clock, project::timemory,
-                           category::timing, os::unix)
+                           category::timing, os::supports_unix)
 TIMEMORY_SET_COMPONENT_API(component::process_cpu_clock, project::timemory,
-                           category::timing, os::unix)
+                           category::timing, os::supports_unix)
 TIMEMORY_SET_COMPONENT_API(component::process_cpu_util, project::timemory,
-                           category::timing, os::unix)
+                           category::timing, os::supports_unix)
 TIMEMORY_SET_COMPONENT_API(component::thread_cpu_util, project::timemory,
-                           category::timing, os::unix)
+                           category::timing, os::supports_unix)
 //
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/components/user_bundle/types.hpp
+++ b/source/timemory/components/user_bundle/types.hpp
@@ -97,8 +97,8 @@ TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::user_ncclp_bundle, false
 TIMEMORY_SET_COMPONENT_API(component::user_global_bundle, project::timemory, os::agnostic)
 TIMEMORY_SET_COMPONENT_API(component::user_list_bundle, project::timemory, os::agnostic)
 TIMEMORY_SET_COMPONENT_API(component::user_tuple_bundle, project::timemory, os::agnostic)
-TIMEMORY_SET_COMPONENT_API(component::user_mpip_bundle, project::timemory, os::linux)
-TIMEMORY_SET_COMPONENT_API(component::user_ncclp_bundle, project::timemory, os::linux)
+TIMEMORY_SET_COMPONENT_API(component::user_mpip_bundle, project::timemory, os::supports_linux)
+TIMEMORY_SET_COMPONENT_API(component::user_ncclp_bundle, project::timemory, os::supports_linux)
 TIMEMORY_SET_COMPONENT_API(component::user_trace_bundle, project::timemory, os::agnostic)
 TIMEMORY_SET_COMPONENT_API(component::user_profiler_bundle, project::timemory,
                            os::agnostic)

--- a/source/timemory/macros/os.hpp
+++ b/source/timemory/macros/os.hpp
@@ -76,31 +76,6 @@
 #endif
 
 //--------------------------------------------------------------------------------------//
-// Work-around below fixes anonymous structs compiler errors in namespace tim::os
-//
-//      struct unix  : public concepts::api {};
-//      struct linux : public concepts::api {};
-//
-// resolving to:
-//
-//      struct       : public concepts::api {};
-//      struct       : public concepts::api {};
-//
-// This work-around just re-defines the macros to perform a text-substitution of the
-// name of the macro. Thus, the text-substitution does not change anything but
-// all "#ifdef unix" and "#ifdef linux" pre-processor checks are still valid.
-//
-#if defined(unix)
-#    undef unix
-#    define unix unix
-#endif
-
-#if defined(linux)
-#    undef linux
-#    define linux linux
-#endif
-
-//--------------------------------------------------------------------------------------//
 // this ensures that winnt.h never causes a 64-bit build to fail
 // also solves issue with ws2def.h and winsock2.h:
 //  https://www.zachburlingame.com/2011/05/


### PR DESCRIPTION
- os::unix -> os::supports_unix
- os::linux -> os::supports_linux
- os::darwin -> os::supports_darwin
- os::windows -> os::supports_windows
- nullifies changes in #92 