### PR TITLE
Timem fix

### DIFF
--- a/source/timemory/sampling/sampler.hpp
+++ b/source/timemory/sampling/sampler.hpp
@@ -239,17 +239,17 @@ public:
     /// \param[in] _verb Logging Verbosity
     ///
     /// \brief Set up the sampler
-    static void configure(std::set<int> _signals, int _verbose = 1);
-    static void configure(int _signal = SIGALRM, int _verbose = 1)
+    static TIMEMORY_INLINE void configure(std::set<int> _signals, int _verbose = 1);
+    static TIMEMORY_INLINE void configure(int _signal = SIGALRM, int _verbose = 1)
     {
         configure({ _signal }, _verbose);
     }
 
-    /// \fn void ignore(std::set<int> _signals)
+    /// \fn void ignore(const std::set<int>& _signals)
     /// \param[in] _signals Set of signals
     ///
     /// \brief Ignore the signals
-    static void ignore(std::set<int> _signals = {});
+    static TIMEMORY_INLINE void ignore(const std::set<int>& _signals);
 
     /// \fn void clear()
     /// \brief Clear all signals. Recommended to call ignore() prior to clearing all the
@@ -258,7 +258,7 @@ public:
 
     /// \fn void pause()
     /// \brief Pause until a signal is delivered
-    static void pause()
+    static TIMEMORY_INLINE void pause()
     {
         if(!get_persistent_data().m_signals.empty())
             ::pause();
@@ -667,7 +667,7 @@ sampler<CompT<Types...>, N, SigIds...>::configure(std::set<int> _signals, int _v
         _custom_sa.sa_flags     = SA_RESTART | SA_SIGINFO;
 
         // start the interval timer
-        for(auto itr : _signals)
+        for(auto& itr : _signals)
         {
             // get the associated itimer type
             auto _itimer = get_itimer(itr);
@@ -701,16 +701,13 @@ sampler<CompT<Types...>, N, SigIds...>::configure(std::set<int> _signals, int _v
 //
 template <template <typename...> class CompT, size_t N, typename... Types, int... SigIds>
 inline void
-sampler<CompT<Types...>, N, SigIds...>::ignore(std::set<int> _signals)
+sampler<CompT<Types...>, N, SigIds...>::ignore(const std::set<int>& _signals)
 {
-    if(_signals.empty())
-        _signals = get_persistent_data().m_signals;
-
-    for(auto itr : _signals)
+    for(const auto& itr : _signals)
         signal(itr, SIG_IGN);
 
     auto& _original_it = get_persistent_data().m_original_itimerval;
-    for(auto itr : _signals)
+    for(const auto& itr : _signals)
     {
         itimerval_t _curr;
         auto        _itimer = get_itimer(itr);

--- a/source/timemory/utility/argparse.hpp
+++ b/source/timemory/utility/argparse.hpp
@@ -112,10 +112,14 @@ static inline char*
 strdup(const char* s)
 {
     auto slen   = strlen(s);
-    auto result = new char[slen];
+    auto result = new char[slen + 1];
     if(result)
-        memcpy(result, s, slen + 1);
-    return result;
+    {
+        memcpy(result, s, slen * sizeof(char));
+        result[slen] = '\0';
+        return result;
+    }
+    return nullptr;
 }
 //
 //--------------------------------------------------------------------------------------//

--- a/source/tools/timemory-timem/timem.hpp
+++ b/source/tools/timemory-timem/timem.hpp
@@ -639,7 +639,7 @@ struct timem_config
     string_t      shell            = tim::get_env<string_t>("SHELL", getusershell());
     string_t      shell_flags  = tim::get_env<string_t>("TIMEM_USE_SHELL_FLAGS", "-i");
     string_t      output_file  = tim::get_env<string_t>("TIMEM_OUTPUT", "");
-    double        sample_freq  = tim::get_env<double>("TIMEM_SAMPLE_FREQ", 1.0);
+    double        sample_freq  = tim::get_env<double>("TIMEM_SAMPLE_FREQ", 5.0);
     double        sample_delay = tim::get_env<double>("TIMEM_SAMPLE_DELAY", 1.0e-6);
     pid_t         master_pid   = getpid();
     pid_t         worker_pid   = getpid();


### PR DESCRIPTION
- bug in argparse::helpers::strdup
- removed unnecessary pause
- eliminated copies which caused problems at high interrupt intervals
- closes #132 