### PR TITLE
Compiler instrumentation api

### DIFF
--- a/source/python/libpytimemory-settings.cpp
+++ b/source/python/libpytimemory-settings.cpp
@@ -191,7 +191,7 @@ generate(py::module& _pymod)
     };
     auto _init = []() {
         auto ret = new tim::settings{};
-        *ret     = *tim::settings::instance<tim::api::native_tag>();
+        *ret     = *tim::settings::instance<TIMEMORY_API>();
         return ret;
     };
     auto _parse = [](py::object _instance) {
@@ -354,7 +354,7 @@ generate(py::module& _pymod)
                         py::arg("subparser") = true);
 
     std::set<std::string> names;
-    auto                  _settings = tim::settings::instance<tim::api::native_tag>();
+    auto                  _settings = tim::settings::instance<TIMEMORY_API>();
     if(_settings)
     {
         for(auto& itr : *_settings)

--- a/source/timemory/api.hpp
+++ b/source/timemory/api.hpp
@@ -24,61 +24,13 @@
 
 #pragma once
 
+#include "timemory/api/macros.hpp"
 #include "timemory/defines.h"
 #include "timemory/macros/os.hpp"
 #include "timemory/mpl/concepts.hpp"
 #include "timemory/version.h"
 
 #include <type_traits>
-
-/// \macro TIMEMORY_DECLARE_NS_API(NS, NAME)
-/// \brief Declare an API category. APIs are used to designate
-/// different project implementations, different external library tools, etc.
-///
-#if !defined(TIMEMORY_DECLARE_NS_API)
-#    define TIMEMORY_DECLARE_NS_API(NS, NAME)                                            \
-        namespace tim                                                                    \
-        {                                                                                \
-        namespace NS                                                                     \
-        {                                                                                \
-        struct NAME;                                                                     \
-        }                                                                                \
-        }
-#endif
-
-#if !defined(TIMEMORY_DECLARE_API)
-#    define TIMEMORY_DECLARE_API(NAME) TIMEMORY_DECLARE_NS_API(api, NAME)
-#endif
-
-//
-/// \macro TIMEMORY_DEFINE_NS_API(NS, NAME)
-/// \param NS sub-namespace within tim::api
-/// \param NAME the name of the API
-///
-/// \brief Define an API category within a namespace
-///
-#if !defined(TIMEMORY_DEFINE_NS_API)
-#    define TIMEMORY_DEFINE_NS_API(NS, NAME)                                             \
-        namespace tim                                                                    \
-        {                                                                                \
-        namespace NS                                                                     \
-        {                                                                                \
-        struct NAME : public concepts::api                                               \
-        {};                                                                              \
-        }                                                                                \
-        }
-#endif
-
-///
-/// \macro TIMEMORY_DEFINE_API
-/// \brief Define an API category. APIs are used to designate
-/// different project implementations, different external library tools, etc.
-/// Note: this macro inherits from \ref concepts::api instead of specializing
-/// is_api<...>, thus allowing specialization from tools downstream
-///
-#if !defined(TIMEMORY_DEFINE_API)
-#    define TIMEMORY_DEFINE_API(NAME) TIMEMORY_DEFINE_NS_API(api, NAME)
-#endif
 
 //
 // General APIs
@@ -216,7 +168,7 @@ class XMLOutputArchive;
 //
 
 #if !defined(TIMEMORY_DEFAULT_API)
-#    define TIMEMORY_DEFAULT_API ::tim::api::native_tag
+#    define TIMEMORY_DEFAULT_API ::tim::project::timemory
 #endif
 
 #if !defined(TIMEMORY_API)

--- a/source/timemory/api/macros.hpp
+++ b/source/timemory/api/macros.hpp
@@ -42,7 +42,7 @@
 #endif
 
 #if !defined(TIMEMORY_DECLARE_API)
-#    define TIMEMORY_DECLARE_API(NAME) TIMEMORY_DECLARE_NS_API(project, NAME)
+#    define TIMEMORY_DECLARE_API(NAME) TIMEMORY_DECLARE_NS_API(api, NAME)
 #endif
 
 //

--- a/source/timemory/api/macros.hpp
+++ b/source/timemory/api/macros.hpp
@@ -72,5 +72,5 @@
 /// is_api<...>, thus allowing specialization from tools downstream
 ///
 #if !defined(TIMEMORY_DEFINE_API)
-#    define TIMEMORY_DEFINE_API(NAME) TIMEMORY_DEFINE_NS_API(project, NAME)
+#    define TIMEMORY_DEFINE_API(NAME) TIMEMORY_DEFINE_NS_API(api, NAME)
 #endif

--- a/source/timemory/api/macros.hpp
+++ b/source/timemory/api/macros.hpp
@@ -1,0 +1,76 @@
+// MIT License
+//
+// Copyright (c) 2020, The Regents of the University of California,
+// through Lawrence Berkeley National Laboratory (subject to receipt of any
+// required approvals from the U.S. Dept. of Energy).  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "timemory/mpl/concepts.hpp"
+
+/// \macro TIMEMORY_DECLARE_NS_API(NS, NAME)
+/// \brief Declare an API category. APIs are used to designate
+/// different project implementations, different external library tools, etc.
+///
+#if !defined(TIMEMORY_DECLARE_NS_API)
+#    define TIMEMORY_DECLARE_NS_API(NS, NAME)                                            \
+        namespace tim                                                                    \
+        {                                                                                \
+        namespace NS                                                                     \
+        {                                                                                \
+        struct NAME;                                                                     \
+        }                                                                                \
+        }
+#endif
+
+#if !defined(TIMEMORY_DECLARE_API)
+#    define TIMEMORY_DECLARE_API(NAME) TIMEMORY_DECLARE_NS_API(project, NAME)
+#endif
+
+//
+/// \macro TIMEMORY_DEFINE_NS_API(NS, NAME)
+/// \param NS sub-namespace within tim::
+/// \param NAME the name of the API
+///
+/// \brief Define an API category within a namespace
+///
+#if !defined(TIMEMORY_DEFINE_NS_API)
+#    define TIMEMORY_DEFINE_NS_API(NS, NAME)                                             \
+        namespace tim                                                                    \
+        {                                                                                \
+        namespace NS                                                                     \
+        {                                                                                \
+        struct NAME : public concepts::api                                               \
+        {};                                                                              \
+        }                                                                                \
+        }
+#endif
+
+///
+/// \macro TIMEMORY_DEFINE_API
+/// \brief Define an API category. APIs are used to designate
+/// different project implementations, different external library tools, etc.
+/// Note: this macro inherits from \ref concepts::api instead of specializing
+/// is_api<...>, thus allowing specialization from tools downstream
+///
+#if !defined(TIMEMORY_DEFINE_API)
+#    define TIMEMORY_DEFINE_API(NAME) TIMEMORY_DEFINE_NS_API(project, NAME)
+#endif

--- a/source/timemory/components/data_tracker/components.hpp
+++ b/source/timemory/components/data_tracker/components.hpp
@@ -306,17 +306,17 @@ using data_handler_t = typename T::handler_type;
 /// \typedef tim::component::data_tracker_integer
 /// \brief Specialization of \ref tim::component::data_tracker for storing signed integer
 /// data
-using data_tracker_integer = data_tracker<intmax_t, project::timemory>;
+using data_tracker_integer = data_tracker<intmax_t, TIMEMORY_API>;
 //
 /// \typedef tim::component::data_tracker_unsigned
 /// \brief Specialization of \ref tim::component::data_tracker for storing unsigned
 /// integer data
-using data_tracker_unsigned = data_tracker<size_t, project::timemory>;
+using data_tracker_unsigned = data_tracker<size_t, TIMEMORY_API>;
 //
 /// \typedef tim::component::data_tracker_floating
 /// \brief Specialization of \ref tim::component::data_tracker for storing floating point
 /// data
-using data_tracker_floating = data_tracker<double, project::timemory>;
+using data_tracker_floating = data_tracker<double, TIMEMORY_API>;
 //
 }  // namespace component
 }  // namespace tim

