### PR TITLE
Component base class refactoring

### DIFF
--- a/cmake/Modules/MacroUtilities.cmake
+++ b/cmake/Modules/MacroUtilities.cmake
@@ -986,7 +986,7 @@ FUNCTION(BUILD_INTERMEDIATE_LIBRARY)
         timemory_target_compile_definitions(${TARGET_NAME} INTERFACE
             TIMEMORY_USE_${UPP_COMP}_EXTERN)
 
-        if(NOT "${COMP_NAME}" STREQUAL "CORE")
+        if(NOT "${UPP_COMP}" STREQUAL "CORE")
             timemory_target_compile_definitions(${TARGET_NAME} PUBLIC
                 TIMEMORY_USE_CORE_EXTERN)
         endif()

--- a/source/tests/traits_tests.cpp
+++ b/source/tests/traits_tests.cpp
@@ -373,20 +373,20 @@ TEST_F(traits_tests, sizeof)
            (unsigned long) sizeof(__VA_ARGS__))
 
     auto void_test     = TYPE_TEST(void_component);
-    auto int_test      = TYPE_TEST(int64_component);
+    auto int64_test    = TYPE_TEST(int64_component);
     auto array_test    = TYPE_TEST(array_component);
-    auto temp_i64_test = TYPE_TEST(template_component<int64_t>);
     auto temp_i32_test = TYPE_TEST(template_component<int32_t>);
+    auto temp_i64_test = TYPE_TEST(template_component<int64_t>);
     auto temp_u64_test = TYPE_TEST(template_component<uint64_t>);
     auto var_test      = TYPE_TEST(variadic_component<double, 1, 3>);
 
-    EXPECT_EQ(void_test, 3);
-    EXPECT_EQ(int_test, 56);
-    EXPECT_EQ(temp_i32_test, 48);
-    EXPECT_EQ(temp_i64_test, 64);
-    EXPECT_EQ(temp_u64_test, 72);
-    EXPECT_EQ(array_test, 72);
-    EXPECT_EQ(var_test, 104);
+    EXPECT_EQ(void_test, 5);
+    EXPECT_EQ(int64_test, 56);
+    EXPECT_EQ(temp_i32_test, 40);
+    EXPECT_EQ(temp_i64_test, 56);
+    EXPECT_EQ(temp_u64_test, 64);
+    EXPECT_EQ(array_test, 64);
+    EXPECT_EQ(var_test, 96);
 #undef TYPE_TEST
 }
 

--- a/source/timemory/backends/mpi.hpp
+++ b/source/timemory/backends/mpi.hpp
@@ -152,7 +152,7 @@ rank(comm_t comm = comm_world_v);
 
 //--------------------------------------------------------------------------------------//
 
