### PR TITLE
Python Hatchet Submodule

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -87,7 +87,7 @@ install:
           $env:PYTHON_EXE = "C:\Python$env:PYTHON\python.exe"
         }
         python -m pip install --disable-pip-version-check --user --upgrade pip wheel
-        python -m pip install --user cython numpy matplotlib pillow
+        python -m pip install --user cython numpy matplotlib pillow pandas pydot
       } elseif ($env:CONDA) {
         if ($env:PLATFORM -eq "x64") {
           $env:PATH = "C:\Miniconda$env:CONDA-x64;C:\Miniconda$env:CONDA-x64\Scripts;$env:PATH"
@@ -101,7 +101,7 @@ install:
           $env:PYTHON_EXE = "C:\Miniconda$env:CONDA\python.exe"
         }
         conda update -y -q -n base conda
-        conda install -y -c defaults -c conda-forge -q pip setuptools scikit-build numpy matplotlib pillow cython
+        conda install -y -c defaults -c conda-forge -q pip setuptools scikit-build numpy matplotlib pillow cython pandas pydot
       }
       $env:TIMEMORY_FILE_OUTPUT = "OFF"
       $env:TIMEMORY_AUTO_OUTPUT = "ON"

--- a/.gitmodules
+++ b/.gitmodules
@@ -22,3 +22,6 @@
 [submodule "external/PTL"]
 	path = external/ptl
 	url = https://github.com/jrmadsen/PTL.git
+[submodule "external/hatchet"]
+	path = external/hatchet
+	url = https://github.com/jrmadsen/hatchet.git

--- a/.requirements/runtime.txt
+++ b/.requirements/runtime.txt
@@ -3,3 +3,5 @@ numpy
 matplotlib
 pillow
 six
+pandas
+pydot

--- a/.travis.yml
+++ b/.travis.yml
@@ -232,7 +232,7 @@ before_install:
   - if [ "${EXECUTE}" -ne 0 ]; then conda config --set always_yes yes --set changeps1 no; fi
 
 install:
-  - if [ "${EXECUTE}" -ne 0 ]; then conda create -c conda-forge -c defaults -n pyctest python=${TRAVIS_PYTHON_VERSION} pyctest scikit-build cmake numpy matplotlib pillow pip cython; fi
+  - if [ "${EXECUTE}" -ne 0 ]; then conda create -c conda-forge -c defaults -n pyctest python=${TRAVIS_PYTHON_VERSION} pyctest scikit-build cmake numpy matplotlib pillow pip cython pydot pandas; fi
   - if [ "${EXECUTE}" -ne 0 ]; then source activate pyctest; fi
   - if [ "${EXECUTE}" -ne 0 ]; then if [ -n "$(which mpicc)" ]; then python -m pip install mpi4py; fi; fi
 

--- a/cmake/Modules/Options.cmake
+++ b/cmake/Modules/Options.cmake
@@ -10,7 +10,14 @@ include_guard(DIRECTORY)
 include(MacroUtilities)
 include(CheckLanguage)
 
-set(TIMEMORY_REQUIRE_PACKAGES ON CACHE BOOL "Disable auto-detection and explicitly require packages")
+set(TIMEMORY_REQUIRE_PACKAGES ON CACHE BOOL
+    "Disable auto-detection and explicitly require packages")
+
+# advanced options not using the "add_option" macro
+option(SPACK_BUILD "Tweak some installation directories when building via spack" OFF)
+option(TIMEMORY_SOURCE_GROUP "Enable source_group" OFF)
+mark_as_advanced(SPACK_BUILD)
+mark_as_advanced(TIMEMORY_SOURCE_GROUP)
 
 function(DEFINE_DEFAULT_OPTION VAR VAL)
     if(TIMEMORY_REQUIRE_PACKAGES)
@@ -74,6 +81,12 @@ endif()
 if(CMAKE_CXX_COMPILER_IS_INTEL)
     set(_USE_XML OFF)
 endif()
+
+set(_HATCHET ${_UNIX_OS})
+# once hatchet is available in a release with timemory support
+# if(SKBUILD OR SPACK_BUILD)
+#    set(_HATCHET OFF)
+# endif()
 
 # Check if CUDA can be enabled if CUDA is enabled or in auto-detect mode
 if(TIMEMORY_USE_CUDA OR (NOT DEFINED TIMEMORY_USE_CUDA AND NOT TIMEMORY_REQUIRE_PACKAGES))
@@ -218,6 +231,8 @@ add_option(TIMEMORY_BUILD_PYTHON
     "Build Python binds for ${PROJECT_NAME}" OFF)
 add_option(TIMEMORY_BUILD_PYTHON_LINE_PROFILER
     "Build customized Python line-profiler" ${_UNIX_OS})
