### PR TITLE
Enable XML support by default for most compilers

### DIFF
--- a/cmake/Modules/Options.cmake
+++ b/cmake/Modules/Options.cmake
@@ -36,6 +36,7 @@ set(_NON_APPLE_UNIX OFF)
 set(_UNIX_OS ${UNIX})
 set(_DEFAULT_BUILD_SHARED ON)
 set(_DEFAULT_BUILD_STATIC OFF)
+set(_USE_XML ON)
 
 set(SANITIZER_TYPE leak CACHE STRING "Sanitizer type")
 set(TIMEMORY_gperftools_COMPONENTS "profiler" CACHE STRING "gperftools components")
@@ -67,6 +68,11 @@ endif()
 
 if(WIN32)
     set(_BUILD_CALIPER OFF)
+endif()
+
+# intel compiler has had issues with rapidxml library in past so default to off
+if(CMAKE_CXX_COMPILER_IS_INTEL)
+    set(_USE_XML OFF)
 endif()
 
 # Check if CUDA can be enabled if CUDA is enabled or in auto-detect mode
@@ -335,6 +341,8 @@ add_option(TIMEMORY_USE_LIKWID_NVMON
     "Enable LIKWID support for nvidia (GPU)" ${_LIKWID_NVMON} CMAKE_DEFINE)
 add_option(TIMEMORY_USE_GOTCHA
     "Enable GOTCHA" ${_GOTCHA} CMAKE_DEFINE)
+add_option(TIMEMORY_USE_XML
+    "Enable XML serialization support" ${_USE_XML} CMAKE_DEFINE)
 add_option(TIMEMORY_BUILD_ERT
     "Build ERT library" ON)
 if(CMAKE_CXX_COMPILER_IS_CLANG OR TIMEMORY_BUILD_DOCS)

--- a/cmake/Modules/Packages.cmake
+++ b/cmake/Modules/Packages.cmake
@@ -16,8 +16,8 @@ add_interface_library(timemory-headers
     "Provides minimal set of include flags to compile with timemory")
 add_interface_library(timemory-precompiled-headers
     "Provides timemory-headers + precompiles headers if CMAKE_VERSION >= 3.16")
