### PR TITLE
timemory_reset_throttle patch

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -238,19 +238,14 @@ else()
     set(CMAKE_UNITY_BUILD ${TIMEMORY_UNITY_BUILD})
 endif()
 
-set(_HIDE_INLINES ON)
-if(CMAKE_CXX_COMPILER_IS_CLANG AND CMAKE_CXX_COMPILER_VERSION VERSION_LESS 8)
-  set(_HIDE_INLINES OFF)
-endif()
-
 # set these as the defaults
 if(timemory_MASTER_PROJECT)
-    set(CMAKE_VISIBILITY_INLINES_HIDDEN ${_HIDE_INLINES} CACHE BOOL
+    set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF CACHE BOOL
         "Add compile flag to hide symbols of inline functions")
     set(CMAKE_C_VISIBILITY_PRESET "default" CACHE STRING "Default visibility")
     set(CMAKE_CXX_VISIBILITY_PRESET "default" CACHE STRING "Default visibility")
 else()
-    set(CMAKE_VISIBILITY_INLINES_HIDDEN ${_HIDE_INLINES})
+    set(CMAKE_VISIBILITY_INLINES_HIDDEN OFF)
     set(CMAKE_C_VISIBILITY_PRESET "default")
     set(CMAKE_CXX_VISIBILITY_PRESET "default")
 endif()

--- a/docs/conf.py
+++ b/docs/conf.py
@@ -155,6 +155,8 @@ for file in glob.glob("*.xml"):
             " TIMEMORY_VISIBLE",
             "TIMEMORY_ALWAYS_INLINE",
             "TIMEMORY_HOT",
+            "TIMEMORY_DLL ",
+            "TIMEMORY_CDLL ",
         ]:
             if key in line:
                 line = line.replace(key, "")

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -8,4 +8,8 @@ if(TIMEMORY_BUILD_PYTHON)
 
     message(STATUS "Adding external/line-profiler")
     add_subdirectory(line-profiler)
+
+    if(TARGET libpytimemory AND TARGET _line_profiler)
+        add_dependencies(libpytimemory _line_profiler)
+    endif()
 endif()

--- a/source/timemory/compat/library.h
+++ b/source/timemory/compat/library.h
@@ -355,7 +355,7 @@ extern "C"
     ///
     /// }
     /// \endcode
-    extern timemory_create_func_t timemory_create_function TIMEMORY_VISIBLE;
+    extern TIMEMORY_DLL timemory_create_func_t timemory_create_function TIMEMORY_VISIBLE;
 
     /// \var timemory_delete_func_t timemory_delete_function
     /// The function pointer to set which deletes an entry created by \ref
@@ -392,7 +392,7 @@ extern "C"
     ///
     /// }
     /// \endcode
-    extern timemory_delete_func_t timemory_delete_function TIMEMORY_VISIBLE;
+    extern TIMEMORY_DLL timemory_delete_func_t timemory_delete_function TIMEMORY_VISIBLE;
 
 #if defined(__cplusplus)
 }

--- a/source/timemory/compat/library.h
+++ b/source/timemory/compat/library.h
@@ -285,6 +285,7 @@ extern "C"
                                           const char*) TIMEMORY_VISIBLE;
 
     extern bool timemory_trace_is_initialized(void) TIMEMORY_VISIBLE;
+    extern void timemory_reset_throttle(const char* name) TIMEMORY_VISIBLE;
     extern bool timemory_is_throttled(const char* name) TIMEMORY_VISIBLE;
     extern void timemory_add_hash_id(uint64_t id, const char* name) TIMEMORY_VISIBLE;
     extern void timemory_add_hash_ids(uint64_t nentries, uint64_t* ids,
@@ -298,7 +299,10 @@ extern "C"
     extern void timemory_trace_set_env(const char*, const char*) TIMEMORY_VISIBLE;
 
 #if defined(TIMEMORY_MPI_GOTCHA)
-    /// \fn timemory_trace_set_mpi
+    /// \fn void timemory_trace_set_mpi(bool use, bool attached)
+    /// \param[in] use Use MPI gotcha
+    /// \param[in] attached Tracing application has attached to a running program
+    ///
     /// This function is only declared and defined if timemory was built
     /// with support for MPI and GOTCHA.
     extern void timemory_trace_set_mpi(bool use, bool attached) TIMEMORY_VISIBLE;

--- a/source/timemory/compat/library.h
+++ b/source/timemory/compat/library.h
@@ -355,7 +355,7 @@ extern "C"
     ///
     /// }
     /// \endcode
-    extern timemory_create_func_t timemory_create_function;
+    extern timemory_create_func_t timemory_create_function TIMEMORY_VISIBLE;
 
     /// \var timemory_delete_func_t timemory_delete_function
     /// The function pointer to set which deletes an entry created by \ref
@@ -392,7 +392,7 @@ extern "C"
     ///
     /// }
     /// \endcode
-    extern timemory_delete_func_t timemory_delete_function;
+    extern timemory_delete_func_t timemory_delete_function TIMEMORY_VISIBLE;
 
 #if defined(__cplusplus)
 }