+add_option(TIMEMORY_BUILD_PYTHON_HATCHET
+    "Build internal Hatchet distribution" ${_HATCHET})
 add_option(TIMEMORY_BUILD_LTO
     "Enable link-time optimizations in build" OFF)
 add_option(TIMEMORY_BUILD_TOOLS
@@ -479,9 +494,6 @@ macro(_TIMEMORY_ACTIVATE_CLANG_TIDY)
     endif()
 endmacro()
 
-option(TIMEMORY_SOURCE_GROUP "Enable source_group" OFF)
-mark_as_advanced(TIMEMORY_SOURCE_GROUP)
-
 # these variables conflict with variables in examples, leading to things like: -lON flags
 get_property(DEFAULT_OPTION_VARIABLES GLOBAL PROPERTY DEFAULT_OPTION_VARIABLES)
 foreach(_VAR ${DEFAULT_OPTION_VARIABLES})
@@ -498,9 +510,6 @@ endif()
 if(TIMEMORY_USE_PYTHON)
     set(TIMEMORY_BUILD_PYTHON ON)
 endif()
-
-option(SPACK_BUILD "Tweak some installation directories when building via spack" OFF)
-mark_as_advanced(SPACK_BUILD)
 
 if(WIN32)
     option(TIMEMORY_USE_WINSOCK "Include winsock.h with the windows build" OFF)

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -21,8 +21,12 @@ if(TIMEMORY_BUILD_PYTHON AND TIMEMORY_BUILD_PYTHON_HATCHET)
         REPO_URL https://github.com/jrmadsen/hatchet.git
         REPO_BRANCH timemory)
 
-    find_package(Cython QUIET)
-    if(Cython_FOUND)
+    # line_profiler might have already found Cython
+    if(CYTHON_EXECUTABLE)
+        find_package(Cython QUIET)
+    endif()
+
+    if(CYTHON_EXECUTABLE OR Cython_FOUND)
         message(STATUS "Adding external/hatchet")
         add_subdirectory(hatchet)
     else()

--- a/external/CMakeLists.txt
+++ b/external/CMakeLists.txt
@@ -13,3 +13,24 @@ if(TIMEMORY_BUILD_PYTHON AND TIMEMORY_BUILD_PYTHON_LINE_PROFILER)
         add_dependencies(libpytimemory _line_profiler)
     endif()
 endif()
+
+if(TIMEMORY_BUILD_PYTHON AND TIMEMORY_BUILD_PYTHON_HATCHET)
+    checkout_git_submodule(RECURSIVE
+        RELATIVE_PATH external/hatchet
+        WORKING_DIRECTORY ${PROJECT_SOURCE_DIR}
+        REPO_URL https://github.com/jrmadsen/hatchet.git
+        REPO_BRANCH timemory)
+
+    find_package(Cython QUIET)
+    if(Cython_FOUND)
+        message(STATUS "Adding external/hatchet")
+        add_subdirectory(hatchet)
+    else()
+        message(WARNING "Internal Hatchet could not built because Cython could not be found")
+        set(TIMEMORY_BUILD_PYTHON_HATCHET OFF PARENT_SCOPE)
+    endif()
+
+    if(TARGET libpytimemory AND TARGET hatchet)
+        add_dependencies(libpytimemory hatchet)
+    endif()
+endif()

--- a/timemory/__init__.py.in
+++ b/timemory/__init__.py.in
@@ -370,3 +370,33 @@ try:
         sys.modules["line_profiler._line_profiler"] = _lineprof
 except (ImportError, AttributeError):
     pass
+
+# try to import real hatchet
+try:
+    if "hatchet" not in sys.modules:
+        # check for timemory reader
+        from hatchet.readers import timemory_reader
+
+        sys.modules["hatchet"] = hatchet
+        sys.modules["timemory.hatchet"] = hatchet
+except (ImportError):
+    pass
+
+# if real hatchet doesn't exist w/ timemory support, try to import the local one
+try:
+    if "hatchet" not in sys.modules:
+        from . import hatchet as hatchet
+
+        sys.modules["hatchet"] = hatchet
+        sys.modules["timemory.hatchet"] = hatchet
+except (ImportError):
+    pass
+
+# if the real hatchet does exist but timemory.hatchet does not:
+try:
+    if "hatchet" in sys.modules and "timemory.hatchet" in sys.modules:
+        from . import hatchet as hatchet
+
+        sys.modules["timemory.hatchet"] = hatchet
+except (ImportError):
+    pass