-inline bool&
+static inline bool&
 use_mpi_thread()
 {
     static bool _instance = true;

--- a/source/timemory/components/base/data.hpp
+++ b/source/timemory/components/base/data.hpp
@@ -1,0 +1,507 @@
+// MIT License
+//
+// Copyright (c) 2020, The Regents of the University of California,
+// through Lawrence Berkeley National Laboratory (subject to receipt of any
+// required approvals from the U.S. Dept. of Energy).  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "timemory/macros/attributes.hpp"
+#include "timemory/mpl/math.hpp"
+#include "timemory/mpl/types.hpp"
+#include "timemory/tpls/cereal/cereal.hpp"
+
+#include <array>
+
+namespace tim
+{
+namespace component
+{
+//
+template <typename Tp, size_t Sz>
+struct base_data;
+//
+template <typename Tp>
+struct base_data<Tp, 0>
+{
+    using value_type = null_type;
+
+    TIMEMORY_INLINE value_type get_value() const { return value_type{}; }
+    TIMEMORY_INLINE value_type get_accum() const { return value_type{}; }
+    TIMEMORY_INLINE value_type get_last() const { return value_type{}; }
+    TIMEMORY_INLINE void       set_value(value_type) {}
+    TIMEMORY_INLINE void       set_accum(value_type) {}
+    TIMEMORY_INLINE void       set_last(value_type) {}
+
+    base_data()  = default;
+    ~base_data() = default;
+
+    base_data& operator=(base_data&&) = default;
+    base_data(base_data&&)            = default;
+
+    base_data(const base_data&) = default;
+    base_data& operator=(const base_data&) = default;
+
+    TIMEMORY_INLINE value_type load(bool) { return value_type{}; }
+    TIMEMORY_INLINE value_type load(bool) const { return value_type{}; }
+
+    void plus(const value_type&) {}
+    void minus(const value_type&) {}
+    void multiply(const value_type&) {}
+    void divide(const value_type&) {}
+
+    template <typename Up>
+    void plus(Up&&)
+    {}
+
+    template <typename Up>
+    void minus(Up&&)
+    {}
+
+    template <typename Up>
+    void multiply(Up&&)
+    {}
+
+    template <typename Up>
+    void divide(Up&&)
+    {}
+
+protected:
+    value_type value = {};
+    value_type accum = {};
+    value_type last  = {};
+};
+//
+template <typename Tp>
+struct base_data<Tp, 1>
+{
+    using empty_type = std::tuple<>;
+    using value_type = Tp;
+    using accum_type = empty_type;
+    using last_type  = empty_type;
+
+    TIMEMORY_INLINE const value_type& get_value() const { return value; }
+    TIMEMORY_INLINE const value_type& get_accum() const { return value; }
+    TIMEMORY_INLINE const value_type& get_last() const { return value; }
+    TIMEMORY_INLINE void              set_value(value_type v) { value = v; }
+    TIMEMORY_INLINE void              set_accum(value_type) {}
+    TIMEMORY_INLINE void              set_last(value_type) {}
+
+    base_data()  = default;
+    ~base_data() = default;
+
+    base_data& operator=(base_data&&) = default;
+    base_data(base_data&&)            = default;
+
+    base_data(const base_data&) = default;
+    base_data& operator=(const base_data&) = default;
+
+    template <typename ArchiveT>
+    void serialize(ArchiveT& ar, const unsigned int = 0)
+    {
+        ar(cereal::make_nvp("value", value));
+    }
+
+    TIMEMORY_INLINE value_type& load(bool) { return value; }
+    TIMEMORY_INLINE const value_type& load(bool) const { return value; }
+
+    void plus(const value_type& lhs)
+    {
+        value = math::compute<value_type>::plus(value, lhs);
+    }
+
+    void minus(const value_type& lhs)
+    {
+        value = math::compute<value_type>::minus(value, lhs);
+    }
+
+    void multiply(const value_type& lhs)
+    {
+        value = math::compute<value_type>::multiply(value, lhs);
+    }
+
+    void divide(const value_type& lhs)
+    {
+        value = math::compute<value_type>::divide(value, lhs);
+    }
+
+    template <typename Up>
+    auto plus(Up&& rhs) -> decltype(std::forward<Up>(rhs).get_value(), void())
+    {
+        value = math::compute<value_type>::plus(value, std::forward<Up>(rhs).get_value());
+    }
+
+    template <typename Up>
+    auto minus(Up&& rhs) -> decltype(std::forward<Up>(rhs).get_value(), void())
+    {
+        value =
+            math::compute<value_type>::minus(value, std::forward<Up>(rhs).get_value());
+    }
+
+    template <typename Up>
+    auto multiply(Up&& rhs) -> decltype(std::forward<Up>(rhs).get_value(), void())
+    {
+        value =
+            math::compute<value_type>::multiply(value, std::forward<Up>(rhs).get_value());
+    }
+
+    template <typename Up>
+    auto divide(Up&& rhs) -> decltype(std::forward<Up>(rhs).get_value(), void())
+    {
+        value =
+            math::compute<value_type>::divide(value, std::forward<Up>(rhs).get_value());
+    }
+
+    // we need 'using base_data<Tp>::accum' to be valid so make a function call
+    value_type& accum() { return value; }
+
+    // we need 'using base_data<Tp>::last' to be valid so make a function call
+    value_type& last() { return value; }
+
+protected:
+    void reset() { value = Tp{}; }
+
+protected:
+    value_type value = Tp{};
+};
+//
+template <typename Tp>
+struct base_data<Tp, 2>
+{
+    template <typename Up, typename ValueT>
+    friend struct base;
+
+    using empty_type = std::tuple<>;
+    using value_type = Tp;
+    using accum_type = Tp;
+    using last_type  = empty_type;
+
+    TIMEMORY_INLINE const value_type& get_value() const { return value; }
+    TIMEMORY_INLINE const value_type& get_accum() const { return accum; }
+    TIMEMORY_INLINE const value_type& get_last() const { return value; }
+    TIMEMORY_INLINE void              set_value(value_type v) { value = v; }
+    TIMEMORY_INLINE void              set_accum(value_type v) { accum = v; }
+    TIMEMORY_INLINE void              set_last(value_type) {}
+
+    base_data()  = default;
+    ~base_data() = default;
+
+    base_data& operator=(base_data&&) = default;
+    base_data(base_data&&)            = default;
+
+    base_data(const base_data& rhs) = default;
+    base_data& operator=(const base_data& rhs) = default;
+
+    template <typename ArchiveT>
+    void serialize(ArchiveT& ar, const unsigned int = 0)
+    {
+        ar(cereal::make_nvp("value", value), cereal::make_nvp("accum", accum));
+    }
+
+    TIMEMORY_INLINE value_type& load(bool is_transient)
+    {
+        return (is_transient) ? accum : value;
+    }
+    TIMEMORY_INLINE const value_type& load(bool is_transient) const
+    {
+        return (is_transient) ? accum : value;
+    }
+
+    void plus(const value_type& rhs)
+    {
+        value = math::compute<value_type>::plus(value, rhs);
+        accum = math::compute<value_type>::plus(accum, rhs);
+    }
+
+    void minus(const value_type& rhs)
+    {
+        value = math::compute<value_type>::minus(value, rhs);
+        accum = math::compute<value_type>::minus(accum, rhs);
+    }
+
+    void multiply(const value_type& rhs)
+    {
+        value = math::compute<value_type>::multiply(value, rhs);
+        accum = math::compute<value_type>::multiply(accum, rhs);
+    }
+
+    void divide(const value_type& rhs)
+    {
+        value = math::compute<value_type>::divide(value, rhs);
+        accum = math::compute<value_type>::divide(accum, rhs);
+    }
+
+    template <typename Up>
+    auto plus(Up&& rhs) -> decltype(std::forward<Up>(rhs).get_value(),
+                                    std::forward<Up>(rhs).get_accum(), void())
+    {
+        value = math::compute<value_type>::plus(value, std::forward<Up>(rhs).get_value());
+        accum = math::compute<value_type>::plus(accum, std::forward<Up>(rhs).get_accum());
+    }
+
+    template <typename Up>
+    auto minus(Up&& rhs) -> decltype(std::forward<Up>(rhs).get_value(),
+                                     std::forward<Up>(rhs).get_accum(), void())
+    {
+        value =
+            math::compute<value_type>::minus(value, std::forward<Up>(rhs).get_value());
+        accum =
+            math::compute<value_type>::minus(accum, std::forward<Up>(rhs).get_accum());
+    }
+
+    template <typename Up>
+    auto multiply(Up&& rhs) -> decltype(std::forward<Up>(rhs).get_value(),
+                                        std::forward<Up>(rhs).get_accum(), void())
+    {
+        value =
+            math::compute<value_type>::multiply(value, std::forward<Up>(rhs).get_value());
+        accum =
+            math::compute<value_type>::multiply(accum, std::forward<Up>(rhs).get_accum());
+    }
+
+    template <typename Up>
+    auto divide(Up&& rhs) -> decltype(std::forward<Up>(rhs).get_value(),
+                                      std::forward<Up>(rhs).get_accum(), void())
+    {
+        value =
+            math::compute<value_type>::divide(value, std::forward<Up>(rhs).get_value());
+        accum =
+            math::compute<value_type>::divide(accum, std::forward<Up>(rhs).get_accum());
+    }
+
+    // we need 'using base_data<Tp>::last' to be valid so make a function call
+    value_type& last() { return value; }
+
+protected:
+    void reset()
+    {
+        value = Tp{};
+        accum = Tp{};
+    }
+
+protected:
+    value_type value = Tp{};
+    value_type accum = Tp{};
+};
+//
+template <typename Tp>
+struct base_data<Tp, 3>
+{
+    template <typename Up, typename ValueT>
+    friend struct base;
+
+    using value_type = Tp;
+    using accum_type = Tp;
+    using last_type  = Tp;
+
+    TIMEMORY_INLINE const value_type& get_value() const { return value; }
+    TIMEMORY_INLINE const value_type& get_accum() const { return accum; }
+    TIMEMORY_INLINE const value_type& get_last() const { return last; }
+    TIMEMORY_INLINE void              set_value(value_type v) { value = v; }
+    TIMEMORY_INLINE void              set_accum(value_type v) { accum = v; }
+    TIMEMORY_INLINE void              set_last(value_type v) { last = v; }
+
+    base_data()  = default;
+    ~base_data() = default;
+
+    base_data& operator=(base_data&&) = default;
+    base_data(base_data&&)            = default;
+
+    base_data(const base_data& rhs) = default;
+    base_data& operator=(const base_data& rhs) = default;
+
+    template <typename ArchiveT>
+    void serialize(ArchiveT& ar, const unsigned int = 0)
+    {
+        ar(cereal::make_nvp("value", value), cereal::make_nvp("accum", accum),
+           cereal::make_nvp("last", last));
+    }
+
+    TIMEMORY_INLINE value_type& load(bool is_transient)
+    {
+        return (is_transient) ? accum : value;
+    }
+    TIMEMORY_INLINE const value_type& load(bool is_transient) const
+    {
+        return (is_transient) ? accum : value;
+    }
+
+    void plus(const value_type& rhs)
+    {
+        value = math::compute<value_type>::plus(value, rhs);
+        accum = math::compute<value_type>::plus(accum, rhs);
+    }
+
+    void minus(const value_type& rhs)
+    {
+        value = math::compute<value_type>::minus(value, rhs);
+        accum = math::compute<value_type>::minus(accum, rhs);
+    }
+
+    void multiply(const value_type& rhs)
+    {
+        value = math::compute<value_type>::multiply(value, rhs);
+        accum = math::compute<value_type>::multiply(accum, rhs);
+    }
+
+    void divide(const value_type& rhs)
+    {
+        value = math::compute<value_type>::divide(value, rhs);
+        accum = math::compute<value_type>::divide(accum, rhs);
+    }
+
+    template <typename Up>
+    auto plus(Up&& rhs) -> decltype(std::forward<Up>(rhs).get_value(),
+                                    std::forward<Up>(rhs).get_accum(), void())
+    {
+        value = math::compute<value_type>::plus(value, std::forward<Up>(rhs).get_value());
+        accum = math::compute<value_type>::plus(accum, std::forward<Up>(rhs).get_accum());
+    }
+
+    template <typename Up>
+    auto minus(Up&& rhs) -> decltype(std::forward<Up>(rhs).get_value(),
+                                     std::forward<Up>(rhs).get_accum(), void())
+    {
+        value =
+            math::compute<value_type>::minus(value, std::forward<Up>(rhs).get_value());
+        accum =
+            math::compute<value_type>::minus(accum, std::forward<Up>(rhs).get_accum());
+    }
+
+    template <typename Up>
+    auto multiply(Up&& rhs) -> decltype(std::forward<Up>(rhs).get_value(),
+                                        std::forward<Up>(rhs).get_accum(), void())
+    {
+        value =
+            math::compute<value_type>::multiply(value, std::forward<Up>(rhs).get_value());
+        accum =
+            math::compute<value_type>::multiply(accum, std::forward<Up>(rhs).get_accum());
+    }
+
+    template <typename Up>
+    auto divide(Up&& rhs) -> decltype(std::forward<Up>(rhs).get_value(),
+                                      std::forward<Up>(rhs).get_accum(), void())
+    {
+        value =
+            math::compute<value_type>::divide(value, std::forward<Up>(rhs).get_value());
+        accum =
+            math::compute<value_type>::divide(accum, std::forward<Up>(rhs).get_accum());
+    }
+
+protected:
+    void reset()
+    {
+        value = Tp{};
+        accum = Tp{};
+        last  = Tp{};
+    }
+
+protected:
+    value_type value = Tp{};
+    value_type accum = Tp{};
+    value_type last  = Tp{};
+};
+//
+struct base_state
+{
+    TIMEMORY_INLINE auto& get_is_running() { return is_running; }
+    TIMEMORY_INLINE auto& get_is_on_stack() { return is_on_stack; }
+    TIMEMORY_INLINE auto& get_is_transient() { return is_transient; }
+    TIMEMORY_INLINE auto& get_is_flat() { return is_flat; }
+    TIMEMORY_INLINE auto& get_depth_change() { return depth_change; }
+
+    TIMEMORY_INLINE auto get_is_running() const { return is_running; }
+    TIMEMORY_INLINE auto get_is_on_stack() const { return is_on_stack; }
+    TIMEMORY_INLINE auto get_is_transient() const { return is_transient; }
+    TIMEMORY_INLINE auto get_is_flat() const { return is_flat; }
+    TIMEMORY_INLINE auto get_depth_change() const { return depth_change; }
+
+    TIMEMORY_INLINE void set_is_running(bool v) { is_running = v; }
+    TIMEMORY_INLINE void set_is_on_stack(bool v) { is_on_stack = v; }
+    TIMEMORY_INLINE void set_is_transient(bool v) { is_transient = v; }
+    TIMEMORY_INLINE void set_is_flat(bool v) { is_flat = v; }
+    TIMEMORY_INLINE void set_depth_change(bool v) { depth_change = v; }
+
+    void reset()
+    {
+        is_running   = false;
+        is_on_stack  = false;
+        is_transient = false;
+        is_flat      = false;
+        depth_change = false;
+    }
+
+protected:
+    bool is_running   = false;
+    bool is_on_stack  = false;
+    bool is_transient = false;
+    bool is_flat      = false;
+    bool depth_change = false;
+};
+//
+namespace internal
+{
+template <typename Tp, typename ValueT>
+struct base_data;
+//
+template <typename Tp>
+struct base_data<Tp, void>
+{
+    using type = ::tim::component::base_data<void, 0>;
+};
+//
+template <typename Tp>
+struct base_data<Tp, std::tuple<>>
+{
+    using type = ::tim::component::base_data<std::tuple<>, 0>;
+};
+//
+template <typename Tp>
+struct base_data<Tp, type_list<>>
+{
+    using type = ::tim::component::base_data<type_list<>, 0>;
+};
+//
+template <typename Tp>
+struct base_data<Tp, null_type>
+{
+    using type = ::tim::component::base_data<null_type, 0>;
+};
+//
+template <typename Tp, typename ValueT>
+struct base_data
+{
+    static constexpr auto   has_accum  = trait::base_has_accum<Tp>::value;
+    static constexpr auto   has_last   = trait::base_has_last<Tp>::value;
+    static constexpr size_t array_size = 1 + ((has_accum) ? 1 : 0) + ((has_last) ? 1 : 0);
+
+    using type = ::tim::component::base_data<ValueT, array_size>;
+
+    static_assert(!(has_last && !has_accum), "Error! base cannot have last w/o accum");
+};
+//
+}  // namespace internal
+//
+template <typename Tp, typename ValueT>
+using base_data_t = typename internal::base_data<Tp, ValueT>::type;
+//
+}  // namespace component
+}  // namespace tim

--- a/source/timemory/components/base/definition.hpp
+++ b/source/timemory/components/base/definition.hpp
@@ -53,15 +53,9 @@ template <typename Tp, typename Value>
 void
 base<Tp, Value>::reset()
 {
-    is_running   = false;
-    is_on_stack  = false;
-    is_transient = false;
-    is_flat      = false;
-    depth_change = false;
-    laps         = 0;
-    value        = value_type{};
-    accum        = accum_type{};
-    last         = last_type{};
+    laps = 0;
+    base_state::reset();
+    data_type::reset();
 }
 //
 //--------------------------------------------------------------------------------------//
@@ -70,7 +64,7 @@ template <typename Tp, typename Value>
 void
 base<Tp, Value>::measure()
 {
-    is_transient                = false;
+    set_is_transient(false);
     Type*                   obj = static_cast<Type*>(this);
     operation::record<Type> m{ *obj };
 }
@@ -93,10 +87,10 @@ base<Tp, Value>::get_opaque_data(void*& ptr, size_t _typeid_hash) const
 {
     if(!ptr && _typeid_hash == typeid_hash<Tp>())
     {
-        auto _data      = static_cast<const Tp*>(this)->get();
-        using data_type = decay_t<decltype(_data)>;
-        auto _pdata     = new data_type(_data);
-        ptr             = reinterpret_cast<void*>(_pdata);
+        auto _data   = static_cast<const Tp*>(this)->get();
+        using data_t = decay_t<decltype(_data)>;
+        auto _pdata  = new data_t(_data);
+        ptr          = reinterpret_cast<void*>(_pdata);
     }
 }
 //
@@ -106,7 +100,7 @@ template <typename Tp, typename Value>
 void
 base<Tp, Value>::set_started()
 {
-    is_running = true;
+    set_is_running(true);
 }
 //
 //--------------------------------------------------------------------------------------//
@@ -115,11 +109,11 @@ template <typename Tp, typename Value>
 void
 base<Tp, Value>::set_stopped()
 {
-    if(is_running)
+    if(get_is_running())
     {
         ++laps;
-        is_transient = true;
-        is_running   = false;
+        set_is_transient(true);
+        set_is_running(false);
     }
 }
 //
@@ -277,8 +271,7 @@ template <typename Tp, typename Value>
 Tp&
 base<Tp, Value>::plus_oper(const Tp& rhs)
 {
-    value = value_compute_type::plus(value, rhs.value);
-    accum = accum_compute_type::plus(accum, rhs.accum);
+    data_type::plus(rhs);
     return static_cast<Type&>(*this);
 }
 //
@@ -288,8 +281,7 @@ template <typename Tp, typename Value>
 Tp&
 base<Tp, Value>::minus_oper(const Tp& rhs)
 {
-    value = value_compute_type::minus(value, rhs.value);
-    accum = accum_compute_type::minus(accum, rhs.accum);
+    data_type::minus(rhs);
     return static_cast<Type&>(*this);
 }
 //
@@ -299,8 +291,7 @@ template <typename Tp, typename Value>
 Tp&
 base<Tp, Value>::multiply_oper(const Tp& rhs)
 {
-    value = value_compute_type::multiply(value, rhs.value);
-    accum = accum_compute_type::multiply(accum, rhs.accum);
+    data_type::multiply(rhs);
     return static_cast<Type&>(*this);
 }
 //
@@ -310,8 +301,7 @@ template <typename Tp, typename Value>
 Tp&
 base<Tp, Value>::divide_oper(const Tp& rhs)
 {
-    value = value_compute_type::divide(value, rhs.value);
-    accum = accum_compute_type::divide(accum, rhs.accum);
+    data_type::divide(rhs);
     return static_cast<Type&>(*this);
 }
 //
@@ -325,8 +315,7 @@ template <typename Tp, typename Value>
 Tp&
 base<Tp, Value>::plus_oper(const Value& rhs)
 {
-    value = value_compute_type::plus(value, rhs);
-    accum = accum_compute_type::plus(accum, rhs);
+    data_type::plus(rhs);
     return static_cast<Type&>(*this);
 }
 //
@@ -336,8 +325,7 @@ template <typename Tp, typename Value>
 Tp&
 base<Tp, Value>::minus_oper(const Value& rhs)
 {
-    value = value_compute_type::minus(value, rhs);
-    accum = accum_compute_type::minus(accum, rhs);
+    data_type::minus(rhs);
     return static_cast<Type&>(*this);
 }
 //
@@ -347,8 +335,7 @@ template <typename Tp, typename Value>
 Tp&
 base<Tp, Value>::multiply_oper(const Value& rhs)
 {
-    value = value_compute_type::multiply(value, rhs);
-    accum = accum_compute_type::multiply(accum, rhs);
+    data_type::minus(rhs);
     return static_cast<Type&>(*this);
 }
 //
@@ -358,8 +345,7 @@ template <typename Tp, typename Value>
 Tp&
 base<Tp, Value>::divide_oper(const Value& rhs)
 {
-    value = value_compute_type::divide(value, rhs);
-    accum = accum_compute_type::divide(accum, rhs);
+    data_type::divide(rhs);
     return static_cast<Type&>(*this);
 }
 //
@@ -412,9 +398,7 @@ template <typename Tp>
 void
 base<Tp, void>::reset()
 {
-    is_running   = false;
-    is_on_stack  = false;
-    is_transient = false;
+    base_state::reset();
 }
 //
 //--------------------------------------------------------------------------------------//
@@ -423,8 +407,7 @@ template <typename Tp>
 void
 base<Tp, void>::measure()
 {
-    // is_running   = false;
-    is_transient = false;
+    set_is_transient(false);
 }
 //
 //--------------------------------------------------------------------------------------//
@@ -433,7 +416,7 @@ template <typename Tp>
 void
 base<Tp, void>::set_started()
 {
-    is_running = true;
+    set_is_running(true);
 }
 //
 //--------------------------------------------------------------------------------------//
@@ -442,8 +425,9 @@ template <typename Tp>
 void
 base<Tp, void>::set_stopped()
 {
-    is_running   = false;
-    is_transient = true;
+    if(get_is_running())
+        set_is_transient(true);
+    set_is_running(false);
 }
 //
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/components/base/templates.hpp
+++ b/source/timemory/components/base/templates.hpp
@@ -57,7 +57,7 @@ template <typename Tp, typename Value>
 template <typename Archive, typename Up,
           enable_if_t<!trait::custom_serialization<Up>::value, int>>
 void
-base<Tp, Value>::load(Archive& ar, const unsigned int)
+base<Tp, Value>::load(Archive& ar, const unsigned int version)
 {
     auto try_catch = [](Archive& arch, const char* key, auto& val) {
         try
@@ -70,11 +70,11 @@ base<Tp, Value>::load(Archive& ar, const unsigned int)
         }
     };
 
-    try_catch(ar, "is_transient", is_transient);
+    bool _transient = get_is_transient();
+    try_catch(ar, "is_transient", _transient);
     try_catch(ar, "laps", laps);
-    try_catch(ar, "value", value);
-    try_catch(ar, "accum", accum);
-    try_catch(ar, "last", last);
+    data_type::serialize(ar, version);
+    set_is_transient(_transient);
 }
 //
 //--------------------------------------------------------------------------------------//
