### PR TITLE
operation::mark + missing kokkosp + other superficial changes

### DIFF
--- a/docs/api/operations.md
+++ b/docs/api/operations.md
@@ -96,6 +96,12 @@ nm --demangle <EXE or LIB> | grep operation
 .. doxygenstruct:: tim::operation::compose
     :members:
     :undoc-members:
+.. doxygenstruct:: tim::operation::is_running
+    :members:
+    :undoc-members:
+.. doxygenstruct:: tim::operation::set_started
+    :members:
+    :undoc-members:
 .. doxygenstruct:: tim::operation::start
     :members:
     :undoc-members:
@@ -108,6 +114,9 @@ nm --demangle <EXE or LIB> | grep operation
 .. doxygenstruct:: tim::operation::delayed_start
     :members:
     :undoc-members:
+.. doxygenstruct:: tim::operation::set_stopped
+    :members:
+    :undoc-members:
 .. doxygenstruct:: tim::operation::stop
     :members:
     :undoc-members:
@@ -118,6 +127,9 @@ nm --demangle <EXE or LIB> | grep operation
     :members:
     :undoc-members:
 .. doxygenstruct:: tim::operation::delayed_stop
+    :members:
+    :undoc-members:
+.. doxygenstruct:: tim::operation::mark
     :members:
     :undoc-members:
 .. doxygenstruct:: tim::operation::mark_begin

--- a/source/kokkosp.cpp
+++ b/source/kokkosp.cpp
@@ -162,6 +162,22 @@ extern "C"
 
     //----------------------------------------------------------------------------------//
 
+    void kokkosp_begin_fence(const char* name, uint32_t devid, uint64_t* kernid)
+    {
+        auto pname = TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
+        *kernid    = kokkosp::get_unique_id();
+        kokkosp::create_profiler<kokkosp::kokkos_bundle>(pname, *kernid);
+        kokkosp::start_profiler<kokkosp::kokkos_bundle>(*kernid);
+    }
+
+    void kokkosp_end_fence(uint64_t kernid)
+    {
+        kokkosp::stop_profiler<kokkosp::kokkos_bundle>(kernid);
+        kokkosp::destroy_profiler<kokkosp::kokkos_bundle>(kernid);
+    }
+
+    //----------------------------------------------------------------------------------//
+
     void kokkosp_push_profile_region(const char* name)
     {
         kokkosp::get_profiler_stack<kokkosp::kokkos_bundle>().push_back(
@@ -263,6 +279,13 @@ extern "C"
         kokkosp::get_profiler_stack<kokkosp::kokkos_bundle>().back().store(
             std::minus<int64_t>{}, 0);
         kokkosp::get_profiler_stack<kokkosp::kokkos_bundle>().pop_back();
+    }
+
+    //----------------------------------------------------------------------------------//
+
+    void kokkosp_profile_event(const char* name)
+    {
+        kokkosp::profiler_t<kokkosp::kokkos_bundle>{}.mark(name);
     }
 
     //----------------------------------------------------------------------------------//

--- a/source/tests/kokkosp_tests.cpp
+++ b/source/tests/kokkosp_tests.cpp
@@ -125,9 +125,11 @@ TEST_F(kokkosp_tests, profiling_routines)
 {
     auto _beg_sz = tim::storage<tim::component::wall_clock>::instance()->size();
 
-    std::array<uint64_t, 3> idx;
+    std::array<uint64_t, 4> idx;
     uint32_t                sec_idx = 0;
     idx.fill(0);
+
+    kokkosp_profile_event(details::get_test_name().c_str());
 
     kokkosp_begin_parallel_for("parallel_for", 0, &idx.at(0));
 
@@ -138,6 +140,10 @@ TEST_F(kokkosp_tests, profiling_routines)
     details::consume(100);
 
     kokkosp_begin_parallel_scan("parallel_scan", 0, &idx.at(2));
+
+    details::consume(100);
+
+    kokkosp_begin_parallel_scan("fence", 0, &idx.at(3));
 
     details::consume(100);
 
@@ -156,6 +162,10 @@ TEST_F(kokkosp_tests, profiling_routines)
     details::consume(100);
 
     kokkosp_pop_profile_region();
+
+    details::consume(100);
+
+    kokkosp_end_fence(idx.at(3));
 
     details::consume(100);
 

--- a/source/timemory/api/kokkosp.hpp
+++ b/source/timemory/api/kokkosp.hpp
@@ -313,6 +313,12 @@ extern "C"
     TIMEMORY_KOKKOSP_PREFIX void kokkosp_end_parallel_scan(uint64_t kernid)
         TIMEMORY_KOKKOSP_POSTFIX;
 
+    TIMEMORY_KOKKOSP_PREFIX void kokkosp_begin_fence(
+        const char* name, uint32_t devid, uint64_t* kernid) TIMEMORY_KOKKOSP_POSTFIX;
+
+    TIMEMORY_KOKKOSP_PREFIX void kokkosp_end_fence(uint64_t kernid)
+        TIMEMORY_KOKKOSP_POSTFIX;
+
     TIMEMORY_KOKKOSP_PREFIX void kokkosp_push_profile_region(const char* name)
         TIMEMORY_KOKKOSP_POSTFIX;
 
@@ -343,4 +349,7 @@ extern "C"
         uint64_t size) TIMEMORY_KOKKOSP_POSTFIX;
 
     TIMEMORY_KOKKOSP_PREFIX void kokkosp_end_deep_copy() TIMEMORY_KOKKOSP_POSTFIX;
+
+    TIMEMORY_KOKKOSP_PREFIX void kokkosp_profile_event(const char* name)
+        TIMEMORY_KOKKOSP_POSTFIX;
 }

--- a/source/timemory/components/cuda/components.hpp
+++ b/source/timemory/components/cuda/components.hpp
@@ -125,6 +125,8 @@ struct cuda_event : public base<cuda_event, float>
     }
 
 public:
+    TIMEMORY_DEFAULT_OBJECT(cuda_event)
+
     explicit cuda_event(cuda::stream_t _stream)
     : m_stream(_stream)
     , m_global(marker{})
@@ -135,13 +137,6 @@ public:
     //: cuda_event(_stream.cast<cuda::stream_t>())
     //{}
 #endif
-
-    cuda_event()                      = default;
-    ~cuda_event()                     = default;
-    cuda_event(const cuda_event&)     = default;
-    cuda_event(cuda_event&&) noexcept = default;
-    cuda_event& operator=(const cuda_event&) = default;
-    cuda_event& operator=(cuda_event&&) noexcept = default;
 
     float get_display() const
     {

--- a/source/timemory/components/cupti/cupti_activity.hpp
+++ b/source/timemory/components/cupti/cupti_activity.hpp
@@ -168,15 +168,10 @@ struct cupti_activity : public base<cupti_activity, intmax_t>
     //----------------------------------------------------------------------------------//
 
 public:
-    cupti_activity() = default;
+    TIMEMORY_DEFAULT_OBJECT(cupti_activity)
 
     // make sure it is removed
     ~cupti_activity() { cupti::activity::get_receiver().remove(this); }
-
-    cupti_activity(const cupti_activity&)     = default;
-    cupti_activity(cupti_activity&&) noexcept = default;
-    cupti_activity& operator=(const cupti_activity&) = default;
-    cupti_activity& operator=(cupti_activity&&) noexcept = default;
 
     //----------------------------------------------------------------------------------//
     // start

--- a/source/timemory/components/papi/components.hpp
+++ b/source/timemory/components/papi/components.hpp
@@ -389,9 +389,9 @@ struct papi_vector
 
     //----------------------------------------------------------------------------------//
 
-    ~papi_vector()                          = default;
-    papi_vector(const papi_vector& rhs)     = default;
-    papi_vector(papi_vector&& rhs) noexcept = default;
+    ~papi_vector()                      = default;
+    papi_vector(const papi_vector&)     = default;
+    papi_vector(papi_vector&&) noexcept = default;
     this_type& operator=(const this_type&) = default;
     this_type& operator=(this_type&&) noexcept = default;
 
@@ -713,9 +713,9 @@ struct papi_array
 
     //----------------------------------------------------------------------------------//
 
-    ~papi_array() {}
-    papi_array(const papi_array& rhs)     = default;
-    papi_array(papi_array&& rhs) noexcept = default;
+    ~papi_array()                     = default;
+    papi_array(const papi_array&)     = default;
+    papi_array(papi_array&&) noexcept = default;
     this_type& operator=(const this_type&) = default;
     this_type& operator=(this_type&&) noexcept = default;
 
@@ -1078,11 +1078,10 @@ public:
         apply<void>::set_value(accum, 0);
     }
 
-    ~papi_tuple() {}
-
-    papi_tuple(const papi_tuple& rhs) = default;
-    this_type& operator=(const this_type& rhs) = default;
-    papi_tuple(papi_tuple&& rhs) noexcept      = default;
+    ~papi_tuple()                     = default;
+    papi_tuple(const papi_tuple&)     = default;
+    papi_tuple(papi_tuple&&) noexcept = default;
+    this_type& operator=(const this_type&) = default;
     this_type& operator=(this_type&&) noexcept = default;
 
     //----------------------------------------------------------------------------------//
@@ -1319,6 +1318,8 @@ public:
     }
 
 public:
