### PR TITLE
Significant improvement to finalization

### DIFF
--- a/source/timemory/operations/types.hpp
+++ b/source/timemory/operations/types.hpp
@@ -618,6 +618,9 @@ struct merge;
 template <typename Type>
 struct merge<Type, true>
 {
+    template <typename KeyT, typename MappedT>
+    using uomap_t = std::unordered_map<KeyT, MappedT>;
+
     static constexpr bool has_data = true;
     using storage_type             = impl::storage<Type, has_data>;
     using singleton_t              = typename storage_type::singleton_type;
@@ -630,7 +633,7 @@ struct merge<Type, true>
     TIMEMORY_DEFAULT_OBJECT(merge)
 
     merge(storage_type& lhs, storage_type& rhs);
-    merge(result_type& lhs, const result_type& rhs);
+    merge(result_type& lhs, result_type& rhs);
 
     // unary
     template <typename Tp>
@@ -978,10 +981,10 @@ struct print<Tp, true> : public base::print
 
     void write_stream(stream_type& stream, result_type& results);
     void print_json(const std::string& fname, result_type& results, int64_t concurrency);
-    auto get_data() const { return data; }
-    auto get_node_results() const { return node_results; }
-    auto get_node_input() const { return node_input; }
-    auto get_node_delta() const { return node_delta; }
+    const auto& get_data() const { return data; }
+    const auto& get_node_results() const { return node_results; }
+    const auto& get_node_input() const { return node_input; }
+    const auto& get_node_delta() const { return node_delta; }
 
     template <typename Archive>
     void print_metadata(Archive& ar, const Tp& obj);

--- a/source/timemory/operations/types/finalize/print.hpp
+++ b/source/timemory/operations/types/finalize/print.hpp
@@ -369,9 +369,7 @@ print<Tp, true>::update_data()
 
     if(node_input.size() > 0 && node_rank == 0)
     {
-        using input_type = decay_t<decltype(node_input)>;
-        using value_type = typename input_type::value_type;
-        node_delta.resize(node_input.size(), value_type{});
+        node_delta.resize(node_input.size());
 
         size_t num_ranks = std::min<size_t>(node_input.size(), node_results.size());
 

--- a/source/timemory/storage/node.hpp
+++ b/source/timemory/storage/node.hpp
@@ -68,7 +68,7 @@ struct entry : std::tuple<Tp, StatT>
     explicit entry(const base_type& _obj)
     : base_type(_obj)
     {}
-    explicit entry(base_type&& _obj)
+    explicit entry(base_type&& _obj) noexcept
     : base_type(std::forward<base_type>(_obj))
     {}
 
@@ -132,18 +132,19 @@ public:
     graph();
     explicit graph(base_type&& _base) noexcept;
 
-    ~graph()                = default;
-    graph(const graph&)     = default;
+    ~graph()            = default;
+    graph(const graph&) = default;
     graph(graph&&) noexcept = default;
     graph(uint64_t _id, const Tp& _obj, int64_t _depth, uint16_t _tid,
           uint16_t _pid = process::get_id(), bool _is_dummy = false);
+
+    graph& operator=(const graph&) = default;
+    graph& operator=(graph&&) noexcept = default;
 
 public:
     static Tp  get_dummy();
     bool       operator==(const graph& rhs) const;
     bool       operator!=(const graph& rhs) const;
-    graph&     operator=(const graph&) = default;
-    graph&     operator=(graph&&) noexcept = default;
     this_type& operator+=(const this_type& rhs)
     {
         obj() += rhs.obj();
@@ -192,9 +193,9 @@ struct result : public data<Tp>::result_type
     using stats_type   = typename data<Tp>::stats_type;
     using this_type    = result<Tp>;
 
-    result()                  = default;
-    ~result()                 = default;
-    result(const result&)     = default;
+    result()              = default;
+    ~result()             = default;
+    result(const result&) = default;
     result(result&&) noexcept = default;
     result& operator=(const result&) = default;
     result& operator=(result&&) noexcept = default;
@@ -278,8 +279,8 @@ public:
     tree(const graph<Tp>&);
     tree& operator=(const graph<Tp>&);
 
-    ~tree()               = default;
-    tree(const tree&)     = default;
+    ~tree()           = default;
+    tree(const tree&) = default;
     tree(tree&&) noexcept = default;
     tree(bool _is_dummy, uint16_t _tid, uint16_t _pid, uint64_t _hash, int64_t _depth,
          const Tp& _obj);
@@ -587,7 +588,7 @@ load(Archive& ar, std::vector<tim::node::result<Tp>>& result_nodes)
 {
     size_t nnodes = 0;
     ar(cereal::make_nvp("graph_size", nnodes));
-    result_nodes.resize(nnodes, tim::node::result<Tp>{});
+    result_nodes.resize(nnodes);
 
     ar.setNextName("graph");
     ar.startNode();


### PR DESCRIPTION
- Finalizing results is now __*order of magnitude*__ faster and consumes less memory
  - This tremendously benefits compiler instrumentation and dynamic instrumentation, where there may be millions of profiling entries
- Previously, finalizing 1.5 million entries took _at least_ 30 minutes per component and required several GB of memory
  - Several implicit copying instances were eliminated along with a significantly more efficient merging algorithm
  - Finalizing now completes in less than a minute per-component with 1,000,000+ entries and tends to require anywhere from only a few dozen MB to about a GB or two
    - The extra memory required while merging depends on whether results are merged across multiple threads and processes, etc.