@@ -99,46 +99,6 @@ base<Tp, Value>::add_sample(Vp&& _obj)
     assert(_storage != nullptr);
     if(_storage)
         _storage->add_sample(std::forward<Vp>(_obj));
-}
-//
-//--------------------------------------------------------------------------------------//
-//
-template <typename Tp, typename Value>
-template <typename Up, enable_if_t<trait::base_has_accum<Up>::value, int>>
-Value&
-base<Tp, Value>::load()
-{
-    return (get_is_transient()) ? accum : value;
-}
-//
-//--------------------------------------------------------------------------------------//
-//
-template <typename Tp, typename Value>
-template <typename Up, enable_if_t<trait::base_has_accum<Up>::value, int>>
-const Value&
-base<Tp, Value>::load() const
-{
-    return (get_is_transient()) ? accum : value;
-}
-//
-//--------------------------------------------------------------------------------------//
-//
-template <typename Tp, typename Value>
-template <typename Up, enable_if_t<!trait::base_has_accum<Up>::value, int>>
-Value&
-base<Tp, Value>::load()
-{
-    return value;
-}
-//
-//--------------------------------------------------------------------------------------//
-//
-template <typename Tp, typename Value>
-template <typename Up, enable_if_t<!trait::base_has_accum<Up>::value, int>>
-const Value&
-base<Tp, Value>::load() const
-{
-    return value;
 }
 //
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/environment/definition.hpp
+++ b/source/timemory/environment/definition.hpp
@@ -230,27 +230,16 @@ get_env(const std::string& env_id, bool _default)
             val = (bool) atoi(var.c_str());
         else
         {
-            const auto        regex_constants = regex_const::egrep | regex_const::icase;
-            const std::string pattern         = "^(off|false|no|n|f|0)$";
-            bool              _match          = false;
-            try
+            for(auto& itr : var)
+                itr = tolower(itr);
+            for(const auto& itr : { "off", "false", "no", "n", "f", "0" })
             {
-                _match = std::regex_match(var, std::regex(pattern, regex_constants));
-            } catch(std::bad_cast&)
-            {
-                for(auto& itr : var)
-                    itr = tolower(itr);
-                for(const auto& itr : { "off", "false", "no", "n", "f", "0" })
+                if(var == itr)
                 {
-                    if(var == itr)
-                    {
-                        _match = true;
-                        break;
-                    }
+                    env_settings::instance()->insert<bool>(env_id, false);
+                    return false;
                 }
             }
-            if(_match)
-                val = false;
         }
         env_settings::instance()->insert<bool>(env_id, val);
         return val;