--- a/timemory/__init__.py.in
+++ b/timemory/__init__.py.in
@@ -371,32 +371,30 @@ try:
 except (ImportError, AttributeError):
     pass
 
+# try to import the local hatchet first
+try:
+    from . import hatchet as local_hatchet
+    from .hatchet.readers import timemory_reader as hatchet_reader
+    from .hatchet.graphframe import GraphFrame as graphframe
+
+    sys.modules["timemory.hatchet"] = local_hatchet
+    sys.modules["timemory.hatchet_reader"] = hatchet_reader
+    __all__ += ["graphframe"]
+except (ImportError) as e:
+    pass
+
 # try to import real hatchet
 try:
     if "hatchet" not in sys.modules:
-        # check for timemory reader
-        from hatchet.readers import timemory_reader
+        import hatchet as global_hatchet
 
-        sys.modules["hatchet"] = hatchet
-        sys.modules["timemory.hatchet"] = hatchet
+        sys.modules["hatchet"] = global_hatchet
 except (ImportError):
     pass
 
-# if real hatchet doesn't exist w/ timemory support, try to import the local one
+# if real hatchet doesn't exist, set the local one as the global
 try:
-    if "hatchet" not in sys.modules:
-        from . import hatchet as hatchet
-
-        sys.modules["hatchet"] = hatchet
-        sys.modules["timemory.hatchet"] = hatchet
-except (ImportError):
-    pass
-
-# if the real hatchet does exist but timemory.hatchet does not:
-try:
-    if "hatchet" in sys.modules and "timemory.hatchet" in sys.modules:
-        from . import hatchet as hatchet
-
-        sys.modules["timemory.hatchet"] = hatchet
-except (ImportError):
+    if "hatchet" not in sys.modules and "timemory.hatchet" in sys.modules:
+        sys.modules["hatchet"] = sys.modules["timemory.hatchet"]
+except (KeyError):
     pass