+    TIMEMORY_DEFAULT_OBJECT(papi_rate_tuple)
+
     void start()
     {
         value.first.start();

--- a/source/timemory/components/timing/backends.hpp
+++ b/source/timemory/components/timing/backends.hpp
@@ -23,13 +23,9 @@
 // SOFTWARE.
 //
 
-/** \file components/timing/backends.hpp
- * \headerfile components/timing/backends.hpp "timemory/components/timing/backends.hpp"
- * Implementation of the timing functions/utilities
- */
-
 #pragma once
 
+#include "timemory/macros/attributes.hpp"
 #include "timemory/macros/os.hpp"
 #include "timemory/utility/macros.hpp"
 
@@ -249,8 +245,8 @@ struct time_units<std::ratio<3600 * 24, 1>>
 
 //--------------------------------------------------------------------------------------//
 
-inline int64_t
-clock_tick() noexcept
+TIMEMORY_HOT_INLINE int64_t
+                    clock_tick() noexcept
 {
 #if defined(_WINDOWS)
     return CLOCKS_PER_SEC;
@@ -262,8 +258,8 @@ clock_tick() noexcept
 //--------------------------------------------------------------------------------------//
 
 template <typename Precision, typename Ret = int64_t>
-inline Ret
-clock_tick() noexcept
+TIMEMORY_HOT_INLINE Ret
+                    clock_tick() noexcept
 {
     return static_cast<Ret>(Precision::den) / static_cast<Ret>(clock_tick());
 }
@@ -271,8 +267,8 @@ clock_tick() noexcept
 //--------------------------------------------------------------------------------------//
 // general struct for the differnt clock_gettime functions
 template <typename Tp = double, typename Precision = std::ratio<1>>
-inline Tp
-get_clock_now(clockid_t clock_id) noexcept
+TIMEMORY_HOT_INLINE Tp
+                    get_clock_now(clockid_t clock_id) noexcept
 {
     constexpr Tp factor = static_cast<Tp>(std::nano::den) / Precision::den;
 #if defined(_MACOS)
@@ -288,8 +284,8 @@ get_clock_now(clockid_t clock_id) noexcept
 // the system's real time (i.e. wall time) clock, expressed as the amount of time since
 // the epoch.
 template <typename Tp = double, typename Precision = std::ratio<1>>
-inline Tp
-get_clock_real_now() noexcept
+TIMEMORY_HOT_INLINE Tp
+                    get_clock_real_now() noexcept
 {
     using clock_type    = std::chrono::steady_clock;
     using duration_type = std::chrono::duration<clock_type::rep, Precision>;
@@ -303,8 +299,8 @@ get_clock_real_now() noexcept
 // clock that increments monotonically, tracking the time since an arbitrary point,
 // and will continue to increment while the system is asleep.
 template <typename Tp = double, typename Precision = std::ratio<1>>
-inline Tp
-get_clock_monotonic_now() noexcept
+TIMEMORY_HOT_INLINE Tp
+                    get_clock_monotonic_now() noexcept
 {
     return get_clock_now<Tp, Precision>(CLOCK_MONOTONIC);
 }
@@ -314,8 +310,8 @@ get_clock_monotonic_now() noexcept
 // CLOCK_MONOTONIC.  However, this clock is unaffected by frequency or time adjustments.
 // It should not be compared to other system time sources.
 template <typename Tp = double, typename Precision = std::ratio<1>>
-inline Tp
-get_clock_monotonic_raw_now() noexcept
+TIMEMORY_HOT_INLINE Tp
+                    get_clock_monotonic_raw_now() noexcept
 {
     return get_clock_now<Tp, Precision>(CLOCK_MONOTONIC_RAW);
 }
@@ -326,8 +322,8 @@ get_clock_monotonic_raw_now() noexcept
 // clock that tracks the amount of CPU (in user- or kernel-mode) used by the calling
 // thread.
 template <typename Tp = double, typename Precision = std::ratio<1>>
-inline Tp
-get_clock_thread_now() noexcept
+TIMEMORY_HOT_INLINE Tp
+                    get_clock_thread_now() noexcept
 {
     return get_clock_now<Tp, Precision>(CLOCK_THREAD_CPUTIME_ID);
 }
@@ -337,8 +333,8 @@ get_clock_thread_now() noexcept
 // clock that tracks the amount of CPU (in user- or kernel-mode) used by the calling
 // process.
 template <typename Tp = double, typename Precision = std::ratio<1>>
-inline Tp
-get_clock_process_now() noexcept
+TIMEMORY_HOT_INLINE Tp
+                    get_clock_process_now() noexcept
 {
     return get_clock_now<Tp, Precision>(CLOCK_PROCESS_CPUTIME_ID);
 }
@@ -347,8 +343,8 @@ get_clock_process_now() noexcept
 // this function extracts only the CPU time spent in user-mode
 // for this process and child processes
 template <typename Tp = double, typename Precision = std::ratio<1>>
-inline Tp
-get_clock_user_now() noexcept
+TIMEMORY_HOT_INLINE Tp
+                    get_clock_user_now() noexcept
 {
     tms _tms;
     ::times(&_tms);
@@ -359,8 +355,8 @@ get_clock_user_now() noexcept
 // this function extracts only the CPU time spent in kernel-mode
 // for this process and child processes
 template <typename Tp = double, typename Precision = std::ratio<1>>
-inline Tp
-get_clock_system_now() noexcept
+TIMEMORY_HOT_INLINE Tp
+                    get_clock_system_now() noexcept
 {
     tms _tms;
     ::times(&_tms);
@@ -371,8 +367,8 @@ get_clock_system_now() noexcept
 // this function extracts only the CPU time spent in both user- and kernel- mode
 // for this process and child processes
 template <typename Tp = double, typename Precision = std::ratio<1>>
-inline Tp
-get_clock_cpu_now() noexcept
+TIMEMORY_HOT_INLINE Tp
+                    get_clock_cpu_now() noexcept
 {
     tms _tms;
     ::times(&_tms);
@@ -384,8 +380,8 @@ get_clock_cpu_now() noexcept
 // this function extracts only the CPU time spent in user-mode
 // for this process only
 template <typename Tp = double, typename Precision = std::ratio<1>>
-inline Tp
-get_self_clock_user_now() noexcept
+TIMEMORY_HOT_INLINE Tp
+                    get_self_clock_user_now() noexcept
 {
     tms _tms;
     ::times(&_tms);
@@ -396,8 +392,8 @@ get_self_clock_user_now() noexcept
 // this function extracts only the CPU time spent in kernel-mode
 // for this process only
 template <typename Tp = double, typename Precision = std::ratio<1>>
-inline Tp
-get_self_clock_system_now() noexcept
+TIMEMORY_HOT_INLINE Tp
+                    get_self_clock_system_now() noexcept
 {
     tms _tms;
     ::times(&_tms);
@@ -408,8 +404,8 @@ get_self_clock_system_now() noexcept
 // this function extracts only the CPU time spent in both user- and kernel- mode
 // for this process only
 template <typename Tp = double, typename Precision = std::ratio<1>>
-inline Tp
-get_self_clock_cpu_now() noexcept
+TIMEMORY_HOT_INLINE Tp
+                    get_self_clock_cpu_now() noexcept
 {
     return (clock() * static_cast<Tp>(Precision::den)) / static_cast<Tp>(CLOCKS_PER_SEC);
 }
@@ -418,8 +414,8 @@ get_self_clock_cpu_now() noexcept
 // this function extracts only the CPU time spent in user-mode
 // for this process only
 template <typename Tp = double, typename Precision = std::ratio<1>>
-inline Tp
-get_child_clock_user_now() noexcept
+TIMEMORY_HOT_INLINE Tp
+                    get_child_clock_user_now() noexcept
 {
     tms _tms;
     ::times(&_tms);
@@ -430,8 +426,8 @@ get_child_clock_user_now() noexcept
 // this function extracts only the CPU time spent in kernel-mode
 // for this process only
 template <typename Tp = double, typename Precision = std::ratio<1>>
-inline Tp
-get_child_clock_system_now() noexcept
+TIMEMORY_HOT_INLINE Tp
+                    get_child_clock_system_now() noexcept
 {
     tms _tms;
     ::times(&_tms);
@@ -442,8 +438,8 @@ get_child_clock_system_now() noexcept
 // this function extracts only the CPU time spent in both user- and kernel- mode
 // for this process only
 template <typename Tp = double, typename Precision = std::ratio<1>>
-inline Tp
-get_child_clock_cpu_now() noexcept
+TIMEMORY_HOT_INLINE Tp
+                    get_child_clock_cpu_now() noexcept
 {
     tms _tms;
     ::times(&_tms);

--- a/source/timemory/general/source_location.hpp
+++ b/source/timemory/general/source_location.hpp
@@ -77,14 +77,7 @@ public:
         : m_result(std::move(_result))
         {}
 
-        captured()  = default;
-        ~captured() = default;
-
-        captured(const captured&)     = default;
-        captured(captured&&) noexcept = default;
-
-        captured& operator=(const captured&) = default;
-        captured& operator=(captured&&) noexcept = default;
+        TIMEMORY_DEFAULT_OBJECT(captured)
 
     protected:
         friend class source_location;

--- a/source/timemory/macros/attributes.hpp
+++ b/source/timemory/macros/attributes.hpp
@@ -124,3 +124,9 @@
 #        define TIMEMORY_NOCLONE
 #    endif
 #endif
+
+//======================================================================================//
+//
+#if !defined(TIMEMORY_HOT_INLINE)
+#    define TIMEMORY_HOT_INLINE TIMEMORY_HOT TIMEMORY_INLINE
+#endif

--- a/source/timemory/mpl/policy.hpp
+++ b/source/timemory/mpl/policy.hpp
@@ -277,12 +277,7 @@ public:
     using pair_type                      = std::pair<int_type, int_type>;
     static constexpr bool thread_support = true;
 
-    instance_tracker()                            = default;
-    ~instance_tracker()                           = default;
-    instance_tracker(const instance_tracker&)     = default;
-    instance_tracker(instance_tracker&&) noexcept = default;
-    instance_tracker& operator=(const instance_tracker&) = default;
-    instance_tracker& operator=(instance_tracker&&) noexcept = default;
+    TIMEMORY_DEFAULT_OBJECT(instance_tracker)
 
     enum
     {

--- a/source/timemory/operations/types.hpp
+++ b/source/timemory/operations/types.hpp
@@ -642,9 +642,6 @@ struct merge;
 template <typename Type>
 struct merge<Type, true>
 {
-    template <typename KeyT, typename MappedT>
-    using uomap_t = std::unordered_map<KeyT, MappedT>;
-
     static constexpr bool has_data = true;
     using storage_type             = impl::storage<Type, has_data>;
     using singleton_t              = typename storage_type::singleton_type;

--- a/source/timemory/operations/types.hpp
+++ b/source/timemory/operations/types.hpp
@@ -292,6 +292,12 @@ struct compose;
 //
 //--------------------------------------------------------------------------------------//
 //
+/// \struct tim::operation::set_started
+/// \tparam T Component type
+///
+/// \brief This operation attempts to call a member function which the component provides
+/// to internally store whether or not it is currently within a phase measurement (to
+/// prevent restarts)
 template <typename T>
 struct set_started
 {
@@ -305,18 +311,24 @@ struct set_started
 
 private:
     template <typename Up>
-    TIMEMORY_HOT_INLINE auto sfinae(Up& obj, int) -> decltype(obj.set_started())
+    static TIMEMORY_HOT_INLINE auto sfinae(Up& obj, int) -> decltype(obj.set_started())
     {
         return obj.set_started();
     }
 
     template <typename Up>
-    TIMEMORY_INLINE auto sfinae(Up&, long) -> void
+    static TIMEMORY_INLINE auto sfinae(Up&, long) -> void
     {}
 };
 //
 //--------------------------------------------------------------------------------------//
 //
+/// \struct tim::operation::set_stopped
+/// \tparam T Component type
+///
+/// \brief This operation attempts to call a member function which the component provides
+/// to internally store whether or not it is currently within a phase measurement (to
+/// prevent stopping when it hasn't been started)
 template <typename T>
 struct set_stopped
 {
@@ -330,18 +342,24 @@ struct set_stopped
 
 private:
     template <typename Up>
-    TIMEMORY_HOT_INLINE auto sfinae(Up& obj, int) -> decltype(obj.set_stopped())
+    static TIMEMORY_HOT_INLINE auto sfinae(Up& obj, int) -> decltype(obj.set_stopped())
     {
         return obj.set_stopped();
     }
 
     template <typename Up>
-    TIMEMORY_INLINE auto sfinae(Up&, long) -> void
+    static TIMEMORY_INLINE auto sfinae(Up&, long) -> void
     {}
 };
 //
 //--------------------------------------------------------------------------------------//
 //
+/// \struct tim::operation::is_running
+/// \tparam T Component type
+/// \tparam DefaultValue The value to return if the member function is not provided
+///
+/// \brief This operation attempts to call a member function which provides whether or not
+/// the component currently within a phase measurement
 template <typename T, bool DefaultValue>
 struct is_running
 {
@@ -412,6 +430,11 @@ struct standard_stop;
 //
 template <typename T>
 struct delayed_stop;
+//
+//--------------------------------------------------------------------------------------//
+//
+template <typename T>
+struct mark;
 //
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/operations/types.hpp
+++ b/source/timemory/operations/types.hpp
@@ -30,6 +30,7 @@
 #pragma once
 
 #include "timemory/backends/dmp.hpp"
+#include "timemory/macros/attributes.hpp"
 #include "timemory/mpl/function_traits.hpp"
 #include "timemory/mpl/types.hpp"
 #include "timemory/operations/macros.hpp"
@@ -297,20 +298,20 @@ struct set_started
     TIMEMORY_DEFAULT_OBJECT(set_started)
 
     template <typename Up>
-    auto operator()(Up& obj) const
+    TIMEMORY_HOT_INLINE auto operator()(Up& obj) const
     {
         return sfinae(obj, 0);
     }
 
 private:
     template <typename Up>
-    static auto sfinae(Up& obj, int) -> decltype(obj.set_started())
+    TIMEMORY_HOT_INLINE auto sfinae(Up& obj, int) -> decltype(obj.set_started())
     {
         return obj.set_started();
     }
 
     template <typename Up>
-    static auto sfinae(Up&, long) -> void
+    TIMEMORY_INLINE auto sfinae(Up&, long) -> void
     {}
 };
 //
@@ -322,20 +323,20 @@ struct set_stopped
     TIMEMORY_DEFAULT_OBJECT(set_stopped)
 
     template <typename Up>
-    auto operator()(Up& obj) const
+    TIMEMORY_HOT_INLINE auto operator()(Up& obj) const
     {
         return sfinae(obj, 0);
     }
 
 private:
     template <typename Up>
-    static auto sfinae(Up& obj, int) -> decltype(obj.set_stopped())
+    TIMEMORY_HOT_INLINE auto sfinae(Up& obj, int) -> decltype(obj.set_stopped())
     {
         return obj.set_stopped();
     }
 
     template <typename Up>
-    static auto sfinae(Up&, long) -> void
+    TIMEMORY_INLINE auto sfinae(Up&, long) -> void
     {}
 };
 //
@@ -347,7 +348,7 @@ struct is_running
     TIMEMORY_DEFAULT_OBJECT(is_running)
 
     template <typename Up>
-    auto operator()(const Up& obj) const
+    TIMEMORY_HOT_INLINE auto operator()(const Up& obj) const
     {
         return sfinae(obj, 0);
     }

--- a/source/timemory/operations/types/add_statistics.hpp
+++ b/source/timemory/operations/types/add_statistics.hpp
@@ -94,34 +94,37 @@ struct add_statistics
     //
     template <typename StatsT, typename U = type,
               enable_if_t<enabled_statistics<U, StatsT>::value, int> = 0>
-    add_statistics(const U& rhs, StatsT& stats)
-    {
-        // for type comparison
-        using incoming_t = decay_t<typename StatsT::value_type>;
-        using expected_t = decay_t<typename trait::statistics<U>::type>;
-        // check the incomming stat type against declared stat type
-        // but allow for permissive_statistics when there is an acceptable
-        // implicit conversion
-        static_assert((!trait::permissive_statistics<U>::value &&
-                       std::is_same<incoming_t, expected_t>::value),
-                      "add_statistics was passed a data type different than declared "
-                      "trait::statistics type. To disable this error, e.g. permit "
-                      "implicit conversion, set trait::permissive_statistics "
-                      "to true_type for component");
-        using stats_policy_type = policy::record_statistics<U>;
-        stats_policy_type::apply(stats, rhs);
-    }
+    TIMEMORY_HOT_INLINE add_statistics(const U& rhs, StatsT& stats);
 
     //----------------------------------------------------------------------------------//
     // if statistics is not enabled
     //
     template <typename StatsT, typename U,
               enable_if_t<!enabled_statistics<U, StatsT>::value, int> = 0>
-    add_statistics(const U&, StatsT&)
+    TIMEMORY_INLINE add_statistics(const U&, StatsT&)
     {}
 };
 //
-//--------------------------------------------------------------------------------------//
+template <typename T>
+template <typename StatsT, typename U,
+          enable_if_t<enabled_statistics<U, StatsT>::value, int>>
+add_statistics<T>::add_statistics(const U& rhs, StatsT& stats)
+{
+    // for type comparison
+    using incoming_t = decay_t<typename StatsT::value_type>;
+    using expected_t = decay_t<typename trait::statistics<U>::type>;
+    // check the incomming stat type against declared stat type
+    // but allow for permissive_statistics when there is an acceptable
+    // implicit conversion
+    static_assert((!trait::permissive_statistics<U>::value &&
+                   std::is_same<incoming_t, expected_t>::value),
+                  "add_statistics was passed a data type different than declared "
+                  "trait::statistics type. To disable this error, e.g. permit "
+                  "implicit conversion, set trait::permissive_statistics "
+                  "to true_type for component");
+    using stats_policy_type = policy::record_statistics<U>;
+    stats_policy_type::apply(stats, rhs);
+}
 //
 }  // namespace operation
 }  // namespace tim

--- a/source/timemory/operations/types/finalize/merge.hpp
+++ b/source/timemory/operations/types/finalize/merge.hpp
@@ -36,12 +36,17 @@
 #include "timemory/storage/basic_tree.hpp"
 #include "timemory/storage/graph.hpp"
 
+#include <unordered_map>
+
 namespace tim
 {
 namespace operation
 {
 namespace finalize
 {
+//
+template <typename KeyT, typename MappedT>
+using uomap_t = std::unordered_map<KeyT, MappedT>;
 //
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/operations/types/generic.hpp
+++ b/source/timemory/operations/types/generic.hpp
@@ -241,7 +241,7 @@ struct generic_deleter
 
     TIMEMORY_DELETED_OBJECT(generic_deleter)
 
-    explicit generic_deleter(type*& obj)
+    TIMEMORY_ALWAYS_INLINE explicit generic_deleter(type*& obj)
     {
         DEBUG_PRINT_HERE("%s %s :: %p", "deleting pointer lvalue",
                          demangle<type>().c_str(), (void*) obj);
@@ -250,7 +250,7 @@ struct generic_deleter
     }
 
     template <typename Up, enable_if_t<std::is_pointer<Up>::value, int> = 0>
-    explicit generic_deleter(Up&& obj)
+    TIMEMORY_ALWAYS_INLINE explicit generic_deleter(Up&& obj)
     {
         DEBUG_PRINT_HERE("%s %s :: %p", "deleting pointer rvalue",
                          demangle<type>().c_str(), (void*) obj);
@@ -259,14 +259,15 @@ struct generic_deleter
     }
 
     template <typename... Deleter>
-    explicit generic_deleter(std::unique_ptr<type, Deleter...>& obj)
+    TIMEMORY_ALWAYS_INLINE explicit generic_deleter(
+        std::unique_ptr<type, Deleter...>& obj)
     {
         DEBUG_PRINT_HERE("%s %s :: %p", "deleting unique_ptr", demangle<type>().c_str(),
                          (void*) obj.get());
         obj.reset();
     }
 
-    explicit generic_deleter(std::shared_ptr<type> obj)
+    TIMEMORY_ALWAYS_INLINE explicit generic_deleter(std::shared_ptr<type> obj)
     {
         DEBUG_PRINT_HERE("%s %s :: %p", "deleting shared_ptr", demangle<type>().c_str(),
                          (void*) obj.get());
@@ -274,7 +275,7 @@ struct generic_deleter
     }
 
     template <typename Up, enable_if_t<!std::is_pointer<Up>::value, int> = 0>
-    explicit generic_deleter(Up&&)
+    TIMEMORY_ALWAYS_INLINE explicit generic_deleter(Up&&)
     {
         DEBUG_PRINT_HERE("%s %s", "type is not deleted", demangle<type>().c_str());
     }
@@ -295,14 +296,14 @@ struct generic_counter
     TIMEMORY_DELETED_OBJECT(generic_counter)
 
     template <typename Up, enable_if_t<std::is_pointer<Up>::value, int> = 0>
-    explicit generic_counter(const Up& obj, uint64_t& count)
+    TIMEMORY_ALWAYS_INLINE explicit generic_counter(const Up& obj, uint64_t& count)
     {
         // static_assert(std::is_same<Up, type>::value, "Error! Up != type");
         count += (trait::runtime_enabled<type>::get() && obj) ? 1 : 0;
     }
 
     template <typename Up, enable_if_t<!std::is_pointer<Up>::value, int> = 0>
-    explicit generic_counter(const Up&, uint64_t& count)
+    TIMEMORY_ALWAYS_INLINE explicit generic_counter(const Up&, uint64_t& count)
     {
         // static_assert(std::is_same<Up, type>::value, "Error! Up != type");
         count += (trait::runtime_enabled<type>::get()) ? 1 : 0;

--- a/source/timemory/operations/types/mark.hpp
+++ b/source/timemory/operations/types/mark.hpp
@@ -41,6 +41,50 @@ namespace operation
 //--------------------------------------------------------------------------------------//
 //
 ///
+/// \struct operation::mark
+/// \brief This operation class is used for marking some event (usually in some external
+/// profiler)
+///
+//
+//--------------------------------------------------------------------------------------//
+//
+template <typename Tp>
+struct mark
+{
+    using type = Tp;
+
+    TIMEMORY_DEFAULT_OBJECT(mark)
+
+    template <typename... Args>
+    explicit mark(type& obj, Args&&... args)
+    {
+        sfinae(obj, 0, std::forward<Args>(args)...);
+    }
+
+    template <typename... Args>
+    auto operator()(type& obj, Args&&... args)
+    {
+        return sfinae(obj, 0, std::forward<Args>(args)...);
+    }
+
+private:
+    //  The equivalent of supports args
+    template <typename Up, typename... Args>
+    auto sfinae(Up& obj, int, Args&&... args)
+        -> decltype(obj.mark(std::forward<Args>(args)...))
+    {
+        return obj.mark(std::forward<Args>(args)...);
+    }
+
+    //  No member function
+    template <typename Up, typename... Args>
+    void sfinae(Up&, long, Args&&...)
+    {}
+};
+//
+//--------------------------------------------------------------------------------------//
+//
+///
 /// \struct operation::mark_begin
 /// \brief This operation class is used for asynchronous routines such as \ref cuda_event
 /// and \ref nvtx_marker which are passed cudaStream_t instances

--- a/source/timemory/operations/types/set.hpp
+++ b/source/timemory/operations/types/set.hpp
@@ -53,20 +53,20 @@ struct set_prefix
 
     TIMEMORY_DELETED_OBJECT(set_prefix)
 
-    set_prefix(type& obj, const string_t& prefix);
-    set_prefix(type& obj, uint64_t nhash, const string_t& prefix);
+    TIMEMORY_HOT_INLINE set_prefix(type& obj, const string_t& prefix);
+    TIMEMORY_HOT_INLINE set_prefix(type& obj, uint64_t nhash, const string_t& prefix);
 
 private:
     //  If the component has a set_prefix(const string_t&) member function
     template <typename U>
-    auto sfinae_str(U& obj, int, int, const string_t& prefix)
+    TIMEMORY_HOT_INLINE auto sfinae_str(U& obj, int, int, const string_t& prefix)
         -> decltype(obj.set_prefix(prefix), void())
     {
         obj.set_prefix(prefix);
     }
 
     template <typename U>
-    auto sfinae_str(U& obj, int, long, const string_t& prefix)
+    TIMEMORY_HOT_INLINE auto sfinae_str(U& obj, int, long, const string_t& prefix)
         -> decltype(obj.set_prefix(prefix.c_str()), void())
     {
         obj.set_prefix(prefix.c_str());
@@ -74,13 +74,13 @@ private:
 
     //  If the component does not have a set_prefix(const string_t&) member function
     template <typename U>
-    void sfinae_str(U&, long, long, const string_t&)
+    TIMEMORY_INLINE void sfinae_str(U&, long, long, const string_t&)
     {}
 
 private:
     //  If the component has a set_prefix(uint64_t) member function
     template <typename U>
-    auto sfinae_hash(U& obj, int, uint64_t nhash)
+    TIMEMORY_HOT_INLINE auto sfinae_hash(U& obj, int, uint64_t nhash)
         -> decltype(obj.set_prefix(nhash), void())
     {
         obj.set_prefix(nhash);
@@ -88,7 +88,7 @@ private:
 
     //  If the component does not have a set_prefix(uint64_t) member function
     template <typename U>
-    void sfinae_hash(U&, long, uint64_t)
+    TIMEMORY_INLINE void sfinae_hash(U&, long, uint64_t)
     {}
 };
 //
@@ -107,12 +107,12 @@ struct set_scope
 
     TIMEMORY_DELETED_OBJECT(set_scope)
 
-    set_scope(type& obj, scope::config _data);
+    TIMEMORY_HOT_INLINE set_scope(type& obj, scope::config _data);
 
 private:
     //  If the component has a set_scope(...) member function
     template <typename T>
-    auto sfinae(T& obj, int, scope::config _data)
+    TIMEMORY_HOT_INLINE auto sfinae(T& obj, int, scope::config _data)
         -> decltype(obj.set_scope(_data), void())
     {
         obj.set_scope(_data);
@@ -120,7 +120,7 @@ private:
 
     //  If the component does not have a set_scope(...) member function
     template <typename T>
-    auto sfinae(T&, long, scope::config) -> decltype(void(), void())
+    TIMEMORY_INLINE auto sfinae(T&, long, scope::config) -> decltype(void(), void())
     {}
 };
 //

--- a/source/timemory/operations/types/start.hpp
+++ b/source/timemory/operations/types/start.hpp
@@ -55,16 +55,16 @@ struct start
 
     TIMEMORY_DELETED_OBJECT(start)
 
-    explicit start(type& obj) { impl(obj); }
+    TIMEMORY_HOT_INLINE explicit start(type& obj) { impl(obj); }
 
     template <typename Arg, typename... Args>
-    start(type& obj, Arg&& arg, Args&&... args)
+    TIMEMORY_HOT_INLINE start(type& obj, Arg&& arg, Args&&... args)
     {
         impl(obj, std::forward<Arg>(arg), std::forward<Args>(args)...);
     }
 
     template <typename... Args>
-    auto operator()(type& obj, Args&&... args)
+    TIMEMORY_HOT_INLINE auto operator()(type& obj, Args&&... args)
     {
         using RetT = decltype(do_sfinae(obj, 0, 0, std::forward<Args>(args)...));
         if(trait::runtime_enabled<type>::get() && !is_running<Tp, false>{}(obj))
@@ -76,11 +76,11 @@ struct start
 
 private:
     template <typename... Args>
-    void impl(type& obj, Args&&... args);
+    TIMEMORY_HOT_INLINE void impl(type& obj, Args&&... args);
 
     // resolution #1 (best)
     template <typename Up, typename... Args>
-    auto do_sfinae(Up& obj, int, int, Args&&... args)
+    TIMEMORY_HOT_INLINE auto do_sfinae(Up& obj, int, int, Args&&... args)
         -> decltype(obj.start(std::forward<Args>(args)...))
     {
         set_started<Tp>{}(obj);
@@ -89,7 +89,8 @@ private:
 
     // resolution #2
     template <typename Up, typename... Args>
-    auto do_sfinae(Up& obj, int, long, Args&&...) -> decltype(obj.start())
+    TIMEMORY_HOT_INLINE auto do_sfinae(Up& obj, int, long, Args&&...)
+        -> decltype(obj.start())
     {
         set_started<Tp>{}(obj);
         return obj.start();
@@ -120,19 +121,19 @@ struct priority_start
     TIMEMORY_DELETED_OBJECT(priority_start)
 
     template <typename... Args>
-    explicit priority_start(type& obj, Args&&... args);
+    TIMEMORY_HOT_INLINE explicit priority_start(type& obj, Args&&... args);
 
 private:
     //  satisfies mpl condition
     template <typename Up, typename... Args>
-    auto sfinae(Up& obj, true_type&&, Args&&... args)
+    TIMEMORY_HOT_INLINE auto sfinae(Up& obj, true_type&&, Args&&... args)
     {
         start<Tp> _tmp(obj, std::forward<Args>(args)...);
     }
 
     //  does not satisfy mpl condition
     template <typename Up, typename... Args>
-    void sfinae(Up&, false_type&&, Args&&...)
+    TIMEMORY_INLINE void sfinae(Up&, false_type&&, Args&&...)
     {}
 };
 //
@@ -151,19 +152,19 @@ struct standard_start
     TIMEMORY_DELETED_OBJECT(standard_start)
 
     template <typename... Args>
-    explicit standard_start(type& obj, Args&&... args);
+    TIMEMORY_HOT_INLINE explicit standard_start(type& obj, Args&&... args);
 
 private:
     //  satisfies mpl condition
     template <typename Up, typename... Args>
-    auto sfinae(Up& obj, true_type&&, Args&&... args)
+    TIMEMORY_HOT_INLINE auto sfinae(Up& obj, true_type&&, Args&&... args)
     {
         start<Tp> _tmp(obj, std::forward<Args>(args)...);
     }
 
     //  does not satisfy mpl condition
     template <typename Up, typename... Args>
-    void sfinae(Up&, false_type&&, Args&&...)
+    TIMEMORY_INLINE void sfinae(Up&, false_type&&, Args&&...)
     {}
 };
 //
@@ -182,19 +183,19 @@ struct delayed_start
     TIMEMORY_DELETED_OBJECT(delayed_start)
 
     template <typename... Args>
-    explicit delayed_start(type& obj, Args&&... args);
+    TIMEMORY_HOT_INLINE explicit delayed_start(type& obj, Args&&... args);
 
 private:
     //  satisfies mpl condition
     template <typename Up, typename... Args>
-    auto sfinae(Up& obj, true_type&&, Args&&... args)
+    TIMEMORY_HOT_INLINE auto sfinae(Up& obj, true_type&&, Args&&... args)
     {
         start<Tp> _tmp(obj, std::forward<Args>(args)...);
     }
 
     //  does not satisfy mpl condition
     template <typename Up, typename... Args>
-    void sfinae(Up&, false_type&&, Args&&...)
+    TIMEMORY_INLINE void sfinae(Up&, false_type&&, Args&&...)
     {}
 };
 //

--- a/source/timemory/operations/types/stop.hpp
+++ b/source/timemory/operations/types/stop.hpp
@@ -55,16 +55,16 @@ struct stop
 
     TIMEMORY_DELETED_OBJECT(stop)
 
-    explicit stop(type& obj) { impl(obj); }
+    TIMEMORY_HOT_INLINE explicit stop(type& obj) { impl(obj); }
 
     template <typename Arg, typename... Args>
-    stop(type& obj, Arg&& arg, Args&&... args)
+    TIMEMORY_HOT_INLINE stop(type& obj, Arg&& arg, Args&&... args)
     {
         impl(obj, std::forward<Arg>(arg), std::forward<Args>(args)...);
     }
 
     template <typename... Args>
-    auto operator()(type& obj, Args&&... args)
+    TIMEMORY_HOT_INLINE auto operator()(type& obj, Args&&... args)
     {
         using RetT = decltype(do_sfinae(obj, 0, 0, std::forward<Args>(args)...));
         if(trait::runtime_enabled<type>::get() && is_running<Tp, true>{}(obj))
@@ -76,11 +76,11 @@ struct stop
 
 private:
     template <typename... Args>
-    void impl(type& obj, Args&&... args);
+    TIMEMORY_HOT_INLINE void impl(type& obj, Args&&... args);
 
     // resolution #1 (best)
     template <typename Up, typename... Args>
-    auto do_sfinae(Up& obj, int, int, Args&&... args)
+    TIMEMORY_HOT_INLINE auto do_sfinae(Up& obj, int, int, Args&&... args)
         -> decltype(obj.stop(std::forward<Args>(args)...))
     {
         set_stopped<Tp>{}(obj);
@@ -89,7 +89,8 @@ private:
 
     // resolution #2
     template <typename Up, typename... Args>
-    auto do_sfinae(Up& obj, int, long, Args&&...) -> decltype(obj.stop())
+    TIMEMORY_HOT_INLINE auto do_sfinae(Up& obj, int, long, Args&&...)
+        -> decltype(obj.stop())
     {
         set_stopped<Tp>{}(obj);
         return obj.stop();
@@ -118,19 +119,19 @@ struct priority_stop
     TIMEMORY_DELETED_OBJECT(priority_stop)
 
     template <typename... Args>
-    explicit priority_stop(type& obj, Args&&... args);
+    TIMEMORY_HOT_INLINE explicit priority_stop(type& obj, Args&&... args);
 
 private:
     //  satisfies mpl condition
     template <typename Up, typename... Args>
-    auto sfinae(Up& obj, true_type&&, Args&&... args)
+    TIMEMORY_HOT_INLINE auto sfinae(Up& obj, true_type&&, Args&&... args)
     {
         stop<Tp> _tmp(obj, std::forward<Args>(args)...);
     }
 
     //  does not satisfy mpl condition
     template <typename Up, typename... Args>
-    void sfinae(Up&, false_type&&, Args&&...)
+    TIMEMORY_INLINE void sfinae(Up&, false_type&&, Args&&...)
     {}
 };
 //
@@ -149,19 +150,19 @@ struct standard_stop
     TIMEMORY_DELETED_OBJECT(standard_stop)
 
     template <typename... Args>
-    explicit standard_stop(type& obj, Args&&... args);
+    TIMEMORY_HOT_INLINE explicit standard_stop(type& obj, Args&&... args);
 
 private:
     //  satisfies mpl condition
     template <typename Up, typename... Args>
-    auto sfinae(Up& obj, true_type&&, Args&&... args)
+    TIMEMORY_HOT_INLINE auto sfinae(Up& obj, true_type&&, Args&&... args)
     {
         stop<Tp> _tmp(obj, std::forward<Args>(args)...);
     }
 
     //  does not satisfy mpl condition
     template <typename Up, typename... Args>
-    void sfinae(Up&, false_type&&, Args&&...)
+    TIMEMORY_INLINE void sfinae(Up&, false_type&&, Args&&...)
     {}
 };
 //
@@ -180,19 +181,19 @@ struct delayed_stop
     TIMEMORY_DELETED_OBJECT(delayed_stop)
 
     template <typename... Args>
-    explicit delayed_stop(type& obj, Args&&... args);
+    TIMEMORY_HOT_INLINE explicit delayed_stop(type& obj, Args&&... args);
 
 private:
     //  satisfies mpl condition
     template <typename Up, typename... Args>
-    auto sfinae(Up& obj, true_type&&, Args&&... args)
+    TIMEMORY_HOT_INLINE auto sfinae(Up& obj, true_type&&, Args&&... args)
     {
         stop<Tp> _tmp(obj, std::forward<Args>(args)...);
     }
 
     //  does not satisfy mpl condition
     template <typename Up, typename... Args>
-    void sfinae(Up&, false_type&&, Args&&...)
+    TIMEMORY_INLINE void sfinae(Up&, false_type&&, Args&&...)
     {}
 };
 //

--- a/source/timemory/storage/node.hpp
+++ b/source/timemory/storage/node.hpp
@@ -132,8 +132,8 @@ public:
     graph();
     explicit graph(base_type&& _base) noexcept;
 
-    ~graph()            = default;
-    graph(const graph&) = default;
+    ~graph()                = default;
+    graph(const graph&)     = default;
     graph(graph&&) noexcept = default;
     graph(uint64_t _id, const Tp& _obj, int64_t _depth, uint16_t _tid,
           uint16_t _pid = process::get_id(), bool _is_dummy = false);
@@ -193,9 +193,9 @@ struct result : public data<Tp>::result_type
     using stats_type   = typename data<Tp>::stats_type;
     using this_type    = result<Tp>;
 
-    result()              = default;
-    ~result()             = default;
-    result(const result&) = default;
+    result()                  = default;
+    ~result()                 = default;
+    result(const result&)     = default;
     result(result&&) noexcept = default;
     result& operator=(const result&) = default;
     result& operator=(result&&) noexcept = default;
@@ -279,8 +279,8 @@ public:
     tree(const graph<Tp>&);
     tree& operator=(const graph<Tp>&);
 
-    ~tree()           = default;
-    tree(const tree&) = default;
+    ~tree()               = default;
+    tree(const tree&)     = default;
     tree(tree&&) noexcept = default;
     tree(bool _is_dummy, uint16_t _tid, uint16_t _pid, uint64_t _hash, int64_t _depth,
          const Tp& _obj);

--- a/source/timemory/utility/types.hpp
+++ b/source/timemory/utility/types.hpp
@@ -352,8 +352,8 @@ get_fields()
 //--------------------------------------------------------------------------------------//
 //
 template <typename Arg, size_t... Idx>
-static TIMEMORY_INLINE TIMEMORY_HOT auto
-                       generate(Arg&& arg, index_sequence<Idx...>)
+static TIMEMORY_HOT_INLINE auto
+generate(Arg&& arg, index_sequence<Idx...>)
 {
     static_assert(sizeof...(Idx) <= scope_count, "Error! Bad index sequence size");
     data_type ret;
@@ -364,8 +364,8 @@ static TIMEMORY_INLINE TIMEMORY_HOT auto
 //--------------------------------------------------------------------------------------//
 //
 template <size_t... Idx>
-static TIMEMORY_INLINE TIMEMORY_HOT auto
-                       either(data_type ret, data_type arg, index_sequence<Idx...>)
+static TIMEMORY_HOT_INLINE auto
+either(data_type ret, data_type arg, index_sequence<Idx...>)
 {
     static_assert(sizeof...(Idx) <= scope_count, "Error! Bad index sequence size");
     TIMEMORY_FOLD_EXPRESSION(ret.set(Idx, ret.test(Idx) || arg.test(Idx)));
@@ -374,8 +374,8 @@ static TIMEMORY_INLINE TIMEMORY_HOT auto
 //
 //--------------------------------------------------------------------------------------//
 //
-static TIMEMORY_INLINE TIMEMORY_HOT data_type
-                                    get_default_bitset()
+static TIMEMORY_HOT_INLINE auto
+get_default_bitset() -> data_type
 {
     return generate(get_fields(), make_index_sequence<scope_count>{});
 }
@@ -573,16 +573,16 @@ struct config : public data_type
 //
 //--------------------------------------------------------------------------------------//
 //
-static TIMEMORY_INLINE TIMEMORY_HOT config
-                                    get_default()
+static TIMEMORY_HOT_INLINE auto
+get_default() -> config
 {
     return config{ get_default_bitset() };
 }
 //
 //--------------------------------------------------------------------------------------//
 //
-TIMEMORY_INLINE TIMEMORY_HOT config
-                             operator+(config _lhs, tree)
+TIMEMORY_HOT_INLINE auto
+operator+(config _lhs, tree) -> config
 {
     _lhs.set(tree::value, true);
     return _lhs;
@@ -590,8 +590,8 @@ TIMEMORY_INLINE TIMEMORY_HOT config
 //
 //--------------------------------------------------------------------------------------//
 //
-TIMEMORY_INLINE TIMEMORY_HOT config
-                             operator+(config _lhs, flat)
+TIMEMORY_HOT_INLINE auto
+operator+(config _lhs, flat) -> config
 {
     _lhs.set(flat::value, true);
     return _lhs;
@@ -599,8 +599,8 @@ TIMEMORY_INLINE TIMEMORY_HOT config
 //
 //--------------------------------------------------------------------------------------//
 //
-TIMEMORY_INLINE TIMEMORY_HOT config
-                             operator+(config _lhs, timeline)
+TIMEMORY_HOT_INLINE auto
+operator+(config _lhs, timeline) -> config
 {
     _lhs.set(timeline::value, true);
     return _lhs;
@@ -608,8 +608,8 @@ TIMEMORY_INLINE TIMEMORY_HOT config
 //
 //--------------------------------------------------------------------------------------//
 //
-TIMEMORY_INLINE TIMEMORY_HOT config
-                             operator+(config _lhs, config _rhs)
+TIMEMORY_HOT_INLINE auto
+operator+(config _lhs, config _rhs) -> config
 {
     return config{ either(_lhs, _rhs, make_index_sequence<scope_count>{}) };
 }

--- a/source/timemory/variadic/auto_bundle.hpp
+++ b/source/timemory/variadic/auto_bundle.hpp
@@ -284,6 +284,13 @@ public:
         if(m_enabled)
             m_temporary.derive(std::forward<Args>(args)...);
     }
+    /// invoke mark member function on all components
+    template <typename... Args>
+    void mark(Args&&... args)
+    {
+        if(m_enabled)
+            m_temporary.mark(std::forward<Args>(args)...);
+    }
     /// invoke mark_begin member function on all components
     template <typename... Args>
     void mark_begin(Args&&... args)

--- a/source/timemory/variadic/auto_list.hpp
+++ b/source/timemory/variadic/auto_list.hpp
@@ -219,6 +219,12 @@ public:
             m_temporary.derive(std::forward<Args>(args)...);
     }
     template <typename... Args>
+    void mark(Args&&... args)
+    {
+        if(m_enabled)
+            m_temporary.mark(std::forward<Args>(args)...);
+    }
+    template <typename... Args>
     void mark_begin(Args&&... args)
     {
         if(m_enabled)

--- a/source/timemory/variadic/auto_tuple.hpp
+++ b/source/timemory/variadic/auto_tuple.hpp
@@ -226,6 +226,12 @@ public:
             m_temporary.derive(std::forward<Args>(args)...);
     }
     template <typename... Args>
+    void mark(Args&&... args)
+    {
+        if(m_enabled)
+            m_temporary.mark(std::forward<Args>(args)...);
+    }
+    template <typename... Args>
     void mark_begin(Args&&... args)
     {
         if(m_enabled)

--- a/source/timemory/variadic/component_bundle.hpp
+++ b/source/timemory/variadic/component_bundle.hpp
@@ -271,7 +271,7 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    // construct the objects that have constructors with matching arguments
+    /// construct the objects that have constructors with matching arguments
     //
     template <typename... Args>
     void construct(Args&&... _args)
@@ -281,7 +281,9 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    /// provide preliminary info to the objects with matching arguments
+    /// provide preliminary info to the objects with matching arguments. This is typically
+    /// used to notify a component that it has been bundled alongside another component
+    /// that it can extract data from.
     //
     template <typename... Args>
     void assemble(Args&&... _args)
@@ -290,7 +292,10 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    /// provide conclusive info to the objects with matching arguments
+    /// provide conclusive info to the objects with matching arguments. This is typically
+    /// used by components to extract data from another component it has been bundled
+    /// alongside, e.g. the cpu_util component can extract data from \ref
+    /// tim::component::wall_clock and \ref tim::component::cpu_clock
     //
     template <typename... Args>
     void derive(Args&&... _args)
@@ -299,8 +304,17 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    // mark a beginning position in the execution (typically used by asynchronous
-    // structures)
+    /// mark an atomic event
+    //
+    template <typename... Args>
+    void mark(Args&&... _args)
+    {
+        invoke::mark(m_data, std::forward<Args>(_args)...);
+    }
+
+    //----------------------------------------------------------------------------------//
+    /// mark a beginning position in the execution (typically used by asynchronous
+    /// structures)
     //
     template <typename... Args>
     void mark_begin(Args&&... _args)
@@ -309,8 +323,8 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    // mark a beginning position in the execution (typically used by asynchronous
-    // structures)
+    /// mark a beginning position in the execution (typically used by asynchronous
+    /// structures)
     //
     template <typename... Args>
     void mark_end(Args&&... _args)
@@ -319,7 +333,7 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    // store a value
+    /// store a value
     //
     template <typename... Args>
     void store(Args&&... _args)
@@ -328,7 +342,8 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    // perform a audit operation (typically for GOTCHA)
+    /// allow the components to inspect the incoming arguments before start
+    /// or out-going return value before returning (typically using in GOTCHA components)
     //
     template <typename... Args>
     void audit(Args&&... _args)
@@ -337,7 +352,8 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    // perform an add_secondary operation
+    /// perform an add_secondary operation. This operation allows components to add
+    /// additional entries to storage which are their direct descendant
     //
     template <typename... Args>
     void add_secondary(Args&&... _args)
@@ -346,7 +362,9 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-
+    /// generic member function for invoking user-provided operations
+    /// \tparam OpT Operation struct
+    //
     template <template <typename> class OpT, typename... Args>
     void invoke(Args&&... _args)
     {
@@ -354,7 +372,10 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-
+    /// generic member function for invoking user-provided operations on a specific
+    /// set of component types
+    /// \tparam OpT Operation struct
+    //
     template <template <typename> class OpT, typename... Tp, typename... Args>
     void invoke(mpl::piecewise_select<Tp...>, Args&&... _args)
     {

--- a/source/timemory/variadic/component_list.hpp
+++ b/source/timemory/variadic/component_list.hpp
@@ -234,7 +234,7 @@ public:
     using bundle_type::store;
 
     //----------------------------------------------------------------------------------//
-    // construct the objects that have constructors with matching arguments
+    /// construct the objects that have constructors with matching arguments
     //
     template <typename... Args>
     void construct(Args&&... _args)
@@ -262,8 +262,17 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    // mark a beginning position in the execution (typically used by asynchronous
-    // structures)
+    /// mark an atomic event
+    //
+    template <typename... Args>
+    void mark(Args&&... _args)
+    {
+        invoke::mark(m_data, std::forward<Args>(_args)...);
+    }
+
+    //----------------------------------------------------------------------------------//
+    /// mark a beginning position in the execution (typically used by asynchronous
+    /// structures)
     //
     template <typename... Args>
     void mark_begin(Args&&... _args)
@@ -272,8 +281,8 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    // mark a beginning position in the execution (typically used by asynchronous
-    // structures)
+    /// mark a beginning position in the execution (typically used by asynchronous
+    /// structures)
     //
     template <typename... Args>
     void mark_end(Args&&... _args)
@@ -282,7 +291,7 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    // store a value
+    /// store a value
     //
     template <typename... Args>
     void store(Args&&... _args)
@@ -291,7 +300,7 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    // perform a audit operation (typically for GOTCHA)
+    /// perform a audit operation (typically for GOTCHA)
     //
     template <typename... Args>
     void audit(Args&&... _args)
@@ -300,7 +309,7 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    // perform an add_secondary operation
+    /// perform an add_secondary operation
     //
     template <typename... Args>
     void add_secondary(Args&&... _args)
@@ -309,11 +318,25 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-
+    /// generic member function for invoking user-provided operations
+    /// \tparam OpT Operation struct
+    //
     template <template <typename> class OpT, typename... Args>
     void invoke(Args&&... _args)
     {
         invoke::invoke<OpT>(m_data, std::forward<Args>(_args)...);
+    }
+
+    //----------------------------------------------------------------------------------//
+    /// generic member function for invoking user-provided operations on a specific
+    /// set of component types
+    /// \tparam OpT Operation struct
+    //
+    template <template <typename> class OpT, typename... Tp, typename... Args>
+    void invoke(mpl::piecewise_select<Tp...>, Args&&... _args)
+    {
+        TIMEMORY_FOLD_EXPRESSION(operation::generic_operator<Tp, OpT<Tp>, TIMEMORY_API>(
+            this->get<Tp>(), std::forward<Args>(_args)...));
     }
 
     //----------------------------------------------------------------------------------//

--- a/source/timemory/variadic/component_tuple.hpp
+++ b/source/timemory/variadic/component_tuple.hpp
@@ -264,7 +264,9 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    /// provide preliminary info to the objects with matching arguments
+    /// provide preliminary info to the objects with matching arguments. This is typically
+    /// used to notify a component that it has been bundled alongside another component
+    /// that it can extract data from.
     //
     template <typename... Args>
     void assemble(Args&&... _args)
@@ -273,12 +275,24 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    /// provide conclusive info to the objects with matching arguments
+    /// provide conclusive info to the objects with matching arguments. This is typically
+    /// used by components to extract data from another component it has been bundled
+    /// alongside, e.g. the cpu_util component can extract data from \ref
+    /// tim::component::wall_clock and \ref tim::component::cpu_clock
     //
     template <typename... Args>
     void derive(Args&&... _args)
     {
         invoke::derive(m_data, std::forward<Args>(_args)...);
+    }
+
+    //----------------------------------------------------------------------------------//
+    /// mark an atomic event
+    //
+    template <typename... Args>
+    void mark(Args&&... _args)
+    {
+        invoke::mark(m_data, std::forward<Args>(_args)...);
     }
 
     //----------------------------------------------------------------------------------//
@@ -330,10 +344,24 @@ public:
 
     //----------------------------------------------------------------------------------//
     /// apply a user-defined operation to all the components
+    /// \tparam OpT Operation struct
+    //
     template <template <typename> class OpT, typename... Args>
     void invoke(Args&&... _args)
     {
         invoke::invoke<OpT>(m_data, std::forward<Args>(_args)...);
+    }
+
+    //----------------------------------------------------------------------------------//
+    /// generic member function for invoking user-provided operations on a specific
+    /// set of component types
+    /// \tparam OpT Operation struct
+    //
+    template <template <typename> class OpT, typename... Tp, typename... Args>
+    void invoke(mpl::piecewise_select<Tp...>, Args&&... _args)
+    {
+        TIMEMORY_FOLD_EXPRESSION(operation::generic_operator<Tp, OpT<Tp>, TIMEMORY_API>(
+            this->get<Tp>(), std::forward<Args>(_args)...));
     }
 
     //----------------------------------------------------------------------------------//

--- a/source/timemory/variadic/functional.hpp
+++ b/source/timemory/variadic/functional.hpp
@@ -76,7 +76,7 @@ using operation_tt = typename OperatorTT<Tag, Op, TupleT>::type;
 //
 template <template <typename> class OpT, typename Tag,
           template <typename...> class TupleT, typename... Tp, typename... Args>
-void
+TIMEMORY_INLINE void
 invoke(TupleT<Tp...>& _obj, Args&&... _args)
 {
     using data_type = std::tuple<Tp...>;
@@ -91,7 +91,7 @@ invoke(TupleT<Tp...>& _obj, Args&&... _args)
 //
 template <template <typename, typename> class OpT, typename Tag,
           template <typename...> class TupleT, typename... Tp, typename... Args>
-void
+TIMEMORY_INLINE void
 invoke(TupleT<Tp...>& _obj, Args&&... _args)
 {
     using data_type = std::tuple<Tp...>;
@@ -106,7 +106,7 @@ invoke(TupleT<Tp...>& _obj, Args&&... _args)
 //
 template <template <typename> class OpT, typename OpTupleT, size_t Idx, typename Tag,
           template <typename...> class TupleT, typename... Tp, typename... Args>
-void
+TIMEMORY_INLINE void
 invoke_out_of_order(TupleT<Tp...>& _obj, Args&&... _args)
 {
     using OperT = operation_t<Tag, OpT, OpTupleT>;
@@ -118,7 +118,7 @@ invoke_out_of_order(TupleT<Tp...>& _obj, Args&&... _args)
 template <template <typename, typename> class OpT, typename OpTupleT, size_t Idx,
           typename Tag, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-void
+TIMEMORY_INLINE void
 invoke_out_of_order(TupleT<Tp...>& _obj, Args&&... _args)
 {
     using OperT = operation_tt<Tag, OpT, OpTupleT>;
@@ -128,7 +128,7 @@ invoke_out_of_order(TupleT<Tp...>& _obj, Args&&... _args)
 //--------------------------------------------------------------------------------------//
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-void
+TIMEMORY_INLINE void
 construct(TupleT<Tp...>& _obj, Args&&... _args)
 {
     using data_type = std::tuple<Tp...>;
@@ -142,14 +142,14 @@ construct(TupleT<Tp...>& _obj, Args&&... _args)
 //======================================================================================//
 //
 template <typename... Args>
-void
+TIMEMORY_INLINE void
 print(std::ostream& os, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(os << args << "\n");
 }
 //
 template <typename... Args>
-void
+TIMEMORY_INLINE void
 print(std::ostream& os, const std::string& delim, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(os << args << delim);
@@ -157,7 +157,7 @@ print(std::ostream& os, const std::string& delim, Args&&... args)
 //
 template <template <typename...> class OpT, typename ApiT,
           template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 invoke(TupleT<Tp...>& obj, Args&&... args)
 {
     invoke_impl::invoke<OpT, ApiT>(obj, std::forward<Args>(args)...);
@@ -165,14 +165,14 @@ invoke(TupleT<Tp...>& obj, Args&&... args)
 //
 template <template <typename...> class OpT, template <typename...> class TupleT,
           typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 invoke(TupleT<Tp...>& obj, Args&&... args)
 {
     invoke<OpT, TIMEMORY_API>(obj, std::forward<Args>(args)...);
 }
 //
 template <typename TupleT, typename ApiT, typename... Args>
-TIMEMORY_HOT auto
+TIMEMORY_HOT_INLINE auto
 construct(Args&&... args)
 {
     IF_CONSTEXPR(trait::is_available<ApiT>::value)
@@ -188,21 +188,21 @@ construct(Args&&... args)
 //
 //
 template <typename TupleT, typename... Args>
-TIMEMORY_HOT auto
+TIMEMORY_HOT_INLINE auto
 construct(Args&&... args)
 {
     return construct<TupleT, TIMEMORY_API>(std::forward<Args>(args)...);
 }
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp>
-TIMEMORY_HOT auto
+TIMEMORY_HOT_INLINE auto
 destroy(TupleT<Tp...>& obj)
 {
     invoke_impl::invoke<operation::generic_deleter, ApiT>(obj);
 }
 //
 template <template <typename...> class TupleT, typename... Tp>
-TIMEMORY_HOT auto
+TIMEMORY_HOT_INLINE auto
 destroy(TupleT<Tp...>& obj)
 {
     destroy<TIMEMORY_API>(obj);
@@ -210,7 +210,7 @@ destroy(TupleT<Tp...>& obj)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 start(TupleT<Tp...>& obj, Args&&... args)
 {
     {
@@ -233,7 +233,7 @@ start(TupleT<Tp...>& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 start(TupleT<Tp...>& obj, Args&&... args)
 {
     start<TIMEMORY_API>(obj, std::forward<Args>(args)...);
@@ -241,7 +241,7 @@ start(TupleT<Tp...>& obj, Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 stop(TupleT<Tp...>& obj, Args&&... args)
 {
     {
@@ -264,7 +264,7 @@ stop(TupleT<Tp...>& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 stop(TupleT<Tp...>& obj, Args&&... args)
 {
     stop<TIMEMORY_API>(obj, std::forward<Args>(args)...);
@@ -272,14 +272,14 @@ stop(TupleT<Tp...>& obj, Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 mark_begin(TupleT<Tp...>& obj, Args&&... args)
 {
     invoke_impl::invoke<operation::mark_begin, ApiT>(obj, std::forward<Args>(args)...);
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 mark_begin(TupleT<Tp...>& obj, Args&&... args)
 {
     mark_begin<TIMEMORY_API>(obj, std::forward<Args>(args)...);
@@ -287,14 +287,14 @@ mark_begin(TupleT<Tp...>& obj, Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 mark_end(TupleT<Tp...>& obj, Args&&... args)
 {
     invoke_impl::invoke<operation::mark_end, ApiT>(obj, std::forward<Args>(args)...);
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 mark_end(TupleT<Tp...>& obj, Args&&... args)
 {
     mark_end<TIMEMORY_API>(obj, std::forward<Args>(args)...);
@@ -302,14 +302,14 @@ mark_end(TupleT<Tp...>& obj, Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 store(TupleT<Tp...>& obj, Args&&... args)
 {
     invoke_impl::invoke<operation::store, ApiT>(obj, std::forward<Args>(args)...);
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 store(TupleT<Tp...>& obj, Args&&... args)
 {
     store<TIMEMORY_API>(obj, std::forward<Args>(args)...);
@@ -317,14 +317,14 @@ store(TupleT<Tp...>& obj, Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 reset(TupleT<Tp...>& obj, Args&&... args)
 {
     invoke_impl::invoke<operation::reset, ApiT>(obj, std::forward<Args>(args)...);
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 reset(TupleT<Tp...>& obj, Args&&... args)
 {
     reset<TIMEMORY_API>(obj, std::forward<Args>(args)...);
@@ -332,14 +332,14 @@ reset(TupleT<Tp...>& obj, Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 record(TupleT<Tp...>& obj, Args&&... args)
 {
     invoke_impl::invoke<operation::record, ApiT>(obj, std::forward<Args>(args)...);
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 record(TupleT<Tp...>& obj, Args&&... args)
 {
     record<TIMEMORY_API>(obj, std::forward<Args>(args)...);
@@ -347,14 +347,14 @@ record(TupleT<Tp...>& obj, Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 measure(TupleT<Tp...>& obj, Args&&... args)
 {
     invoke_impl::invoke<operation::measure, ApiT>(obj, std::forward<Args>(args)...);
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 measure(TupleT<Tp...>& obj, Args&&... args)
 {
     measure<TIMEMORY_API>(obj, std::forward<Args>(args)...);
@@ -362,14 +362,14 @@ measure(TupleT<Tp...>& obj, Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 push(TupleT<Tp...>& obj, Args&&... args)
 {
     invoke_impl::invoke<operation::push_node, ApiT>(obj, std::forward<Args>(args)...);
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 push(TupleT<Tp...>& obj, Args&&... args)
 {
     push<TIMEMORY_API>(obj, std::forward<Args>(args)...);
@@ -377,14 +377,14 @@ push(TupleT<Tp...>& obj, Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 pop(TupleT<Tp...>& obj, Args&&... args)
 {
     invoke_impl::invoke<operation::pop_node, ApiT>(obj, std::forward<Args>(args)...);
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 pop(TupleT<Tp...>& obj, Args&&... args)
 {
     pop<TIMEMORY_API>(obj, std::forward<Args>(args)...);
@@ -392,14 +392,14 @@ pop(TupleT<Tp...>& obj, Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 set_prefix(TupleT<Tp...>& obj, Args&&... args)
 {
     invoke_impl::invoke<operation::set_prefix, ApiT>(obj, std::forward<Args>(args)...);
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 set_prefix(TupleT<Tp...>& obj, Args&&... args)
 {
     set_prefix<TIMEMORY_API>(obj, std::forward<Args>(args)...);
@@ -407,14 +407,14 @@ set_prefix(TupleT<Tp...>& obj, Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 set_scope(TupleT<Tp...>& obj, Args&&... args)
 {
     invoke_impl::invoke<operation::set_scope, ApiT>(obj, std::forward<Args>(args)...);
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 set_scope(TupleT<Tp...>& obj, Args&&... args)
 {
     set_scope<TIMEMORY_API>(obj, std::forward<Args>(args)...);
@@ -422,14 +422,14 @@ set_scope(TupleT<Tp...>& obj, Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 assemble(TupleT<Tp...>& obj, Args&&... args)
 {
     invoke_impl::invoke<operation::assemble, ApiT>(obj, std::forward<Args>(args)...);
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 assemble(TupleT<Tp...>& obj, Args&&... args)
 {
     assemble<TIMEMORY_API>(obj, std::forward<Args>(args)...);
@@ -437,14 +437,14 @@ assemble(TupleT<Tp...>& obj, Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 derive(TupleT<Tp...>& obj, Args&&... args)
 {
     invoke_impl::invoke<operation::derive, ApiT>(obj, std::forward<Args>(args)...);
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 derive(TupleT<Tp...>& obj, Args&&... args)
 {
     derive<TIMEMORY_API>(obj, std::forward<Args>(args)...);
@@ -452,14 +452,14 @@ derive(TupleT<Tp...>& obj, Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 audit(TupleT<Tp...>& obj, Args&&... args)
 {
     invoke_impl::invoke<operation::audit, ApiT>(obj, std::forward<Args>(args)...);
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 audit(TupleT<Tp...>& obj, Args&&... args)
 {
     audit<TIMEMORY_API>(obj, std::forward<Args>(args)...);
@@ -467,14 +467,14 @@ audit(TupleT<Tp...>& obj, Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 add_secondary(TupleT<Tp...>& obj, Args&&... args)
 {
     invoke_impl::invoke<operation::add_secondary, ApiT>(obj, std::forward<Args>(args)...);
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 add_secondary(TupleT<Tp...>& obj, Args&&... args)
 {
     add_secondary<TIMEMORY_API>(obj, std::forward<Args>(args)...);
@@ -482,7 +482,7 @@ add_secondary(TupleT<Tp...>& obj, Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT auto
+TIMEMORY_HOT_INLINE auto
 get(TupleT<Tp...>& obj, Args&&... args)
 {
     using data_type         = TupleT<std::remove_pointer_t<Tp>...>;
@@ -496,7 +496,7 @@ get(TupleT<Tp...>& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT auto
+TIMEMORY_HOT_INLINE auto
 get(TupleT<Tp...>& obj, Args&&... args)
 {
     return ::tim::invoke::get<TIMEMORY_API>(obj, std::forward<Args>(args)...);
@@ -504,7 +504,7 @@ get(TupleT<Tp...>& obj, Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
-TIMEMORY_HOT auto
+TIMEMORY_HOT_INLINE auto
 get_labeled(TupleT<Tp...>& obj, Args&&... args)
 {
     using data_type         = TupleT<std::remove_pointer_t<Tp>...>;
@@ -518,14 +518,14 @@ get_labeled(TupleT<Tp...>& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT auto
+TIMEMORY_HOT_INLINE auto
 get_labeled(TupleT<Tp...>& obj, Args&&... args)
 {
     return get_labeled<TIMEMORY_API>(obj, std::forward<Args>(args)...);
 }
 //
 template <typename... BundleT>
-TIMEMORY_HOT auto
+TIMEMORY_HOT_INLINE auto
 get_cache()
 {
     operation::construct_cache<std::tuple<BundleT...>> tmp{};
@@ -546,7 +546,7 @@ namespace invoke_impl
 //
 template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
           typename... Args>
-void
+TIMEMORY_INLINE void
 start(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).start(std::forward<Args>(args)...));
@@ -554,7 +554,7 @@ start(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 //
 template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
           typename... Args>
-void
+TIMEMORY_INLINE void
 stop(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).stop(std::forward<Args>(args)...));
@@ -562,7 +562,7 @@ stop(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 //
 template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
           typename... Args>
-void
+TIMEMORY_INLINE void
 mark_begin(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).mark_begin(std::forward<Args>(args)...));
@@ -570,7 +570,7 @@ mark_begin(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 //
 template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
           typename... Args>
-void
+TIMEMORY_INLINE void
 mark_end(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).mark_end(std::forward<Args>(args)...));
@@ -578,7 +578,7 @@ mark_end(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 //
 template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
           typename... Args>
-void
+TIMEMORY_INLINE void
 store(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).store(std::forward<Args>(args)...));
@@ -586,7 +586,7 @@ store(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 //
 template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
           typename... Args>
-void
+TIMEMORY_INLINE void
 reset(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).reset(std::forward<Args>(args)...));
@@ -594,7 +594,7 @@ reset(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 //
 template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
           typename... Args>
-void
+TIMEMORY_INLINE void
 record(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).record(std::forward<Args>(args)...));
@@ -602,7 +602,7 @@ record(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 //
 template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
           typename... Args>
-void
+TIMEMORY_INLINE void
 measure(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).measure(std::forward<Args>(args)...));
@@ -610,7 +610,7 @@ measure(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 //
 template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
           typename... Args>
-void
+TIMEMORY_INLINE void
 push(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).push(std::forward<Args>(args)...));
@@ -618,7 +618,7 @@ push(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 //
 template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
           typename... Args>
-void
+TIMEMORY_INLINE void
 pop(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).pop(std::forward<Args>(args)...));
@@ -626,7 +626,7 @@ pop(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 //
 template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
           typename... Args>
-void
+TIMEMORY_INLINE void
 set_prefix(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).set_prefix(std::forward<Args>(args)...));
@@ -634,7 +634,7 @@ set_prefix(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 //
 template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
           typename... Args>
-void
+TIMEMORY_INLINE void
 set_scope(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).set_scope(std::forward<Args>(args)...));
@@ -642,7 +642,7 @@ set_scope(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 //
 template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
           typename... Args>
-void
+TIMEMORY_INLINE void
 assemble(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).assemble(std::forward<Args>(args)...));
@@ -650,7 +650,7 @@ assemble(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 //
 template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
           typename... Args>
-void
+TIMEMORY_INLINE void
 derive(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).derive(std::forward<Args>(args)...));
@@ -658,7 +658,7 @@ derive(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 //
 template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
           typename... Args>
-void
+TIMEMORY_INLINE void
 audit(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).audit(std::forward<Args>(args)...));
@@ -666,7 +666,7 @@ audit(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 //
 template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
           typename... Args>
-void
+TIMEMORY_INLINE void
 add_secondary(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(
@@ -678,7 +678,7 @@ add_secondary(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 //--------------------------------------------------------------------------------------//
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 start(TupleT<Tp...>&& obj, Args&&... args)
 {
     invoke_impl::start(std::forward<TupleT<Tp...>>(obj),
@@ -687,7 +687,7 @@ start(TupleT<Tp...>&& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 stop(TupleT<Tp...>&& obj, Args&&... args)
 {
     invoke_impl::stop(std::forward<TupleT<Tp...>>(obj),
@@ -696,7 +696,7 @@ stop(TupleT<Tp...>&& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 mark_begin(TupleT<Tp...>&& obj, Args&&... args)
 {
     invoke_impl::mark_begin(std::forward<TupleT<Tp...>>(obj),
@@ -705,7 +705,7 @@ mark_begin(TupleT<Tp...>&& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 mark_end(TupleT<Tp...>&& obj, Args&&... args)
 {
     invoke_impl::mark_end(std::forward<TupleT<Tp...>>(obj),
@@ -714,7 +714,7 @@ mark_end(TupleT<Tp...>&& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 store(TupleT<Tp...>&& obj, Args&&... args)
 {
     invoke_impl::store(std::forward<TupleT<Tp...>>(obj),
@@ -723,7 +723,7 @@ store(TupleT<Tp...>&& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 reset(TupleT<Tp...>&& obj, Args&&... args)
 {
     invoke_impl::reset(std::forward<TupleT<Tp...>>(obj),
@@ -732,7 +732,7 @@ reset(TupleT<Tp...>&& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 record(TupleT<Tp...>&& obj, Args&&... args)
 {
     invoke_impl::record(std::forward<TupleT<Tp...>>(obj),
@@ -741,7 +741,7 @@ record(TupleT<Tp...>&& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 measure(TupleT<Tp...>&& obj, Args&&... args)
 {
     invoke_impl::measure(std::forward<TupleT<Tp...>>(obj),
@@ -750,7 +750,7 @@ measure(TupleT<Tp...>&& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 push(TupleT<Tp...>&& obj, Args&&... args)
 {
     invoke_impl::push(std::forward<TupleT<Tp...>>(obj),
@@ -759,7 +759,7 @@ push(TupleT<Tp...>&& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 pop(TupleT<Tp...>&& obj, Args&&... args)
 {
     invoke_impl::pop(std::forward<TupleT<Tp...>>(obj),
@@ -768,7 +768,7 @@ pop(TupleT<Tp...>&& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 set_prefix(TupleT<Tp...>&& obj, Args&&... args)
 {
     invoke_impl::set_prefix(std::forward<TupleT<Tp...>>(obj),
@@ -777,7 +777,7 @@ set_prefix(TupleT<Tp...>&& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 set_scope(TupleT<Tp...>&& obj, Args&&... args)
 {
     invoke_impl::set_scope(std::forward<TupleT<Tp...>>(obj),
@@ -786,7 +786,7 @@ set_scope(TupleT<Tp...>&& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 assemble(TupleT<Tp...>&& obj, Args&&... args)
 {
     invoke_impl::assemble(std::forward<TupleT<Tp...>>(obj),
@@ -795,7 +795,7 @@ assemble(TupleT<Tp...>&& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 derive(TupleT<Tp...>&& obj, Args&&... args)
 {
     invoke_impl::derive(std::forward<TupleT<Tp...>>(obj),
@@ -804,7 +804,7 @@ derive(TupleT<Tp...>&& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 audit(TupleT<Tp...>&& obj, Args&&... args)
 {
     invoke_impl::audit(std::forward<TupleT<Tp...>>(obj),
@@ -813,7 +813,7 @@ audit(TupleT<Tp...>&& obj, Args&&... args)
 }
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT void
+TIMEMORY_HOT_INLINE void
 add_secondary(TupleT<Tp...>&& obj, Args&&... args)
 {
     invoke_impl::add_secondary(std::forward<TupleT<Tp...>>(obj),

--- a/source/timemory/variadic/functional.hpp
+++ b/source/timemory/variadic/functional.hpp
@@ -273,6 +273,21 @@ stop(TupleT<Tp...>& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
+mark(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::mark, ApiT>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+TIMEMORY_HOT_INLINE void
+mark(TupleT<Tp...>& obj, Args&&... args)
+{
+    mark<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+TIMEMORY_HOT_INLINE void
 mark_begin(TupleT<Tp...>& obj, Args&&... args)
 {
     invoke_impl::invoke<operation::mark_begin, ApiT>(obj, std::forward<Args>(args)...);
@@ -563,6 +578,14 @@ stop(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
           typename... Args>
 TIMEMORY_INLINE void
+mark(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
+{
+    TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).mark(std::forward<Args>(args)...));
+}
+//
+template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
+          typename... Args>
+TIMEMORY_INLINE void
 mark_begin(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
 {
     TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).mark_begin(std::forward<Args>(args)...));
@@ -691,6 +714,15 @@ TIMEMORY_HOT_INLINE void
 stop(TupleT<Tp...>&& obj, Args&&... args)
 {
     invoke_impl::stop(std::forward<TupleT<Tp...>>(obj),
+                      std::make_index_sequence<sizeof...(Tp)>{},
+                      std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+TIMEMORY_HOT_INLINE void
+mark(TupleT<Tp...>&& obj, Args&&... args)
+{
+    invoke_impl::mark(std::forward<TupleT<Tp...>>(obj),
                       std::make_index_sequence<sizeof...(Tp)>{},
                       std::forward<Args>(args)...);
 }

--- a/source/timemory/variadic/lightweight_tuple.hpp
+++ b/source/timemory/variadic/lightweight_tuple.hpp
@@ -201,7 +201,7 @@ public:
     using bundle_type::store;
 
     //----------------------------------------------------------------------------------//
-    // construct the objects that have constructors with matching arguments
+    /// construct the objects that have constructors with matching arguments
     //
     template <typename... Args>
     void construct(Args&&... _args)
@@ -211,7 +211,9 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    /// provide preliminary info to the objects with matching arguments
+    /// provide preliminary info to the objects with matching arguments. This is typically
+    /// used to notify a component that it has been bundled alongside another component
+    /// that it can extract data from.
     //
     void assemble() { invoke::assemble(m_data, *this); }
 
@@ -222,7 +224,10 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    /// provide conclusive info to the objects with matching arguments
+    /// provide conclusive info to the objects with matching arguments. This is typically
+    /// used by components to extract data from another component it has been bundled
+    /// alongside, e.g. the cpu_util component can extract data from \ref
+    /// tim::component::wall_clock and \ref tim::component::cpu_clock
     //
     void derive() { invoke::derive(m_data, *this); }
 
@@ -233,8 +238,8 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    // mark a beginning position in the execution (typically used by asynchronous
-    // structures)
+    /// mark a beginning position in the execution (typically used by asynchronous
+    /// structures)
     //
     template <typename... Args>
     void mark_begin(Args&&... _args)
@@ -243,8 +248,8 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    // mark a beginning position in the execution (typically used by asynchronous
-    // structures)
+    /// mark a beginning position in the execution (typically used by asynchronous
+    /// structures)
     //
     template <typename... Args>
     void mark_end(Args&&... _args)
@@ -253,7 +258,7 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    // store a value
+    /// store a value
     //
     template <typename... Args>
     void store(Args&&... _args)
@@ -262,7 +267,8 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    // perform a auditd operation (typically for GOTCHA)
+    /// allow the components to inspect the incoming arguments before start
+    /// or out-going return value before returning (typically using in GOTCHA components)
     //
     template <typename... Args>
     void audit(Args&&... _args)
@@ -271,7 +277,9 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-
+    /// apply a user-defined operation to all the components
+    /// \tparam OpT Operation struct
+    //
     template <template <typename> class OpT, typename... Args>
     void invoke(Args&&... _args)
     {
@@ -279,7 +287,19 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    // get member functions taking either a type
+    /// generic member function for invoking user-provided operations on a specific
+    /// set of component types
+    /// \tparam OpT Operation struct
+    //
+    template <template <typename> class OpT, typename... Tp, typename... Args>
+    void invoke(mpl::piecewise_select<Tp...>, Args&&... _args)
+    {
+        TIMEMORY_FOLD_EXPRESSION(operation::generic_operator<Tp, OpT<Tp>, TIMEMORY_API>(
+            this->get<Tp>(), std::forward<Args>(_args)...));
+    }
+
+    //----------------------------------------------------------------------------------//
+    /// get member functions taking either a type
     //
     template <typename T, enable_if_t<is_one_of<T, data_type>::value, int> = 0>
     T* get()
@@ -344,7 +364,7 @@ public:
     }
 
     //----------------------------------------------------------------------------------//
-    //  variadic initialization
+    ///  variadic initialization
     //
     template <typename... T, typename... Args>
     auto initialize(Args&&... args)

--- a/source/tools/kokkos-connector/kp_timemory.cpp
+++ b/source/tools/kokkos-connector/kp_timemory.cpp
@@ -220,6 +220,24 @@ kokkosp_end_parallel_scan(uint64_t kernid)
 //--------------------------------------------------------------------------------------//
 
 extern "C" void
+kokkosp_begin_fence(const char* name, uint32_t devid, uint64_t* kernid)
+{
+    auto pname = TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
+    *kernid    = get_unique_id();
+    create_profiler(pname, *kernid);
+    start_profiler(*kernid);
+}
+
+extern "C" void
+kokkosp_end_fence(uint64_t kernid)
+{
+    stop_profiler(kernid);
+    destroy_profiler(kernid);
+}
+
+//--------------------------------------------------------------------------------------//
+
+extern "C" void
 kokkosp_push_profile_region(const char* name)
 {
     get_profile_stack().push_back(profile_entry_t(name, true));
@@ -266,3 +284,9 @@ kokkosp_stop_profile_section(uint32_t secid)
 }
 
 //--------------------------------------------------------------------------------------//
+
+extern "C" void
+kokkosp_profile_event(const char* name)
+{
+    profile_entry_t{}.mark(name);
+}

--- a/source/tools/kokkos-connector/kp_timemory.cpp.in
+++ b/source/tools/kokkos-connector/kp_timemory.cpp.in
@@ -44,6 +44,8 @@ struct kp_timemory_parallel_reduce
 {};
 struct kp_timemory_parallel_scan
 {};
+struct kp_timemory_fence
+{};
 struct kp_timemory_region
 {};
 struct kp_timemory_section
@@ -255,6 +257,30 @@ kokkosp_end_parallel_scan(uint64_t kernid)
 //--------------------------------------------------------------------------------------//
 
 extern "C" void
+kokkosp_begin_fence(const char* name, uint32_t devid, uint64_t* kernid)
+{
+    if_constexpr(profile_entry_t::size() > 0)
+    {
+        auto pname = TIMEMORY_JOIN('/', "kokkos", TIMEMORY_JOIN("", "dev", devid), name);
+        *kernid    = get_unique_id();
+        create_profiler(pname, *kernid);
+        start_profiler(*kernid, kp_timemory_fence{}, name, devid);
+    }
+}
+
+extern "C" void
+kokkosp_end_fence(uint64_t kernid)
+{
+    if_constexpr(profile_entry_t::size() > 0)
+    {
+        stop_profiler(kernid);
+        destroy_profiler(kernid);
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+
+extern "C" void
 kokkosp_push_profile_region(const char* name)
 {
     if_constexpr(profile_entry_t::size() > 0)
@@ -312,6 +338,14 @@ extern "C" void
 kokkosp_stop_profile_section(uint32_t secid)
 {
     if_constexpr(profile_entry_t::size() > 0) { stop_profiler(secid); }
+}
+
+//--------------------------------------------------------------------------------------//
+
+extern "C" void
+kokkosp_profile_event(const char* name)
+{
+    profile_entry_t{}.mark(name);
 }
 
 //--------------------------------------------------------------------------------------//


### PR DESCRIPTION
- introduces `operation::mark`, similar to `operation::store` insomuch as it is intended to be a function which is atomic (i.e. not a phase)
  - although `operation::store` could be effectively used for this purpose, it was introduced as "marking" is common nomenclature when adding metadata labels to external profilers
  - member functions were added to {component,auto}_{bundle,list,tuple} and lightweight tuple
- This closes #118 by providing `kokkosp_begin_fence`, `kokkosp_end_fence` and `kokkosp_profile_event`
- Most of the other changes were superficial
  - Doxygen comments
  - Forcing inlines 
  - Adding the "hot" attribute to functions which are called very frequently
  - Replacing 6 lines of defaulting the ctor, dtor, copy-ctor, move-ctor, copy-assign, and move-assign with the `TIMEMORY_DEFAULT_OBJECT` macro, e.g.:

```cpp
    cuda_event()                      = default;
    ~cuda_event()                     = default;
    cuda_event(const cuda_event&)     = default;
    cuda_event(cuda_event&&) noexcept = default;
    cuda_event& operator=(const cuda_event&) = default;
    cuda_event& operator=(cuda_event&&) noexcept = default;
```

is simply expressed as:

```cpp
    TIMEMORY_DEFAULT_OBJECT(cuda_event)
```