--- a/source/timemory/components/data_tracker/types.hpp
+++ b/source/timemory/components/data_tracker/types.hpp
@@ -32,7 +32,7 @@
 #include "timemory/mpl/types.hpp"
 
 TIMEMORY_DECLARE_TEMPLATE_COMPONENT(data_tracker, typename InpT,
-                                    typename Tag = project::timemory)
+                                    typename Tag = TIMEMORY_API)
 
 //--------------------------------------------------------------------------------------//
 //
@@ -47,17 +47,17 @@ namespace component
 /// \typedef tim::component::data_tracker_integer
 /// \brief Specialization of \ref tim::component::data_tracker for storing signed integer
 /// data
-using data_tracker_integer = data_tracker<intmax_t, project::timemory>;
+using data_tracker_integer = data_tracker<intmax_t, TIMEMORY_API>;
 
 /// \typedef tim::component::data_tracker_unsigned
 /// \brief Specialization of \ref tim::component::data_tracker for storing unsigned
 /// integer data
-using data_tracker_unsigned = data_tracker<size_t, project::timemory>;
+using data_tracker_unsigned = data_tracker<size_t, TIMEMORY_API>;
 
 /// \typedef tim::component::data_tracker_floating
 /// \brief Specialization of \ref tim::component::data_tracker for storing floating point
 /// data
-using data_tracker_floating = data_tracker<double, project::timemory>;
+using data_tracker_floating = data_tracker<double, TIMEMORY_API>;
 }  // namespace component
 }  // namespace tim
 //
@@ -68,7 +68,7 @@ namespace trait
 template <typename InpT, typename Tag>
 struct component_apis<component::data_tracker<InpT, Tag>>
 {
-    using type = type_list<project::timemory, category::logger, os::agnostic>;
+    using type = type_list<TIMEMORY_API, category::logger, os::agnostic>;
 };
 //
 #if defined(TIMEMORY_COMPILER_INSTRUMENTATION)

--- a/source/timemory/components/macros.hpp
+++ b/source/timemory/components/macros.hpp
@@ -404,7 +404,7 @@
                                             trait::uses_value_storage<TYPE>::value>;         \
         extern template class storage<TYPE, typename TYPE::value_type>;                      \
         extern template class singleton<alias::storage_impl_t<TYPE>,                         \
-                                        alias::storage_pointer_t<TYPE>>;                     \
+                                        alias::storage_pointer_t<TYPE>, TIMEMORY_API>;       \
         extern template storage_singleton<alias::storage_t<TYPE>>*                           \
                                             get_storage_singleton<alias::storage_t<TYPE>>(); \
         extern template storage_initializer storage_initializer::get<TYPE>();                \
@@ -421,7 +421,7 @@
         template class impl::storage<TYPE, trait::uses_value_storage<TYPE>::value>;      \
         template class storage<TYPE, typename TYPE::value_type>;                         \
         template class singleton<alias::storage_impl_t<TYPE>,                            \