-add_interface_library(timemory-cereal-xml
-    "Enables XML serialization output")
+add_interface_library(timemory-xml
+    "Enables XML serialization support")
 add_interface_library(timemory-extern
     "Enables pre-processor directive to ensure all extern templates are used")
 add_interface_library(timemory-statistics
@@ -377,6 +377,10 @@ endif()
 # include threading because of rooflines
 target_link_libraries(timemory-headers INTERFACE timemory-threading)
 
+if(TIMEMORY_USE_XML)
+    target_link_libraries(timemory-headers INTERFACE timemory-xml)
+endif()
+
 # minimum: C++14
 target_compile_features(timemory-headers INTERFACE
     cxx_std_14
@@ -467,7 +471,7 @@ endif()
 #----------------------------------------------------------------------------------------#
 
 
-timemory_target_compile_definitions(timemory-cereal-xml INTERFACE TIMEMORY_USE_XML_ARCHIVE)
+timemory_target_compile_definitions(timemory-xml INTERFACE TIMEMORY_USE_XML)
 
 
 #----------------------------------------------------------------------------------------#

--- a/docs/api/type_traits.md
+++ b/docs/api/type_traits.md
@@ -98,7 +98,7 @@ user code.
 .. doxygenstruct:: tim::trait::output_archive
    :members:
    :undoc-members:
-.. doxygenstruct:: tim::trait::pretty_json
+.. doxygenstruct:: tim::trait::pretty_archive
    :members:
    :undoc-members:
 .. doxygenstruct:: tim::trait::requires_json

--- a/examples/ex-cxx-tuple/CMakeLists.txt
+++ b/examples/ex-cxx-tuple/CMakeLists.txt
@@ -3,7 +3,7 @@ cmake_minimum_required(VERSION 3.11 FATAL_ERROR)
 project(timemory-CXX-Tuple-Example LANGUAGES C CXX)
 
 set(EXE_NAME ex_cxx_tuple)
-set(COMPONENTS compile-options threading analysis-tools OPTIONAL_COMPONENTS cereal-xml cxx)
+set(COMPONENTS compile-options threading analysis-tools OPTIONAL_COMPONENTS xml cxx)
 
 option(USE_MPI "Enable MPI" ON)
 if(USE_MPI)

--- a/examples/ex-cxx-tuple/ex_cxx_tuple.cpp
+++ b/examples/ex-cxx-tuple/ex_cxx_tuple.cpp
@@ -23,6 +23,13 @@
 // SOFTWARE.
 //
 
+#define TIMEMORY_INPUT_ARCHIVE ::tim::cereal::XMLInputArchive
+#define TIMEMORY_OUTPUT_ARCHIVE ::tim::cereal::XMLOutputArchive
+
+#include "timemory/timemory.hpp"
+#include "timemory/utility/signals.hpp"
+#include "timemory/utility/testing.hpp"
+
 #include <cassert>
 #include <chrono>
 #include <cmath>
@@ -33,10 +40,6 @@
 #include <thread>
 #include <unordered_map>
 #include <vector>
-
-#include "timemory/timemory.hpp"
-#include "timemory/utility/signals.hpp"
-#include "timemory/utility/testing.hpp"
 
 using namespace tim::stl;
 using namespace tim::component;

--- a/examples/ex-statistics/ex_statistics.cpp
+++ b/examples/ex-statistics/ex_statistics.cpp
@@ -35,7 +35,7 @@
 //
 // all types use pretty json
 //
-TIMEMORY_DEFINE_CONCRETE_TRAIT(pretty_json, void, std::true_type)
+TIMEMORY_DEFINE_CONCRETE_TRAIT(pretty_archive, void, std::true_type)
 
 #include "timemory/components/types.hpp"
 

--- a/source/timemory/api.hpp
+++ b/source/timemory/api.hpp
@@ -253,26 +253,12 @@ class XMLOutputArchive;
 #    define TIMEMORY_PYTHON_PLOTTER "python"
 #endif
 
-#if !defined(TIMEMORY_USE_XML_ARCHIVE)
-//
-#    if !defined(TIMEMORY_DEFAULT_INPUT_ARCHIVE)
-#        define TIMEMORY_DEFAULT_INPUT_ARCHIVE cereal::JSONInputArchive
-#    endif
-//
-#    if !defined(TIMEMORY_DEFAULT_OUTPUT_ARCHIVE)
-#        define TIMEMORY_DEFAULT_OUTPUT_ARCHIVE ::tim::type_list<>
-#    endif
-//
-#else
-//
-#    if !defined(TIMEMORY_DEFAULT_INPUT_ARCHIVE)
-#        define TIMEMORY_DEFAULT_INPUT_ARCHIVE cereal::XMLInputArchive
-#    endif
-//
-#    if !defined(TIMEMORY_DEFAULT_OUTPUT_ARCHIVE)
-#        define TIMEMORY_DEFAULT_OUTPUT_ARCHIVE cereal::XMLOutputArchive
-#    endif
-//
+#if !defined(TIMEMORY_DEFAULT_INPUT_ARCHIVE)
+#    define TIMEMORY_DEFAULT_INPUT_ARCHIVE cereal::JSONInputArchive
+#endif
+
+#if !defined(TIMEMORY_DEFAULT_OUTPUT_ARCHIVE)
+#    define TIMEMORY_DEFAULT_OUTPUT_ARCHIVE ::tim::type_list<>
 #endif
 
 #if !defined(TIMEMORY_INPUT_ARCHIVE)

--- a/source/timemory/mpl/filters.hpp
+++ b/source/timemory/mpl/filters.hpp
@@ -149,51 +149,6 @@ template <template <typename> class TraitT, typename... T>
 using get_trait_type_t = typename get_trait_type<TraitT, T...>::type;
 
 //======================================================================================//
-// check if type is in expansion
-//
-template <typename...>
-struct is_one_of
-{
-    static constexpr bool value = false;
-};
-
-template <typename F, typename S, template <typename...> class Tuple, typename... T>
-struct is_one_of<F, S, Tuple<T...>>
-{
-    static constexpr bool value =
-        std::is_same<F, S>::value || is_one_of<F, Tuple<T...>>::value;
-};
-
-template <typename F, typename S, template <typename...> class Tuple, typename... T>
-struct is_one_of<F, Tuple<S, T...>>
-{
-    static constexpr bool value = is_one_of<F, S, Tuple<T...>>::value;
-};
-
-//======================================================================================//
-// check if trait is satisfied by at least one type in variadic sequence
-//
-template <template <typename> class Test, typename Sequence>
-struct contains_one_of;
-
-template <template <typename> class Test, template <typename...> class Tuple>
-struct contains_one_of<Test, Tuple<>>
-{
-    static constexpr bool value = false;
-    using type                  = Tuple<>;
-};
-
-template <template <typename> class Test, typename F, template <typename...> class Tuple,
-          typename... T>
-struct contains_one_of<Test, Tuple<F, T...>>
-{
-    static constexpr bool value =
-        Test<F>::value || contains_one_of<Test, Tuple<T...>>::value;
-    using type = conditional_t<(Test<F>::value), F,
-                               typename contains_one_of<Test, Tuple<T...>>::type>;
-};
-
-//======================================================================================//
 // check if any types are integral types
 //
 template <typename...>
@@ -412,21 +367,6 @@ using append_type_t = typename append_type<Tp, Types>::type;
 ///
 template <typename Tp, typename Types>
 using remove_type_t = typename remove_type<Tp, Types>::type;
-
-///
-/// check if type is in expansion
-///
-template <typename Tp, typename Types>
-using is_one_of = typename impl::is_one_of<Tp, Types>;
-
-///
-/// check if type is in expansion
-///
-template <template <typename> class Predicate, typename Types>
-using contains_one_of = typename impl::contains_one_of<Predicate, Types>;
-
-template <template <typename> class Predicate, typename Types>
-using contains_one_of_t = typename contains_one_of<Predicate, Types>::type;
 
 //======================================================================================//
 

--- a/source/timemory/mpl/policy.hpp
+++ b/source/timemory/mpl/policy.hpp
@@ -215,6 +215,57 @@ struct output_archive<cereal::MinimalJSONOutputArchive, Api>
     }
 };
 