--- a/source/timemory/compat/macros.h
+++ b/source/timemory/compat/macros.h
@@ -93,31 +93,31 @@
 //
 //======================================================================================//
 
-#if !defined(tim_cdll)
+#if !defined(TIMEMORY_CDLL)
 #    if defined(_WINDOWS)
 #        if defined(TIMEMORY_CDLL_EXPORT)
-#            define tim_cdll __declspec(dllexport)
+#            define TIMEMORY_CDLL __declspec(dllexport)
 #        elif defined(TIMEMORY_CDLL_IMPORT)
-#            define tim_cdll __declspec(dllimport)
+#            define TIMEMORY_CDLL __declspec(dllimport)
 #        else
-#            define tim_cdll
+#            define TIMEMORY_CDLL
 #        endif
 #    else
-#        define tim_cdll
+#        define TIMEMORY_CDLL
 #    endif
 #endif
 
-#if !defined(tim_dll)
+#if !defined(TIMEMORY_DLL)
 #    if defined(_WINDOWS)
 #        if defined(TIMEMORY_DLL_EXPORT)
-#            define tim_dll __declspec(dllexport)
+#            define TIMEMORY_DLL __declspec(dllexport)
 #        elif defined(TIMEMORY_DLL_IMPORT)
-#            define tim_dll __declspec(dllimport)
+#            define TIMEMORY_DLL __declspec(dllimport)
 #        else
-#            define tim_dll
+#            define TIMEMORY_DLL
 #        endif
 #    else
-#        define tim_dll
+#        define TIMEMORY_DLL
 #    endif
 #endif
 

--- a/source/timemory/utility/signals.hpp
+++ b/source/timemory/utility/signals.hpp
@@ -271,8 +271,12 @@ enable_signal_detection(signal_settings::signal_set_t operations)
         operations = signal_settings::enabled();
     else
     {
-        for(auto& itr : signal_settings::get_enabled())
-            signal_settings::disable(itr);
+        auto _enabled = signal_settings::get_enabled();
+        if(!_enabled.empty())
+        {
+            for(const auto& itr : _enabled)
+                signal_settings::disable(itr);
+        }
         signal_settings::check_environment();
         for(auto& itr : operations)
             signal_settings::enable(itr);

--- a/timemory/__init__.py.in
+++ b/timemory/__init__.py.in
@@ -46,6 +46,11 @@ __maintainer__ = "Jonathan Madsen"
 __email__ = "jrmadsen@lbl.gov"
 __status__ = "Development"
 
+try:
+    import cPickle as pickle
+except ImportError:
+    import pickle
+
 # get the path to this directory
 this_path = os.path.abspath(os.path.dirname(__file__))
 
@@ -310,3 +315,12 @@ build_info = sys.modules[__name__].__getattribute__("build_info")
 
 version = sys.modules[__name__].__getattribute__("version")
 '''Version string'''
+
+# this is required for correct pickling
+try:
+    if 'line_profiler' not in sys.modules:
+        from . import line_profiler as lineprof
+        sys.modules['line_profiler'] = lineprof
+        sys.modules['line_profiler._line_profiler'] = lineprof._line_profiler
+except ImportError:
+    pass


### PR DESCRIPTION
- the modifications to `timemory/compat/library.h` (required for the breathe documentation to render correctly) was missing a declaration of `void timemory_reset_throttle(const char*)`
- the macros were also tweaked bc of the documentation and this caused Windows builds to fail