-                                 alias::storage_pointer_t<TYPE>>;                        \
+                                 alias::storage_pointer_t<TYPE>, TIMEMORY_API>;          \
         template storage_singleton<alias::storage_t<TYPE>>*                              \
                                      get_storage_singleton<alias::storage_t<TYPE>>();    \
         template storage_initializer storage_initializer::get<TYPE>();                   \

--- a/source/timemory/components/ompt/types.hpp
+++ b/source/timemory/components/ompt/types.hpp
@@ -39,12 +39,12 @@
 
 //======================================================================================//
 //
-TIMEMORY_DECLARE_TEMPLATE_COMPONENT(user_bundle, size_t Idx,
-                                    typename Tag = api::native_tag)
+TIMEMORY_DECLARE_TEMPLATE_COMPONENT(user_bundle, size_t Idx, typename Tag = TIMEMORY_API)
 //
 TIMEMORY_BUNDLE_INDEX(ompt_bundle_idx, 11110)
 //
-TIMEMORY_COMPONENT_ALIAS(user_ompt_bundle, user_bundle<ompt_bundle_idx, api::native_tag>)
+TIMEMORY_COMPONENT_ALIAS(user_ompt_bundle,
+                         user_bundle<ompt_bundle_idx, project::timemory>)
 //
 //--------------------------------------------------------------------------------------//
 //