+//--------------------------------------------------------------------------------------//
+#if defined(TIMEMORY_USE_XML)
+///
+/// partial specialization for XMLOutputArchive
+///
+template <typename Api>
+struct output_archive<cereal::XMLOutputArchive, Api>
+{
+    using type        = cereal::XMLOutputArchive;
+    using pointer     = std::shared_ptr<type>;
+    using option_type = typename type::Options;
+    using indent_type = bool;
+    using output_type = bool;
+
+    static unsigned int& precision()
+    {
+        static unsigned int value = 16;
+        return value;
+    }
+
+    // indent the output
+    static indent_type& indent()
+    {
+        static indent_type value =
+            trait::pretty_archive<Api>::value || trait::pretty_archive<void>::value;
+        return value;
+    }
+
+    // output the type as an attribute
+    static output_type& type_attribute()
+    {
+        static output_type value = false;
+        return value;
+    }
+
+    // Whether dynamically sized containers output the size=dynamic attribute
+    static output_type& size_attribute()
+    {
+        static output_type value = false;
+        return value;
+    }
+
+    static pointer get(std::ostream& os)
+    {
+        //  Option args: precision, spacing, indent size
+        //  The last two options are meaningless for the minimal writer
+        option_type opts(precision(), indent(), type_attribute(), size_attribute());
+        return std::make_shared<type>(os, opts);
+    }
+};
+#endif
 //======================================================================================//
 
 template <typename Tp>