### PR DESCRIPTION
- [Hatchet](https://github.com/LLNL/hatchet) ([docs](https://hatchet.readthedocs.io/en/latest/index.html)) supports converting the timemory hierarchical JSON output (e.g. files with `.tree.json` extension or JSON dict via `timemory.get(hierarchy=True)` in python) to Pandas dataframes.
  - Hatchet supports several visualizations outputs and interactive Jupyter notebook exploration of the data
  - Hatchet also supports many other profiling output formats which timemory can forward markers to, such as Caliper. 
- Currently, hatchet has not created a release which has the timemory support and hatchet is probably going to used for most of the future developments w.r.t. to plotting and analysis so distributing it as a submodule makes sense.
  - Care has been taken to ensure that the local (internal) copy of hatchet is essentially a mirror of the upstream one and that having the real hatchet installed along with the submodule will not create conflicts
  - Once hatchet v1.3.1 or v1.4.0 has been released, when timemory is installed via `setup.py` or Spack, it will disable installing Hatchet via the submodule by default.

## Example Script

```python
import sys
import numpy as np
import timemory
import hatchet
from timemory.profiler import profile

@profile(["wall_clock"])
def fib(n):
    return n if n < 2 else (fib(n - 1) + fib(n - 2))


@profile(["wall_clock"])
def inefficient(n):
    a = 0
    for i in range(n):
        a += i
        for j in range(n):
            a += j
    arr = np.arange(a * n * n * n, dtype=np.double)
    return arr.sum()


def run(nfib):
    ret = 0
    ret += fib(nfib)
    ret += fib(nfib % 5 + 1)
    ret += inefficient(nfib)
    return ret


if __name__ == "__main__":
    nfib = int(sys.argv[1]) if len(sys.argv) > 1 else 20
    ans = run(nfib)
    print("Answer = {}".format(ans))
    gf = hatchet.graphframe.GraphFrame.from_timemory(timemory.get(hierarchy=True))
    print(gf.tree("sum.inc"))
```

## Example Text Output

```console
|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
|                                                           REAL-CLOCK TIMER (I.E. WALL-CLOCK TIMER)                                                           |
|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
|                               LABEL                                | COUNT  | DEPTH  | METRIC | UNITS  |  SUM   | MEAN   |  MIN   |  MAX   | STDDEV | % SELF |
|--------------------------------------------------------------------|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|
| >>> fib/ex_python_hatchet:15                                       |      2 |      0 | wall   | sec    |  0.314 |  0.157 |  0.314 |  0.314 |  0.222 |    0.0 |
| >>> |_fib/ex_python_hatchet:15                                     |      2 |      1 | wall   | sec    |  0.314 |  0.157 |  0.195 |  0.195 |  0.053 |    0.0 |
| >>>   |_fib/ex_python_hatchet:15                                   |      4 |      2 | wall   | sec    |  0.314 |  0.078 |  0.121 |  0.121 |  0.031 |    0.0 |
| >>>     |_fib/ex_python_hatchet:15                                 |      8 |      3 | wall   | sec    |  0.314 |  0.039 |  0.073 |  0.073 |  0.018 |    0.1 |
| >>>       |_fib/ex_python_hatchet:15                               |     16 |      4 | wall   | sec    |  0.314 |  0.020 |  0.045 |  0.045 |  0.010 |    0.1 |
| >>>         |_fib/ex_python_hatchet:15                             |     32 |      5 | wall   | sec    |  0.313 |  0.010 |  0.027 |  0.027 |  0.005 |    0.3 |
| >>>           |_fib/ex_python_hatchet:15                           |     64 |      6 | wall   | sec    |  0.312 |  0.005 |  0.017 |  0.017 |  0.003 |    0.6 |
| >>>             |_fib/ex_python_hatchet:15                         |    128 |      7 | wall   | sec    |  0.310 |  0.002 |  0.010 |  0.010 |  0.002 |    1.2 |
| >>>               |_fib/ex_python_hatchet:15                       |    256 |      8 | wall   | sec    |  0.307 |  0.001 |  0.006 |  0.006 |  0.001 |    2.3 |
| >>>                 |_fib/ex_python_hatchet:15                     |    512 |      9 | wall   | sec    |  0.300 |  0.001 |  0.004 |  0.004 |  0.000 |    4.6 |
| >>>                   |_fib/ex_python_hatchet:15                   |   1024 |     10 | wall   | sec    |  0.286 |  0.000 |  0.002 |  0.002 |  0.000 |    9.6 |
| >>>                     |_fib/ex_python_hatchet:15                 |   2026 |     11 | wall   | sec    |  0.259 |  0.000 |  0.002 |  0.002 |  0.000 |   18.7 |
| >>>                       |_fib/ex_python_hatchet:15               |   3632 |     12 | wall   | sec    |  0.210 |  0.000 |  0.001 |  0.001 |  0.000 |   33.1 |
| >>>                         |_fib/ex_python_hatchet:15             |   5020 |     13 | wall   | sec    |  0.141 |  0.000 |  0.001 |  0.001 |  0.000 |   48.2 |
| >>>                           |_fib/ex_python_hatchet:15           |   4760 |     14 | wall   | sec    |  0.073 |  0.000 |  0.000 |  0.000 |  0.000 |   62.9 |
| >>>                             |_fib/ex_python_hatchet:15         |   2942 |     15 | wall   | sec    |  0.027 |  0.000 |  0.000 |  0.000 |  0.000 |   74.1 |
| >>>                               |_fib/ex_python_hatchet:15       |   1152 |     16 | wall   | sec    |  0.007 |  0.000 |  0.000 |  0.000 |  0.000 |   83.7 |
| >>>                                 |_fib/ex_python_hatchet:15     |    274 |     17 | wall   | sec    |  0.001 |  0.000 |  0.000 |  0.000 |  0.000 |   88.5 |
| >>>                                   |_fib/ex_python_hatchet:15   |     36 |     18 | wall   | sec    |  0.000 |  0.000 |  0.000 |  0.000 |  0.000 |   96.7 |
| >>>                                     |_fib/ex_python_hatchet:15 |      2 |     19 | wall   | sec    |  0.000 |  0.000 |  0.000 |  0.000 |  0.000 |  100.0 |
| >>> inefficient/ex_python_hatchet:20                               |      1 |      0 | wall   | sec    |  0.115 |  0.115 |  0.115 |  0.115 |  0.000 |    0.1 |
| >>> |_inefficient/ex_python_hatchet:20                             |      2 |      1 | wall   | sec    |  0.115 |  0.057 |  0.101 |  0.101 |  0.062 |   88.0 |
| >>>   |__sum/_methods.py:36                                        |      1 |      2 | wall   | sec    |  0.014 |  0.014 |  0.014 |  0.014 |  0.000 |    0.1 |
| >>>     |__sum/_methods.py:36                                      |      1 |      3 | wall   | sec    |  0.014 |  0.014 |  0.014 |  0.014 |  0.000 |  100.0 |
|--------------------------------------------------------------------------------------------------------------------------------------------------------------|
```

## Example Hatchet Output

![Screen Shot 2020-12-02 at 1 32 10 PM](https://user-images.githubusercontent.com/6001865/100933903-d9e5e280-34a2-11eb-8649-8aa6b985dbd2.png)