@@ -59,7 +59,7 @@ namespace tim
 {
 namespace component
 {
-template <typename Api = api::native_tag>
+template <typename Api = TIMEMORY_API>
 struct ompt_handle;
 
 template <typename Api>
@@ -68,8 +68,8 @@ struct ompt_data_tracker;
 struct ompt_target_data_tag
 {};
 
-using ompt_native_handle       = ompt_handle<api::native_tag>;
-using ompt_native_data_tracker = ompt_data_tracker<api::native_tag>;
+using ompt_native_handle       = ompt_handle<TIMEMORY_API>;
+using ompt_native_data_tracker = ompt_data_tracker<TIMEMORY_API>;
 //
 using ompt_data_tracker_t = data_tracker<int64_t, ompt_target_data_tag>;
 //
@@ -122,7 +122,7 @@ struct is_available<component::ompt_native_data_tracker> : false_type
 //
 //--------------------------------------------------------------------------------------//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(ompt_handle<api::native_tag>, OMPT_HANDLE, "ompt_handle",
+TIMEMORY_PROPERTY_SPECIALIZATION(ompt_handle<TIMEMORY_API>, OMPT_HANDLE, "ompt_handle",
                                  "ompt", "ompt_handle", "openmp", "openmp_tools")
 //
 //======================================================================================//
@@ -166,7 +166,7 @@ struct endpoint_callback
 /// \brief this struct provides the methods through which a unique identifier and
 /// a label are generated for each OMPT callback.
 ///
-template <typename Api = api::native_tag>
+template <typename Api = TIMEMORY_API>
 struct context_handler;
 //
 //--------------------------------------------------------------------------------------//
@@ -175,7 +175,7 @@ struct context_handler;
 /// \brief this struct provides the routines through which timemory components
 /// are applied to the callbacks
 ///
-template <typename Components, typename Api = api::native_tag>
+template <typename Components, typename Api = TIMEMORY_API>
 struct callback_connector;
 //
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/containers/extern.cpp
+++ b/source/timemory/containers/extern.cpp
@@ -22,23 +22,6 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-//======================================================================================//
-// clang-format off
-//
-#include "timemory/containers/types.hpp"
 #include "timemory/containers/declaration.hpp"
 #include "timemory/containers/definition.hpp"
-//
-// #include "timemory/containers/extern.hpp"
-//
-// clang-format on
-//======================================================================================//
-
-// template class tim::component_list<tim::component::user_bundle<11100ul,
-// tim::api::native_tag>, tim::component::gperftools_cpu_profiler,
-// tim::component::gperftools_heap_profiler, tim::component::caliper,
-// tim::component::tau_marker, tim::component::papi_array<8ul>,
-// tim::component::cpu_roofline<float, double>, tim::component::cuda_event,
-// tim::component::nvtx_marker, tim::component::cupti_activity,
-// tim::component::cupti_counters, tim::component::gpu_roofline<float>,
-// tim::component::gpu_roofline<double> >;
+#include "timemory/containers/types.hpp"

--- a/source/timemory/data/handler.hpp
+++ b/source/timemory/data/handler.hpp
@@ -48,7 +48,7 @@ namespace data
 /// defined for a specific data type (e.g. int) with a tag (e.g. ConvergenceIterations)
 /// and shared among multiple template types of data_tracker<T>
 ///
-template <typename V, typename Tag = api::native_tag>
+template <typename V, typename Tag = TIMEMORY_API>
 struct handler
 {
     using value_type = V;

--- a/source/timemory/macros.hpp
+++ b/source/timemory/macros.hpp
@@ -584,7 +584,7 @@
 //======================================================================================//
 //
 #if !defined(TIMEMORY_OMPT_API_TAG)
-#    define TIMEMORY_OMPT_API_TAG ::tim::api::native_tag
+#    define TIMEMORY_OMPT_API_TAG TIMEMORY_API
 #endif
 
 // for callback declarations

--- a/source/timemory/mpl/type_traits.hpp
+++ b/source/timemory/mpl/type_traits.hpp
@@ -164,13 +164,13 @@ template <>
 struct runtime_enabled<void>
 {
     // GET specialization if component is available
-    static bool get() { return get_runtime_value(); }
+    static TIMEMORY_HOT TIMEMORY_INLINE bool get() { return get_runtime_value(); }
 
     // SET specialization if component is available
     static void set(bool val) { get_runtime_value() = val; }
 
 private:
-    static bool& get_runtime_value()
+    static TIMEMORY_HOT TIMEMORY_INLINE bool& get_runtime_value()
     {
         static bool _instance = TIMEMORY_DEFAULT_ENABLED;
         return _instance;
@@ -192,7 +192,7 @@ struct runtime_enabled
 
     // GET specialization if component is available
     template <typename U = T>
-    TIMEMORY_HOT static inline enable_if_t<is_available<U>::value, bool> get()
+    static TIMEMORY_HOT TIMEMORY_INLINE enable_if_t<is_available<U>::value, bool> get()
     {
         return (runtime_enabled<void>::get() && get_runtime_value() &&
                 apply<runtime_enabled>{}(api_type_list{}));
@@ -200,25 +200,26 @@ struct runtime_enabled
 
     /// SET specialization if component is available
     template <typename U = T>
-    TIMEMORY_HOT static inline enable_if_t<is_available<U>::value, void> set(bool val)
+    static TIMEMORY_HOT TIMEMORY_INLINE enable_if_t<is_available<U>::value, void> set(
+        bool val)
     {
         get_runtime_value() = val;
     }
 
     /// GET specialization if component is NOT available
     template <typename U = T>
-    static inline enable_if_t<!is_available<U>::value, bool> get()
+    static TIMEMORY_INLINE enable_if_t<!is_available<U>::value, bool> get()
     {
         return false;
     }
 
     /// SET specialization if component is NOT available
     template <typename U = T>
-    static inline enable_if_t<!is_available<U>::value, void> set(bool)
+    static TIMEMORY_INLINE enable_if_t<!is_available<U>::value, void> set(bool)
     {}
 
 private:
-    TIMEMORY_HOT static bool& get_runtime_value()
+    static TIMEMORY_HOT TIMEMORY_INLINE bool& get_runtime_value()
     {
         static bool _instance = is_available<T>::value;
         return _instance;
@@ -564,13 +565,13 @@ struct output_archive
 };
 
 template <>
-struct output_archive<manager, api::native_tag>
+struct output_archive<manager, TIMEMORY_API>
 {
     using type = cereal::BaseJSONOutputArchive<cereal::PrettyJsonWriter>;
 };
 
 template <typename Api>
-struct output_archive<manager, Api> : output_archive<manager, api::native_tag>
+struct output_archive<manager, Api> : output_archive<manager, TIMEMORY_API>
 {};
 
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/mpl/types.hpp
+++ b/source/timemory/mpl/types.hpp
@@ -217,16 +217,16 @@ struct units;
 template <typename T>
 struct echo_enabled;
 
-template <typename Api = api::native_tag>
+template <typename Api = TIMEMORY_API>
 struct api_input_archive;
 
-template <typename Api = api::native_tag>
+template <typename Api = TIMEMORY_API>
 struct api_output_archive;
 
-template <typename T, typename Api = api::native_tag>
+template <typename T, typename Api = TIMEMORY_API>
 struct input_archive;
 
-template <typename T, typename Api = api::native_tag>
+template <typename T, typename Api = TIMEMORY_API>
 struct output_archive;
 
 template <typename T>
@@ -382,7 +382,7 @@ struct record_statistics;
 /// \brief Provides a static get() function which returns a shared pointer to an instance
 /// of the given archive format for input. Can also provides static functions for any
 /// global configuration options, if necessary.
-template <typename Archive, typename Api = api::native_tag>
+template <typename Archive, typename Api = TIMEMORY_API>
 struct input_archive;
 
 /// \struct tim::policy::output_archive
@@ -391,7 +391,7 @@ struct input_archive;
 /// global configuration options for the archive format. For example, the (pretty) JSON
 /// output archive supports specification of the precision, indentation length, and the
 /// indentation character.
-template <typename Archive, typename Api = api::native_tag>
+template <typename Archive, typename Api = TIMEMORY_API>
 struct output_archive;
 
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/operations/types/finalize/flamegraph.hpp
+++ b/source/timemory/operations/types/finalize/flamegraph.hpp
@@ -94,7 +94,7 @@ flamegraph<Type>::flamegraph(storage_type* _data, std::string _label)  // NOLINT
 
     using Archive = cereal::MinimalJSONOutputArchive;
     // using Archive     = cereal::PrettyJSONOutputArchive;
-    using policy_type = policy::output_archive<Archive, api::native_tag>;
+    using policy_type = policy::output_archive<Archive, TIMEMORY_API>;
 
     auto outfname =
         settings::compose_output_filename(_label + std::string(".flamegraph"), ".json");

--- a/source/timemory/operations/types/finalize/mpi_get.hpp
+++ b/source/timemory/operations/types/finalize/mpi_get.hpp
@@ -133,7 +133,7 @@ mpi_get<Type, true>::operator()(distrib_type& results)
         std::stringstream ss;
         {
             auto oa = policy::output_archive<cereal::MinimalJSONOutputArchive,
-                                             api::native_tag>::get(ss);
+                                             TIMEMORY_API>::get(ss);
             (*oa)(cereal::make_nvp("data", src));
         }
         return ss.str();
@@ -148,7 +148,7 @@ mpi_get<Type, true>::operator()(distrib_type& results)
         ss << src;
         {
             auto ia =
-                policy::input_archive<cereal::JSONInputArchive, api::native_tag>::get(ss);
+                policy::input_archive<cereal::JSONInputArchive, TIMEMORY_API>::get(ss);
             (*ia)(cereal::make_nvp("data", ret));
             if(settings::debug())
                 printf("[RECV: %i]> data size: %lli\n", comm_rank,
@@ -359,7 +359,7 @@ mpi_get<Type, true>::operator()(basic_tree_vector_type& bt)
         std::stringstream ss;
         {
             auto oa = policy::output_archive<cereal::MinimalJSONOutputArchive,
-                                             api::native_tag>::get(ss);
+                                             TIMEMORY_API>::get(ss);
             (*oa)(cereal::make_nvp("data", src));
         }
         return ss.str();
@@ -374,7 +374,7 @@ mpi_get<Type, true>::operator()(basic_tree_vector_type& bt)
         ss << src;
         {
             auto ia =
-                policy::input_archive<cereal::JSONInputArchive, api::native_tag>::get(ss);
+                policy::input_archive<cereal::JSONInputArchive, TIMEMORY_API>::get(ss);
             (*ia)(cereal::make_nvp("data", ret));
             if(settings::debug())
                 printf("[RECV: %i]> data size: %lli\n", comm_rank,
@@ -479,7 +479,7 @@ mpi_get<Type, true>::mpi_get(std::vector<Type>& dst, const Type& inp,
         std::stringstream ss;
         {
             auto oa = policy::output_archive<cereal::MinimalJSONOutputArchive,
-                                             api::native_tag>::get(ss);
+                                             TIMEMORY_API>::get(ss);
             (*oa)(cereal::make_nvp("data", src));
         }
         return ss.str();
@@ -494,7 +494,7 @@ mpi_get<Type, true>::mpi_get(std::vector<Type>& dst, const Type& inp,
         ss << src;
         {
             auto ia =
-                policy::input_archive<cereal::JSONInputArchive, api::native_tag>::get(ss);
+                policy::input_archive<cereal::JSONInputArchive, TIMEMORY_API>::get(ss);
             (*ia)(cereal::make_nvp("data", ret));
         }
         return ret;

--- a/source/timemory/operations/types/finalize/upc_get.hpp
+++ b/source/timemory/operations/types/finalize/upc_get.hpp
@@ -121,7 +121,7 @@ upc_get<Type, true>::operator()(distrib_type& results)
         std::stringstream ss;
         {
             auto oa = policy::output_archive<cereal::MinimalJSONOutputArchive,
-                                             api::native_tag>::get(ss);
+                                             TIMEMORY_API>::get(ss);
             (*oa)(cereal::make_nvp("data", src));
         }
         return ss.str();
@@ -136,7 +136,7 @@ upc_get<Type, true>::operator()(distrib_type& results)
         ss << src;
         {
             auto ia =
-                policy::input_archive<cereal::JSONInputArchive, api::native_tag>::get(ss);
+                policy::input_archive<cereal::JSONInputArchive, TIMEMORY_API>::get(ss);
             (*ia)(cereal::make_nvp("data", ret));
             if(settings::debug())
                 printf("[RECV: %i]> data size: %lli\n", comm_rank,
@@ -338,7 +338,7 @@ upc_get<Type, true>::operator()(basic_tree_vector_type& bt)
         std::stringstream ss;
         {
             auto oa = policy::output_archive<cereal::MinimalJSONOutputArchive,
-                                             api::native_tag>::get(ss);
+                                             TIMEMORY_API>::get(ss);
             (*oa)(cereal::make_nvp("data", src));
         }
         return ss.str();
@@ -353,7 +353,7 @@ upc_get<Type, true>::operator()(basic_tree_vector_type& bt)
         ss << src;
         {
             auto ia =
-                policy::input_archive<cereal::JSONInputArchive, api::native_tag>::get(ss);
+                policy::input_archive<cereal::JSONInputArchive, TIMEMORY_API>::get(ss);
             (*ia)(cereal::make_nvp("data", ret));
             if(settings::debug())
                 printf("[RECV: %i]> data size: %lli\n", comm_rank,

--- a/source/timemory/settings/extern.hpp
+++ b/source/timemory/settings/extern.hpp
@@ -27,4 +27,4 @@
 #include "timemory/settings.hpp"
 #include "timemory/tpls/cereal/archives.hpp"
 
-TIMEMORY_SETTINGS_EXTERN_TEMPLATE(api::native_tag)
+TIMEMORY_SETTINGS_EXTERN_TEMPLATE(TIMEMORY_API)

--- a/source/timemory/settings/settings.cpp
+++ b/source/timemory/settings/settings.cpp
@@ -65,7 +65,7 @@ TIMEMORY_SETTINGS_INLINE
 std::shared_ptr<settings>
 settings::shared_instance()
 {
-    static auto _instance = shared_instance<project::timemory>();
+    static auto _instance = shared_instance<TIMEMORY_API>();
     return _instance;
 }
 //

--- a/source/timemory/settings/settings.hpp
+++ b/source/timemory/settings/settings.hpp
@@ -282,7 +282,7 @@ public:
                                            std::string   _explicit = "")
         TIMEMORY_VISIBILITY("default");
 
-    static void parse(settings* = instance<api::native_tag>())
+    static void parse(settings* = instance<TIMEMORY_API>())
         TIMEMORY_VISIBILITY("default");
 
     static void parse(std::shared_ptr<settings>) TIMEMORY_VISIBILITY("default");

--- a/source/timemory/settings/tsettings.hpp
+++ b/source/timemory/settings/tsettings.hpp
@@ -225,7 +225,7 @@ struct tsettings : public vsettings
         return val;
     }
 
-    virtual parser_func_t get_action(project::timemory) override { return get_action(); }
+    virtual parser_func_t get_action(TIMEMORY_API) override { return get_action(); }
 
 private:
     template <typename Up = decay_t<Tp>, enable_if_t<std::is_same<Up, bool>::value> = 0>

--- a/source/timemory/settings/vsettings.hpp
+++ b/source/timemory/settings/vsettings.hpp
@@ -175,7 +175,7 @@ struct vsettings
 
     void set(const std::string& _val) { parse(_val); }
 
-    virtual parser_func_t get_action(project::timemory) = 0;
+    virtual parser_func_t get_action(TIMEMORY_API) = 0;
 
 protected:
     std::type_index          m_type_index  = std::type_index(typeid(void));

--- a/source/timemory/storage/definition.hpp
+++ b/source/timemory/storage/definition.hpp
@@ -373,7 +373,8 @@ storage<Type, true>::~storage()
     {
         if(singleton_t::master_instance())
         {
-            printf("[%s]> merging into master @ %i...\n", m_label.c_str(), __LINE__);
+            if(_debug)
+                printf("[%s]> merging into master @ %i...\n", m_label.c_str(), __LINE__);
             singleton_t::master_instance()->merge(this);
         }
     }

--- a/source/timemory/storage/types.hpp
+++ b/source/timemory/storage/types.hpp
@@ -186,7 +186,8 @@ class storage;
 //--------------------------------------------------------------------------------------//
 //
 template <typename Tp>
-using storage_singleton = singleton<Tp, std::unique_ptr<Tp, impl::storage_deleter<Tp>>>;
+using storage_singleton =
+    singleton<Tp, std::unique_ptr<Tp, impl::storage_deleter<Tp>>, TIMEMORY_API>;
 //
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/utility/singleton.hpp
+++ b/source/timemory/utility/singleton.hpp
@@ -32,6 +32,7 @@
 
 #pragma once
 
+#include "timemory/api.hpp"
 #include "timemory/macros/attributes.hpp"
 
 #include <cstddef>
@@ -45,14 +46,13 @@
 
 namespace tim
 {
-//======================================================================================//
-
 template <typename Type,
-          typename Pointer = std::unique_ptr<Type, std::default_delete<Type>>>
+          typename Pointer = std::unique_ptr<Type, std::default_delete<Type>>,
+          typename Tag     = TIMEMORY_API>
 class singleton
 {
 public:
-    using this_type     = singleton<Type, Pointer>;
+    using this_type     = singleton<Type, Pointer, Tag>;
     using thread_id_t   = std::thread::id;
     using mutex_t       = std::recursive_mutex;
     using auto_lock_t   = std::unique_lock<mutex_t>;
@@ -261,60 +261,60 @@ private:
 
 //======================================================================================//
 
-template <typename Type, typename Pointer>
-typename singleton<Type, Pointer>::thread_id_t&
-singleton<Type, Pointer>::f_master_thread()
+template <typename Type, typename Pointer, typename Tag>
+typename singleton<Type, Pointer, Tag>::thread_id_t&
+singleton<Type, Pointer, Tag>::f_master_thread()
 {
     return f_persistent_data().m_master_thread;
 }
 
 //--------------------------------------------------------------------------------------//
 
-template <typename Type, typename Pointer>
-typename singleton<Type, Pointer>::pointer&
-singleton<Type, Pointer>::f_master_instance()
+template <typename Type, typename Pointer, typename Tag>
+typename singleton<Type, Pointer, Tag>::pointer&
+singleton<Type, Pointer, Tag>::f_master_instance()
 {
     return f_persistent_data().m_master_instance;
 }
 
 //--------------------------------------------------------------------------------------//
 
-template <typename Type, typename Pointer>
-typename singleton<Type, Pointer>::mutex_t&
-singleton<Type, Pointer>::f_mutex()
+template <typename Type, typename Pointer, typename Tag>
+typename singleton<Type, Pointer, Tag>::mutex_t&
+singleton<Type, Pointer, Tag>::f_mutex()
 {
     return f_persistent_data().m_mutex;
 }
 
 //--------------------------------------------------------------------------------------//
 
-template <typename Type, typename Pointer>
-typename singleton<Type, Pointer>::list_t&
-singleton<Type, Pointer>::f_children()
+template <typename Type, typename Pointer, typename Tag>
+typename singleton<Type, Pointer, Tag>::list_t&
+singleton<Type, Pointer, Tag>::f_children()
 {
     return f_persistent_data().m_children;
 }
 
 //--------------------------------------------------------------------------------------//
 
-template <typename Type, typename Pointer>
-singleton<Type, Pointer>::singleton()
+template <typename Type, typename Pointer, typename Tag>
+singleton<Type, Pointer, Tag>::singleton()
 {
     initialize();
 }
 
 //--------------------------------------------------------------------------------------//
 
-template <typename Type, typename Pointer>
-singleton<Type, Pointer>::singleton(pointer ptr)
+template <typename Type, typename Pointer, typename Tag>
+singleton<Type, Pointer, Tag>::singleton(pointer ptr)
 {
     initialize(ptr);
 }
 
 //--------------------------------------------------------------------------------------//
 
-template <typename Type, typename Pointer>
-singleton<Type, Pointer>::~singleton()
+template <typename Type, typename Pointer, typename Tag>
+singleton<Type, Pointer, Tag>::~singleton()
 {
     auto& del = get_deleter();
     if(del)
@@ -323,9 +323,9 @@ singleton<Type, Pointer>::~singleton()
 
 //--------------------------------------------------------------------------------------//
 
-template <typename Type, typename Pointer>
+template <typename Type, typename Pointer, typename Tag>
 void
-singleton<Type, Pointer>::initialize()
+singleton<Type, Pointer, Tag>::initialize()
 {
     if(!f_master_instance())
     {
@@ -336,9 +336,9 @@ singleton<Type, Pointer>::initialize()
 
 //--------------------------------------------------------------------------------------//
 
-template <typename Type, typename Pointer>
+template <typename Type, typename Pointer, typename Tag>
 void
-singleton<Type, Pointer>::initialize(pointer ptr)
+singleton<Type, Pointer, Tag>::initialize(pointer ptr)
 {
     if(!f_master_instance())
     {
@@ -349,9 +349,9 @@ singleton<Type, Pointer>::initialize(pointer ptr)
 
 //--------------------------------------------------------------------------------------//
 
-template <typename Type, typename Pointer>
+template <typename Type, typename Pointer, typename Tag>
 void
-singleton<Type, Pointer>::destroy()
+singleton<Type, Pointer, Tag>::destroy()
 {
     if(std::this_thread::get_id() == f_master_thread() && f_master_instance())
     {
@@ -366,9 +366,9 @@ singleton<Type, Pointer>::destroy()
 
 //--------------------------------------------------------------------------------------//
 
-template <typename Type, typename Pointer>
-typename singleton<Type, Pointer>::pointer
-singleton<Type, Pointer>::instance()
+template <typename Type, typename Pointer, typename Tag>
+typename singleton<Type, Pointer, Tag>::pointer
+singleton<Type, Pointer, Tag>::instance()
 {
     if(std::this_thread::get_id() == f_master_thread())
         return master_instance();
@@ -382,9 +382,9 @@ singleton<Type, Pointer>::instance()
 
 //--------------------------------------------------------------------------------------//
 
-template <typename Type, typename Pointer>
-typename singleton<Type, Pointer>::pointer
-singleton<Type, Pointer>::master_instance()
+template <typename Type, typename Pointer, typename Tag>
+typename singleton<Type, Pointer, Tag>::pointer
+singleton<Type, Pointer, Tag>::master_instance()
 {
     if(!f_master_instance())
     {

--- a/source/timemory/utility/types.hpp
+++ b/source/timemory/utility/types.hpp
@@ -232,7 +232,7 @@ consume_parameters(ArgsT&&...)
 //
 //--------------------------------------------------------------------------------------//
 //
-template <typename Tp, typename DeleterT>
+template <typename Tp, typename DeleterT, typename Tag>
 class singleton;
 //
 //--------------------------------------------------------------------------------------//
@@ -353,7 +353,7 @@ get_fields()
 //
 template <typename Arg, size_t... Idx>
 static TIMEMORY_INLINE TIMEMORY_HOT auto
-generate(Arg&& arg, index_sequence<Idx...>)
+                       generate(Arg&& arg, index_sequence<Idx...>)
 {
     static_assert(sizeof...(Idx) <= scope_count, "Error! Bad index sequence size");
     data_type ret;
@@ -365,7 +365,7 @@ generate(Arg&& arg, index_sequence<Idx...>)
 //
 template <size_t... Idx>
 static TIMEMORY_INLINE TIMEMORY_HOT auto
-either(data_type ret, data_type arg, index_sequence<Idx...>)
+                       either(data_type ret, data_type arg, index_sequence<Idx...>)
 {
     static_assert(sizeof...(Idx) <= scope_count, "Error! Bad index sequence size");
     TIMEMORY_FOLD_EXPRESSION(ret.set(Idx, ret.test(Idx) || arg.test(Idx)));
@@ -375,7 +375,7 @@ either(data_type ret, data_type arg, index_sequence<Idx...>)
 //--------------------------------------------------------------------------------------//
 //
 static TIMEMORY_INLINE TIMEMORY_HOT data_type
-get_default_bitset()
+                                    get_default_bitset()
 {
     return generate(get_fields(), make_index_sequence<scope_count>{});
 }
@@ -574,7 +574,7 @@ struct config : public data_type
 //--------------------------------------------------------------------------------------//
 //
 static TIMEMORY_INLINE TIMEMORY_HOT config
-get_default()
+                                    get_default()
 {
     return config{ get_default_bitset() };
 }
@@ -582,7 +582,7 @@ get_default()
 //--------------------------------------------------------------------------------------//
 //
 TIMEMORY_INLINE TIMEMORY_HOT config
-operator+(config _lhs, tree)
+                             operator+(config _lhs, tree)
 {
     _lhs.set(tree::value, true);
     return _lhs;
@@ -591,7 +591,7 @@ operator+(config _lhs, tree)
 //--------------------------------------------------------------------------------------//
 //
 TIMEMORY_INLINE TIMEMORY_HOT config
-operator+(config _lhs, flat)
+                             operator+(config _lhs, flat)
 {
     _lhs.set(flat::value, true);
     return _lhs;
@@ -600,7 +600,7 @@ operator+(config _lhs, flat)
 //--------------------------------------------------------------------------------------//
 //
 TIMEMORY_INLINE TIMEMORY_HOT config
-operator+(config _lhs, timeline)
+                             operator+(config _lhs, timeline)
 {
     _lhs.set(timeline::value, true);
     return _lhs;
@@ -609,7 +609,7 @@ operator+(config _lhs, timeline)
 //--------------------------------------------------------------------------------------//
 //
 TIMEMORY_INLINE TIMEMORY_HOT config
-operator+(config _lhs, config _rhs)
+                             operator+(config _lhs, config _rhs)
 {
     return config{ either(_lhs, _rhs, make_index_sequence<scope_count>{}) };
 }

--- a/source/tools/kokkos-connector/CMakeLists.txt
+++ b/source/tools/kokkos-connector/CMakeLists.txt
@@ -475,7 +475,7 @@ endif()
 
 add_connector_config(ompt
     CONDITION "${USE_OMPT}"
-    COMPONENTS ompt_handle<tim::api::native_tag>
+    COMPONENTS ompt_handle<tim::project::timemory>
     DEFINITIONS TIMEMORY_USE_OMPT_LIBRARY
     TARGETS ${_OMPT_LIB})
 

--- a/source/tools/timemory-compiler-instrument/compiler-instrument-base.cpp
+++ b/source/tools/timemory-compiler-instrument/compiler-instrument-base.cpp
@@ -28,6 +28,15 @@
 #define TIMEMORY_VISIBILITY(...) TIMEMORY_INTERNAL
 #define TIMEMORY_INTERNAL_NO_INSTRUMENT TIMEMORY_INTERNAL TIMEMORY_NEVER_INSTRUMENT
 
+#include "timemory/api/macros.hpp"
+
+// create an API for the compiler instrumentation whose singletons will not be shared
+// with the default timemory API
+TIMEMORY_DEFINE_NS_API(project, compiler_instrument)
+
+// define the API for all instantiations before including any more timemory headers
+#define TIMEMORY_API ::tim::project::compiler_instrument
+
 #include "timemory/timemory.hpp"
 #include "timemory/trace.hpp"
 

--- a/source/tools/timemory-mpip/timemory-mpip.cpp
+++ b/source/tools/timemory-mpip/timemory-mpip.cpp
@@ -51,7 +51,7 @@ TIMEMORY_DEFINE_CONCRETE_TRAIT(is_memory_category, mpi_data_tracker_t, true_type
 //
 //--------------------------------------------------------------------------------------//
 //
-using api_t            = tim::api::native_tag;
+using api_t            = TIMEMORY_API;
 using mpi_toolset_t    = tim::component_tuple<user_mpip_bundle, mpi_comm_data>;
 using mpip_handle_t    = mpip_handle<mpi_toolset_t, api_t>;
 uint64_t global_id     = 0;
@@ -123,7 +123,7 @@ struct mpi_comm_data : base<mpi_comm_data, void>
     using value_type = void;
     using this_type  = mpi_comm_data;
     using base_type  = base<this_type, value_type>;
-    using tracker_t  = tim::auto_bundle<tim::api::native_tag, mpi_data_tracker_t*>;
+    using tracker_t  = tim::auto_bundle<TIMEMORY_API, mpi_data_tracker_t*>;
     using data_type  = float;
 
     TIMEMORY_DEFAULT_OBJECT(mpi_comm_data)

--- a/source/tools/timemory-ncclp/timemory-ncclp.cpp
+++ b/source/tools/timemory-ncclp/timemory-ncclp.cpp
@@ -128,7 +128,7 @@ struct nccl_comm_data : base<nccl_comm_data, void>
     using value_type = void;
     using this_type  = nccl_comm_data;
     using base_type  = base<this_type, value_type>;
-    using tracker_t  = tim::auto_bundle<tim::api::native_tag, nccl_data_tracker_t*>;
+    using tracker_t  = tim::auto_bundle<TIMEMORY_API, nccl_data_tracker_t*>;
     using data_type  = float;
 
     TIMEMORY_DEFAULT_OBJECT(nccl_comm_data)

--- a/source/tools/timemory-ompt/timemory-ompt.cpp
+++ b/source/tools/timemory-ompt/timemory-ompt.cpp
@@ -33,7 +33,7 @@
 
 using namespace tim::component;
 
-using api_t          = tim::api::native_tag;
+using api_t          = TIMEMORY_API;
 using ompt_handle_t  = ompt_handle<api_t>;
 using ompt_toolset_t = typename ompt_handle_t::toolset_type;
 using ompt_bundle_t  = tim::component_tuple<ompt_handle_t>;

--- a/source/trace.cpp
+++ b/source/trace.cpp
@@ -808,7 +808,7 @@ extern "C"
             return;
         }
 
-        tim::auto_lock_t lock(tim::type_mutex<tim::api::native_tag>());
+        tim::auto_lock_t lock(tim::type_mutex<TIMEMORY_API>());
 
         // tim::settings::enabled() = false;
         get_library_state()[1] = true;


### PR DESCRIPTION
- Using the concept of timemory APIs, the singletons for the string-hash map, settings, manager, and storage exist as entirely different symbols in the library
- This ensures that even when the compiler instrumentation in applied to source code instrumented with timemory, the data collection is exclusive and thus the compiler instrumentation can effectively instrument timemory itself without recursion.