--- a/source/timemory/operations/types.hpp
+++ b/source/timemory/operations/types.hpp
@@ -347,26 +347,26 @@ struct is_running
     TIMEMORY_DEFAULT_OBJECT(is_running)
 
     template <typename Up>
-    auto operator()(Up& obj) const
+    auto operator()(const Up& obj) const
     {
         return sfinae(obj, 0);
     }
 
 private:
     template <typename Up>
-    static auto sfinae(Up& obj, int) -> decltype(obj.get_is_running())
+    static auto sfinae(const Up& obj, int) -> decltype(obj.get_is_running())
     {
         return obj.get_is_running();
     }
 
     template <typename Up>
-    static auto sfinae(Up& obj, long) -> decltype(obj.is_running())
+    static auto sfinae(const Up& obj, long) -> decltype(obj.is_running())
     {
         return obj.is_running();
     }
 
     template <typename Up>
-    static auto sfinae(Up&, ...) -> bool
+    static auto sfinae(const Up&, ...) -> bool
     {
         return DefaultValue;
     }


### PR DESCRIPTION
- refactors the component base to privately inherit from `base_state` and `base_data` classes
  - this introduces no changes to components built on-top of the base-class
  - additionally, this eliminated the need for a handful of SFINAE templates in the base-class
- `base_state` contains the logical fields for is_running/on_stack/etc.
- `base_data` contains the data fields value/accum/last
- this refactoring reduced the size of the components by 8 bytes in most cases
- additionally, fixed an issue with TIMEMORY_USE_CORE_EXTERN being defined when compiling the core library