--- a/source/timemory/operations/types/finalize/print.hpp
+++ b/source/timemory/operations/types/finalize/print.hpp
@@ -202,11 +202,7 @@ print<Tp, true>::setup()
         return success;
     };
 
-    auto is_minimal_json = std::is_same<trait::output_archive_t<Tp>,
-                                        cereal::MinimalJSONOutputArchive>::value;
-    auto is_pretty_json =
-        std::is_same<trait::output_archive_t<Tp>, cereal::PrettyJSONOutputArchive>::value;
-    auto fext       = (is_minimal_json || is_pretty_json) ? ".json" : ".xml";
+    auto fext       = trait::archive_extension<trait::output_archive_t<Tp>>{}();
     auto extensions = tim::delimit(m_settings->get_input_extensions(), ",; ");
 
     tree_outfname = settings::compose_output_filename(label + ".tree", fext);

--- a/source/timemory/tpls/cereal/archives.hpp
+++ b/source/timemory/tpls/cereal/archives.hpp
@@ -33,9 +33,24 @@
 #    pragma GCC diagnostic ignored "-Wclass-memaccess"
 #endif
 
+// forward decls
+namespace tim
+{
+namespace cereal
+{
+class BinaryInputArchive;
+class BinaryOutputArchive;
+class PortableBinaryInputArchive;
+class PortableBinaryOutputArchive;
+class XMLInputArchive;
+class XMLOutputArchive;
+// json are always included so no forward decl necessary
+}  // namespace cereal
+}  // namespace tim
+
 // archives
 #include "timemory/tpls/cereal/cereal/archives/json.hpp"
-#if defined(TIMEMORY_USE_XML_ARCHIVE)
+#if defined(TIMEMORY_USE_XML)
 #    include "timemory/tpls/cereal/cereal/archives/xml.hpp"
 #endif
 

--- a/source/timemory/tpls/cereal/cereal/archives/xml.hpp
+++ b/source/timemory/tpls/cereal/cereal/archives/xml.hpp
@@ -53,7 +53,7 @@ namespace xml_detail
 //! The default name for the root node in a cereal xml archive.
 /*! You can define TIMEMORY_CEREAL_XML_STRING_VALUE to be different assuming you do so
     before this file is included. */
-#    define TIMEMORY_CEREAL_XML_STRING_VALUE "cereal"
+#    define TIMEMORY_CEREAL_XML_STRING_VALUE "timemory_xml"
 #endif  // TIMEMORY_CEREAL_XML_STRING_VALUE
 
 //! The name given to the root node in a cereal xml archive

--- a/source/timemory/tpls/cereal/cereal/cereal.hpp
+++ b/source/timemory/tpls/cereal/cereal/cereal.hpp
@@ -617,8 +617,11 @@ private:
         //    hash, detail::Version<T>::version);
 
         if(insertion.second)  // insertion took place, serialize the version number
+        {
+#if !defined(TIMEMORY_DISABLE_CEREAL_CLASS_VERSION)
             process(make_nvp<ArchiveType>("cereal_class_version", version));
-
+#endif
+        }
         return version;
     }
 
@@ -1059,9 +1062,11 @@ private:
             return lookupResult->second;
         else  // need to load
         {
-            std::uint32_t version;
+            std::uint32_t version = 0;
 
+#if !defined(TIMEMORY_DISABLE_CEREAL_CLASS_VERSION)
             process(make_nvp<ArchiveType>("cereal_class_version", version));
+#endif
             itsVersionedTypes.emplace_hint(lookupResult, hash, version);
 
             return version;


### PR DESCRIPTION
- renames `pretty_json` type-trait to `pretty_archive`
- adds default policy settings for `cereal::XMLOutputArchive`
- renames `timemory-cereal-xml` INTERFACE library to `timemory-xml`
- creates `trait::archive_extension` for configuring the default extension for archive types
- forward declares `tim::cereal::Binary{Input,Output}Archive` and `tim::cereal::PortableBinary{Input,Output}Archive` and configures their default extension to `.dat`