### PR TITLE
JSON output support in timem

### DIFF
--- a/cmake/Modules/FindPAPI.cmake
+++ b/cmake/Modules/FindPAPI.cmake
@@ -145,7 +145,7 @@ find_package_handle_standard_args(PAPI DEFAULT_MSG
 #----------------------------------------------------------------------------------------#
 
 if(PAPI_FOUND)
-    if(NOT TARGET PAPI::papi-shared)
+    if(NOT TARGET PAPI::papi-shared AND PAPI_LIBRARY)
         add_library(PAPI::papi-shared INTERFACE IMPORTED)
         target_link_libraries(PAPI::papi-shared INTERFACE ${PAPI_LIBRARY})
         target_include_directories(PAPI::papi-shared INTERFACE ${PAPI_INCLUDE_DIR})
@@ -154,7 +154,7 @@ if(PAPI_FOUND)
         endif()
     endif()
 
-    if(NOT TARGET PAPI::papi-static)
+    if(NOT TARGET PAPI::papi-static AND PAPI_STATIC_LIBRARY)
         add_library(PAPI::papi-static INTERFACE IMPORTED)
         target_link_libraries(PAPI::papi-static INTERFACE ${PAPI_STATIC_LIBRARY})
         target_include_directories(PAPI::papi-static INTERFACE ${PAPI_INCLUDE_DIR})

--- a/pyctest-runner.py
+++ b/pyctest-runner.py
@@ -706,7 +706,7 @@ def run_pyctest():
             {
                 "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
                 "LABELS": pyct.PROJECT_NAME,
-                "TIMEOUT": "120",
+                "TIMEOUT": "30",
                 "ENVIRONMENT": test_env,
             },
         )
@@ -714,11 +714,44 @@ def run_pyctest():
     if "timem" in args.tools:
         pyct.test(
             "timemory-timem",
-            ["./timem", "--", "sleep 2"],
+            ["./timem", "--", "sleep", "2"],
             {
                 "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
                 "LABELS": pyct.PROJECT_NAME,
-                "TIMEOUT": "120",
+                "TIMEOUT": "30",
+                "ENVIRONMENT": base_env,
+            },
+        )
+
+        pyct.test(
+            "timemory-timem-shell",
+            ["./timem", "-s", "--", "sleep", "2"],
+            {
+                "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
+                "LABELS": pyct.PROJECT_NAME,
+                "TIMEOUT": "30",
+                "ENVIRONMENT": base_env,
+            },
+        )
+
+        pyct.test(
+            "timemory-timem-no-sample",
+            ["./timem", "--disable-sample", "--", "sleep", "2"],
+            {
+                "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
+                "LABELS": pyct.PROJECT_NAME,
+                "TIMEOUT": "30",
+                "ENVIRONMENT": base_env,
+            },
+        )
+
+        pyct.test(
+            "timemory-timem-json",
+            ["./timem", "-o", "timem-output", "--", "sleep", "2"],
+            {
+                "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
+                "LABELS": pyct.PROJECT_NAME,
+                "TIMEOUT": "30",
                 "ENVIRONMENT": base_env,
             },
         )
@@ -726,11 +759,54 @@ def run_pyctest():
         if args.mpi and dmprun is not None:
             pyct.test(
                 "timemory-timem-mpi",
-                [dmprun] + dmpargs + ["./timem-mpi", "sleep 2"],
+                [dmprun] + dmpargs + ["./timem-mpi", "sleep", "2"],
                 {
                     "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
                     "LABELS": pyct.PROJECT_NAME,
-                    "TIMEOUT": "120",
+                    "TIMEOUT": "30",
+                    "ENVIRONMENT": base_env,
+                },
+            )
+
+            pyct.test(
+                "timemory-timem-mpi-shell",
+                [dmprun] + dmpargs + ["./timem-mpi", "-s", "--", "sleep", "2"],
+                {
+                    "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
+                    "LABELS": pyct.PROJECT_NAME,
+                    "TIMEOUT": "30",
+                    "ENVIRONMENT": base_env,
+                },
+            )
+
+            pyct.test(
+                "timemory-timem-mpi-individual",
+                [dmprun] + dmpargs + ["./timem-mpi", "-i", "--", "sleep", "2"],
+                {
+                    "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
+                    "LABELS": pyct.PROJECT_NAME,
+                    "TIMEOUT": "30",
+                    "ENVIRONMENT": base_env,
+                },
+            )
+
+            pyct.test(
+                "timemory-timem-mpi-individual-json",
+                [dmprun]
+                + dmpargs
+                + [
+                    "./timem-mpi",
+                    "-i",
+                    "-o",
+                    "timem-mpi-output",
+                    "--",
+                    "sleep",
+                    "2",
+                ],
+                {
+                    "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
+                    "LABELS": pyct.PROJECT_NAME,
+                    "TIMEOUT": "30",
                     "ENVIRONMENT": base_env,
                 },
             )
@@ -738,7 +814,11 @@ def run_pyctest():
     if args.python:
         pyct.test(
             "timemory-python",
-            [sys.executable, "-c", '"import timemory"'],
+            [
+                sys.executable,
+                "-c",
+                '"import timemory; print(timemory.__file__)"',
+            ],
             {
                 "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
                 "LABELS": pyct.PROJECT_NAME,

--- a/source/tests/kokkosp_tests.cpp
+++ b/source/tests/kokkosp_tests.cpp
@@ -181,7 +181,7 @@ TEST_F(kokkosp_tests, profiling_routines)
 
     auto _end_sz = tim::storage<tim::component::wall_clock>::instance()->size();
 
-    EXPECT_EQ(_end_sz - _beg_sz, 5)
+    EXPECT_EQ(_end_sz - _beg_sz, 6)
         << " begin size: " << _beg_sz << ", end size: " << _end_sz;
 }
 

--- a/source/timemory/components/base/declaration.hpp
+++ b/source/timemory/components/base/declaration.hpp
@@ -90,14 +90,14 @@ public:
     using dynamic_type                 = typename trait::dynamic_base<Tp>::type;
     using cache_type                   = typename trait::cache<Tp>::type;
 
-    using this_type          = Tp;
-    using base_type          = base<Tp, Value>;
-    using storage_type       = storage<Tp, Value>;
-    using base_storage_type  = tim::base::storage;
-    using graph_iterator     = typename storage_type::iterator;
-    using state_t            = state<this_type>;
-    using statistics_policy  = policy::record_statistics<Tp, Value>;
-    using fmtflags           = std::ios_base::fmtflags;
+    using this_type         = Tp;
+    using base_type         = base<Tp, Value>;
+    using storage_type      = storage<Tp, Value>;
+    using base_storage_type = tim::base::storage;
+    using graph_iterator    = typename storage_type::iterator;
+    using state_t           = state<this_type>;
+    using statistics_policy = policy::record_statistics<Tp, Value>;
+    using fmtflags          = std::ios_base::fmtflags;
 
 private:
     friend class impl::storage<Tp, trait::uses_value_storage<Tp, Value>::value>;
@@ -157,9 +157,6 @@ public:
 
     /// reset the values
     TIMEMORY_INLINE void reset();
-
-    /// record a measurement
-    TIMEMORY_INLINE void measure();
 
     /// assign to pointer
     TIMEMORY_INLINE void get_opaque_data(void*& ptr, size_t _hash) const;
@@ -295,8 +292,8 @@ public:
     TIMEMORY_INLINE auto minus(crtp::base, const base_type& rhs) { this->minus(rhs); }
 
 protected:
-    int64_t        laps         = 0;
-    graph_iterator graph_itr    = graph_iterator{ nullptr };
+    int64_t        laps      = 0;
+    graph_iterator graph_itr = graph_iterator{ nullptr };
 
     using base_state::depth_change;
     using base_state::is_flat;
@@ -418,7 +415,6 @@ public:
     TIMEMORY_INLINE void set_started();
     TIMEMORY_INLINE void set_stopped();
     TIMEMORY_INLINE void reset();
-    TIMEMORY_INLINE void measure();
     TIMEMORY_INLINE int64_t get_laps() const { return 0; }
     TIMEMORY_INLINE void*   get_iterator() const { return nullptr; }
 
@@ -546,8 +542,7 @@ public:
     {}
 
 public:
-    TIMEMORY_INLINE void reset();    // reset the values
-    TIMEMORY_INLINE void measure();  // just record a measurment
+    TIMEMORY_INLINE void reset();  // reset the values
     TIMEMORY_INLINE void start();
     TIMEMORY_INLINE void stop();
 
@@ -572,7 +567,7 @@ public:
     TIMEMORY_INLINE void get(void*&, size_t) const {}
     TIMEMORY_INLINE void get_opaque_data(void*&, size_t) const {}
 
-    TIMEMORY_INLINE int64_t        get_laps() const { return laps; }
+    TIMEMORY_INLINE int64_t get_laps() const { return laps; }
     TIMEMORY_INLINE graph_iterator get_iterator() const { return graph_itr; }
 
     TIMEMORY_INLINE void set_laps(int64_t v) { laps = v; }
@@ -611,11 +606,11 @@ public:
     TIMEMORY_INLINE auto minus(crtp::base, const base_type&) {}
 
 protected:
-    int64_t        laps         = 0;
-    value_type     value        = value_type{};
-    accum_type     accum        = accum_type{};
-    last_type      last         = last_type{};
-    graph_iterator graph_itr    = nullptr;
+    int64_t        laps      = 0;
+    value_type     value     = value_type{};
+    accum_type     accum     = accum_type{};
+    last_type      last      = last_type{};
+    graph_iterator graph_itr = nullptr;
 
 public:
     static std::string label() { return ""; }

--- a/source/timemory/components/base/definition.hpp
+++ b/source/timemory/components/base/definition.hpp
@@ -62,17 +62,6 @@ base<Tp, Value>::reset()
 //
 template <typename Tp, typename Value>
 void
-base<Tp, Value>::measure()
-{
-    set_is_transient(false);
-    Type*                   obj = static_cast<Type*>(this);
-    operation::record<Type> m{ *obj };
-}
-//
-//--------------------------------------------------------------------------------------//
-//
-template <typename Tp, typename Value>
-void
 base<Tp, Value>::get(void*& ptr, size_t _typeid_hash) const
 {
     if(!ptr && _typeid_hash == typeid_hash<Tp>())
@@ -399,15 +388,6 @@ void
 base<Tp, void>::reset()
 {
     base_state::reset();
-}
-//
-//--------------------------------------------------------------------------------------//
-//
-template <typename Tp>
-void
-base<Tp, void>::measure()
-{
-    set_is_transient(false);
 }
 //
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/components/io/components.hpp
+++ b/source/timemory/components/io/components.hpp
@@ -219,33 +219,31 @@ struct read_char : public base<read_char, std::pair<int64_t, int64_t>>
         return _instance;
     }
 
-    //----------------------------------------------------------------------------------//
-    // record a measurment (for file sampling)
-    //
-    void measure()
+    /// sample a measurement
+    void sample()
     {
         std::get<0>(accum) = std::get<0>(value) =
             std::max<int64_t>(std::get<0>(value), get_char_read());
     }
 
-    /// read the value from the cache
-    template <typename CacheT                                    = cache_type,
-              enable_if_t<std::is_same<CacheT, io_cache>::value> = 0>
-    static value_type record(const CacheT& _cache)
+    /// sample a measurement from cached data
+    void sample(const cache_type& _cache)
+    {
+        std::get<0>(accum) = std::get<0>(value) =
+            std::max<int64_t>(std::get<0>(value), _cache.get_char_read());
+    }
+
+    /// read the value from cached data
+    static value_type record(const cache_type& _cache)
     {
         return value_type{ _cache.get_char_read(), get_timestamp() };
     }
 
-    template <typename CacheT                                    = cache_type,
-              enable_if_t<std::is_same<CacheT, io_cache>::value> = 0>
-    void start(const CacheT& _cache)
-    {
-        value = record(_cache);
-    }
+    /// start a measurement using the cached data
+    void start(const cache_type& _cache) { value = record(_cache); }
 
-    template <typename CacheT                                    = cache_type,
-              enable_if_t<std::is_same<CacheT, io_cache>::value> = 0>
-    void stop(const CacheT& _cache)
+    /// stop a measurement using the cached data
+    void stop(const cache_type& _cache)
     {
         using namespace tim::component::operators;
         auto diff         = (record(_cache) - value);
@@ -429,33 +427,31 @@ struct written_char : public base<written_char, std::array<int64_t, 2>>
         return _instance;
     }
 
-    //----------------------------------------------------------------------------------//
-    // record a measurment (for file sampling)
-    //
-    void measure()
+    /// sample a measurement
+    void sample()
     {
         std::get<0>(accum) = std::get<0>(value) =
             std::max<int64_t>(std::get<0>(value), get_char_written());
     }
 
-    /// read the value from the cache
-    template <typename CacheT                                    = cache_type,
-              enable_if_t<std::is_same<CacheT, io_cache>::value> = 0>
-    static value_type record(const CacheT& _cache)
+    /// sample a measurement from cached data
+    void sample(const cache_type& _cache)
+    {
+        std::get<0>(accum) = std::get<0>(value) =
+            std::max<int64_t>(std::get<0>(value), _cache.get_char_written());
+    }
+
+    /// read the value from cached data
+    static value_type record(const cache_type& _cache)
     {
         return value_type{ { _cache.get_char_written(), get_timestamp() } };
     }
 
-    template <typename CacheT                                    = cache_type,
-              enable_if_t<std::is_same<CacheT, io_cache>::value> = 0>
-    void start(const CacheT& _cache)
-    {
-        value = record(_cache);
-    }
+    /// start a measurement using the cached data
+    void start(const cache_type& _cache) { value = record(_cache); }
 
-    template <typename CacheT                                    = cache_type,
-              enable_if_t<std::is_same<CacheT, io_cache>::value> = 0>
-    void stop(const CacheT& _cache)
+    /// stop a measurement using the cached data
+    void stop(const cache_type& _cache)
     {
         using namespace tim::component::operators;
         auto diff         = (record(_cache) - value);
@@ -636,33 +632,31 @@ struct read_bytes : public base<read_bytes, std::pair<int64_t, int64_t>>
         return _instance;
     }
 
-    //----------------------------------------------------------------------------------//
-    // record a measurment (for file sampling)
-    //
-    void measure()
+    /// sample a measurement
+    void sample()
     {
         std::get<0>(accum) = std::get<0>(value) =
             std::max<int64_t>(std::get<0>(value), get_bytes_read());
     }
 
+    /// sample a measurement from cached data
+    void sample(const cache_type& _cache)
+    {
+        std::get<0>(accum) = std::get<0>(value) =
+            std::max<int64_t>(std::get<0>(value), _cache.get_bytes_read());
+    }
+
     /// read the value from the cache
-    template <typename CacheT                                    = cache_type,
-              enable_if_t<std::is_same<CacheT, io_cache>::value> = 0>
-    static value_type record(const CacheT& _cache)
+    static value_type record(const cache_type& _cache)
     {
         return value_type{ _cache.get_bytes_read(), get_timestamp() };
     }
 
-    template <typename CacheT                                    = cache_type,
-              enable_if_t<std::is_same<CacheT, io_cache>::value> = 0>
-    void start(const CacheT& _cache)
-    {
-        value = record(_cache);
-    }
+    /// start a measurement using the cached data
+    void start(const cache_type& _cache) { value = record(_cache); }
 
-    template <typename CacheT                                    = cache_type,
-              enable_if_t<std::is_same<CacheT, io_cache>::value> = 0>
-    void stop(const CacheT& _cache)
+    /// stop a measurement using the cached data
+    void stop(const cache_type& _cache)
     {
         using namespace tim::component::operators;
         auto diff         = (record(_cache) - value);
@@ -844,33 +838,31 @@ struct written_bytes : public base<written_bytes, std::array<int64_t, 2>>
         return _instance;
     }
 
-    //----------------------------------------------------------------------------------//
-    // record a measurment (for file sampling)
-    //
-    void measure()
+    /// sample a measurement
+    void sample()
     {
         std::get<0>(accum) = std::get<0>(value) =
             std::max<int64_t>(std::get<0>(value), get_bytes_written());
     }
 
+    /// sample a measurement from cached data
+    void sample(const cache_type& _cache)
+    {
+        std::get<0>(accum) = std::get<0>(value) =
+            std::max<int64_t>(std::get<0>(value), _cache.get_bytes_written());
+    }
+
     /// read the value from the cache
-    template <typename CacheT                                    = cache_type,
-              enable_if_t<std::is_same<CacheT, io_cache>::value> = 0>
-    static value_type record(const CacheT& _cache)
+    static value_type record(const cache_type& _cache)
     {
         return value_type{ { _cache.get_bytes_written(), get_timestamp() } };
     }
 
-    template <typename CacheT                                    = cache_type,
-              enable_if_t<std::is_same<CacheT, io_cache>::value> = 0>
-    void start(const CacheT& _cache)
-    {
-        value = record(_cache);
-    }
+    /// start a measurement using the cached data
+    void start(const cache_type& _cache) { value = record(_cache); }
 
-    template <typename CacheT                                    = cache_type,
-              enable_if_t<std::is_same<CacheT, io_cache>::value> = 0>
-    void stop(const CacheT& _cache)
+    /// stop a measurement using the cached data
+    void stop(const cache_type& _cache)
     {
         using namespace tim::component::operators;
         auto diff         = (record(_cache) - value);

--- a/source/timemory/components/papi/papi_array.hpp
+++ b/source/timemory/components/papi/papi_array.hpp
@@ -126,6 +126,20 @@ struct papi_array
     }
 
     //----------------------------------------------------------------------------------//
+    // sample
+    //
+    void sample()
+    {
+        if(events.size() == 0)
+        {
+            configure();
+            events = get_events<common_type>();
+        }
+
+        accum = value = record();
+    }
+
+    //----------------------------------------------------------------------------------//
     // start
     //
     void start()

--- a/source/timemory/components/papi/papi_array.hpp
+++ b/source/timemory/components/papi/papi_array.hpp
@@ -130,13 +130,13 @@ struct papi_array
     //
     void sample()
     {
-        if(events.size() == 0)
-        {
+        if(tracker_type::get_thread_started() == 0)
             configure();
+        if(events.empty())
             events = get_events<common_type>();
-        }
 
-        accum = value = record();
+        tracker_type::start();
+        value = record();
     }
 
     //----------------------------------------------------------------------------------//

--- a/source/timemory/components/papi/papi_tuple.hpp
+++ b/source/timemory/components/papi/papi_tuple.hpp
@@ -151,6 +151,20 @@ public:
     TIMEMORY_DEFAULT_OBJECT(papi_tuple)
 
     //----------------------------------------------------------------------------------//
+    // sample
+    //
+    void sample()
+    {
+        if(events.size() == 0)
+        {
+            configure();
+            events = get_events<common_type>();
+        }
+
+        accum = value = record();
+    }
+
+    //----------------------------------------------------------------------------------//
     // start
     //
     void start()

--- a/source/timemory/components/papi/papi_tuple.hpp
+++ b/source/timemory/components/papi/papi_tuple.hpp
@@ -155,13 +155,13 @@ public:
     //
     void sample()
     {
-        if(events.size() == 0)
-        {
+        if(tracker_type::get_thread_started() == 0)
             configure();
+        if(events.empty())
             events = get_events<common_type>();
-        }
 
-        accum = value = record();
+        tracker_type::start();
+        value = record();
     }
 
     //----------------------------------------------------------------------------------//

--- a/source/timemory/components/papi/papi_vector.hpp
+++ b/source/timemory/components/papi/papi_vector.hpp
@@ -142,13 +142,13 @@ struct papi_vector
     //
     void sample()
     {
-        if(events.size() == 0)
-        {
+        if(tracker_type::get_thread_started() == 0)
             configure();
+        if(events.empty())
             events = get_events<common_type>();
-        }
 
-        accum = value = record();
+        tracker_type::start();
+        value = record();
     }
 
     //----------------------------------------------------------------------------------//

--- a/source/timemory/components/papi/papi_vector.hpp
+++ b/source/timemory/components/papi/papi_vector.hpp
@@ -138,6 +138,20 @@ struct papi_vector
     }
 
     //----------------------------------------------------------------------------------//
+    // sample
+    //
+    void sample()
+    {
+        if(events.size() == 0)
+        {
+            configure();
+            events = get_events<common_type>();
+        }
+
+        accum = value = record();
+    }
+
+    //----------------------------------------------------------------------------------//
     // start
     //
     void start()

--- a/source/timemory/components/rusage/components.hpp
+++ b/source/timemory/components/rusage/components.hpp
@@ -81,25 +81,23 @@ struct peak_rss : public base<peak_rss>
         accum += value;
     }
 
-    void measure() { accum = value = std::max<int64_t>(value, record()); }
+    /// sample a measurement
+    void sample() { accum = value = std::max<int64_t>(value, record()); }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    static value_type record(const CacheT& _cache)
+    /// sample a measurement from cached data
+    void sample(const cache_type& _cache)
     {
-        return _cache.get_peak_rss();
+        accum = value = std::max<int64_t>(value, record(_cache));
     }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void start(const CacheT& _cache)
-    {
-        value = record(_cache);
-    }
+    /// read the value from cached data
+    static value_type record(const cache_type& _cache) { return _cache.get_peak_rss(); }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void stop(const CacheT& _cache)
+    /// start a measurement using the cached data
+    void start(const cache_type& _cache) { value = record(_cache); }
+
+    /// stop a measurement using the cached data
+    void stop(const cache_type& _cache)
     {
         auto tmp   = record(_cache);
         auto delta = tmp - value;
@@ -141,7 +139,7 @@ struct page_rss : public base<page_rss, int64_t>
         value = (record() - value);
         accum += value;
     }
-    void measure() { accum = value = std::max<int64_t>(value, record()); }
+    void sample() { accum = value = std::max<int64_t>(value, record()); }
 };
 
 //--------------------------------------------------------------------------------------//
@@ -177,23 +175,11 @@ struct num_io_in : public base<num_io_in>
         accum += value;
     }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    static value_type record(const CacheT& _cache)
-    {
-        return _cache.get_num_io_in();
-    }
+    static value_type record(const cache_type& _cache) { return _cache.get_num_io_in(); }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void start(const CacheT& _cache)
-    {
-        value = record(_cache);
-    }
+    void start(const cache_type& _cache) { value = record(_cache); }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void stop(const CacheT& _cache)
+    void stop(const cache_type& _cache)
     {
         auto tmp = record(_cache);
         accum += (tmp - value);
@@ -234,23 +220,11 @@ struct num_io_out : public base<num_io_out>
         accum += value;
     }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    static value_type record(const CacheT& _cache)
-    {
-        return _cache.get_num_io_out();
-    }
+    static value_type record(const cache_type& _cache) { return _cache.get_num_io_out(); }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void start(const CacheT& _cache)
-    {
-        value = record(_cache);
-    }
+    void start(const cache_type& _cache) { value = record(_cache); }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void stop(const CacheT& _cache)
+    void stop(const cache_type& _cache)
     {
         auto tmp = record(_cache);
         accum += (tmp - value);
@@ -293,23 +267,14 @@ struct num_minor_page_faults : public base<num_minor_page_faults>
         accum += value;
     }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    static value_type record(const CacheT& _cache)
+    static value_type record(const cache_type& _cache)
     {
         return _cache.get_num_minor_page_faults();
     }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void start(const CacheT& _cache)
-    {
-        value = record(_cache);
-    }
+    void start(const cache_type& _cache) { value = record(_cache); }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void stop(const CacheT& _cache)
+    void stop(const cache_type& _cache)
     {
         auto tmp = record(_cache);
         accum += (tmp - value);
@@ -350,23 +315,14 @@ struct num_major_page_faults : public base<num_major_page_faults>
         accum += value;
     }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    static value_type record(const CacheT& _cache)
+    static value_type record(const cache_type& _cache)
     {
         return _cache.get_num_major_page_faults();
     }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void start(const CacheT& _cache)
-    {
-        value = record(_cache);
-    }
+    void start(const cache_type& _cache) { value = record(_cache); }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void stop(const CacheT& _cache)
+    void stop(const cache_type& _cache)
     {
         auto tmp = record(_cache);
         accum += (tmp - value);
@@ -410,23 +366,14 @@ struct voluntary_context_switch : public base<voluntary_context_switch>
         accum += value;
     }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    static value_type record(const CacheT& _cache)
+    static value_type record(const cache_type& _cache)
     {
         return _cache.get_num_voluntary_context_switch();
     }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void start(const CacheT& _cache)
-    {
-        value = record(_cache);
-    }
+    void start(const cache_type& _cache) { value = record(_cache); }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void stop(const CacheT& _cache)
+    void stop(const cache_type& _cache)
     {
         auto tmp = record(_cache);
         accum += (tmp - value);
@@ -471,23 +418,14 @@ struct priority_context_switch : public base<priority_context_switch>
         accum += value;
     }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    static value_type record(const CacheT& _cache)
+    static value_type record(const cache_type& _cache)
     {
         return _cache.get_num_priority_context_switch();
     }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void start(const CacheT& _cache)
-    {
-        value = record(_cache);
-    }
+    void start(const cache_type& _cache) { value = record(_cache); }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void stop(const CacheT& _cache)
+    void stop(const cache_type& _cache)
     {
         auto tmp = record(_cache);
         accum += (tmp - value);
@@ -522,7 +460,7 @@ struct virtual_memory : public base<virtual_memory>
         value = (record() - value);
         accum += value;
     }
-    void measure() { accum = value = std::max<int64_t>(value, record()); }
+    void sample() { accum = value = std::max<int64_t>(value, record()); }
 };
 
 //--------------------------------------------------------------------------------------//
@@ -562,23 +500,14 @@ struct user_mode_time : public base<user_mode_time, int64_t>
         }
     }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    static value_type record(const CacheT& _cache)
+    static value_type record(const cache_type& _cache)
     {
         return _cache.get_user_mode_time();
     }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void start(const CacheT& _cache)
-    {
-        value = record(_cache);
-    }
+    void start(const cache_type& _cache) { value = record(_cache); }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void stop(const CacheT& _cache)
+    void stop(const cache_type& _cache)
     {
         auto tmp = record(_cache);
         if(tmp > value)
@@ -626,23 +555,14 @@ struct kernel_mode_time : public base<kernel_mode_time, int64_t>
         }
     }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    static value_type record(const CacheT& _cache)
+    static value_type record(const cache_type& _cache)
     {
         return _cache.get_kernel_mode_time();
     }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void start(const CacheT& _cache)
-    {
-        value = record(_cache);
-    }
+    void start(const cache_type& _cache) { value = record(_cache); }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void stop(const CacheT& _cache)
+    void stop(const cache_type& _cache)
     {
         auto tmp = record(_cache);
         if(tmp > value)
@@ -683,23 +603,14 @@ struct current_peak_rss : public base<current_peak_rss, std::pair<int64_t, int64
         accum = std::max(accum, value);
     }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    static value_type record(const CacheT& _cache)
+    static value_type record(const cache_type& _cache)
     {
         return value_type{ _cache.get_peak_rss(), 0 };
     }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void start(const CacheT& _cache)
-    {
-        value = record(_cache);
-    }
+    void start(const cache_type& _cache) { value = record(_cache); }
 
-    template <typename CacheT                                        = cache_type,
-              enable_if_t<std::is_same<CacheT, rusage_cache>::value> = 0>
-    void stop(const CacheT& _cache)
+    void stop(const cache_type& _cache)
     {
         value = value_type{ value.first, record(_cache).first };
         accum = std::max(accum, value);

--- a/source/timemory/general.hpp
+++ b/source/timemory/general.hpp
@@ -1,0 +1,29 @@
+// MIT License
+//
+// Copyright (c) 2020, The Regents of the University of California,
+// through Lawrence Berkeley National Laboratory (subject to receipt of any
+// required approvals from the U.S. Dept. of Energy).  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "timemory/general/serialization.hpp"
+#include "timemory/general/source_location.hpp"
+#include "timemory/general/types.hpp"

--- a/source/timemory/general/serialization.hpp
+++ b/source/timemory/general/serialization.hpp
@@ -1,0 +1,124 @@
+// MIT License
+//
+// Copyright (c) 2020, The Regents of the University of California,
+// through Lawrence Berkeley National Laboratory (subject to receipt of any
+// required approvals from the U.S. Dept. of Energy).  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "timemory/tpls/cereal/archives.hpp"
+
+#if defined(DISABLE_TIMEMORY) || defined(TIMEMORY_DISABLED) ||                           \
+    (defined(TIMEMORY_ENABLED) && TIMEMORY_ENABLED == 0)
+
+namespace tim
+{
+//
+template <typename... Types, typename... Args>
+void
+generic_serialization(Args&&...)
+{}
+//
+}  // namespace tim
+
+#else
+
+namespace tim
+{
+//--------------------------------------------------------------------------------------//
+/// \fn void generic_serialization(std::string fname, Tp obj, std::string mname,
+/// std::string dname)
+/// \param[in] fname Filename
+/// \param[in] obj Object to serialize
+/// \param[in] mname Main label for archive (default: "timemory")
+/// \param[in] dname Label for the data (default: "data")
+///
+/// \brief Generic function for serializing data. Uses the \ref
+/// tim::policy::output_archive to determine the output archive type and configure
+/// settings such as spacing, indentation width, and precision.
+///
+template <typename Tp, typename FuncT>
+void
+generic_serialization(const std::string& fname, const Tp& obj,
+                      const std::string& _main_name = "timemory",
+                      const std::string& _data_name = "data",
+                      FuncT&&            _func =
+                          [](typename policy::output_archive_t<decay_t<Tp>>::type&) {})
+{
+    std::ofstream ofs(fname.c_str());
+    if(ofs)
+    {
+        // ensure json write final block during destruction before the file is closed
+        using policy_type = policy::output_archive_t<decay_t<Tp>>;
+        auto oa           = policy_type::get(ofs);
+        oa->setNextName(_main_name.c_str());
+        oa->startNode();
+        _func(*oa);
+        (*oa)(cereal::make_nvp(_data_name.c_str(), obj));
+        oa->finishNode();
+    }
+    if(ofs)
+        ofs << std::endl;
+    ofs.close();
+}
+//
+/// \fn void generic_serialization(std::string fname, Tp obj, std::string mname,
+/// std::string dname)
+/// \tparam ArchiveT Output archive type
+/// \tparam ApiT API tag for \ref tim::policy::output_archive look-up
+/// \param[in] fname Filename
+/// \param[in] obj Object to serialize
+/// \param[in] mname Main label for archive (default: "timemory")
+/// \param[in] dname Label for the data (default: "data")
+///
+/// \brief Generic function for serializing data. Uses the \ref
+/// tim::policy::output_archive to configure settings such as spacing, indentation width,
+/// and precision.
+///
+template <typename ArchiveT, typename ApiT = TIMEMORY_API, typename Tp, typename FuncT>
+void
+generic_serialization(const std::string& fname, const Tp& obj,
+                      const std::string& _main_name = "timemory",
+                      const std::string& _data_name = "data",
+                      FuncT&&            _func =
+                          [](typename policy::output_archive_t<decay_t<Tp>>::type&) {})
+{
+    static_assert(concepts::is_output_archive<ArchiveT>::value,
+                  "Error! Not an output archive type");
+    std::ofstream ofs(fname.c_str());
+    if(ofs)
+    {
+        // ensure json write final block during destruction before the file is closed
+        using policy_type = policy::output_archive<ArchiveT, ApiT>;
+        auto oa           = policy_type::get(ofs);
+        oa->setNextName(_main_name.c_str());
+        oa->startNode();
+        _func(*oa);
+        (*oa)(cereal::make_nvp(_data_name.c_str(), obj));
+        oa->finishNode();
+    }
+    if(ofs)
+        ofs << std::endl;
+    ofs.close();
+}
+}  // namespace tim
+
+#endif

--- a/source/timemory/operations/types/compose.hpp
+++ b/source/timemory/operations/types/compose.hpp
@@ -73,9 +73,9 @@ struct compose
         ret.set_is_running(false);
         ret.set_is_on_stack(false);
         ret.set_is_transient(lhs.is_transient && rhs.is_transient);
-        ret.laps         = std::min(lhs.laps, rhs.laps);
-        ret.value        = (lhs.value + rhs.value);
-        ret.accum        = (lhs.accum + rhs.accum);
+        ret.laps  = std::min(lhs.laps, rhs.laps);
+        ret.value = (lhs.value + rhs.value);
+        ret.accum = (lhs.accum + rhs.accum);
         return ret;
     }
 
@@ -87,9 +87,9 @@ struct compose
         ret.set_is_running(false);
         ret.set_is_on_stack(false);
         ret.set_is_transient(lhs.is_transient && rhs.is_transient);
-        ret.laps         = std::min(lhs.laps, rhs.laps);
-        ret.value        = func(lhs.value, rhs.value);
-        ret.accum        = func(lhs.accum, rhs.accum);
+        ret.laps  = std::min(lhs.laps, rhs.laps);
+        ret.value = func(lhs.value, rhs.value);
+        ret.accum = func(lhs.accum, rhs.accum);
         return ret;
     }
 };

--- a/source/timemory/operations/types/echo_measurement.hpp
+++ b/source/timemory/operations/types/echo_measurement.hpp
@@ -61,8 +61,9 @@ struct echo_measurement<Tp, false> : public common_utils
 template <typename Tp>
 struct echo_measurement<Tp, true> : public common_utils
 {
-    using type       = Tp;
-    using value_type = typename type::value_type;
+    using type         = Tp;
+    using value_type   = typename type::value_type;
+    using attributes_t = std::map<std::string, std::string>;
 
     //----------------------------------------------------------------------------------//
     /// generate a name attribute

--- a/source/timemory/operations/types/finalize/ctest_notes.hpp
+++ b/source/timemory/operations/types/finalize/ctest_notes.hpp
@@ -55,6 +55,13 @@ struct ctest_notes_deleter : public std::default_delete<std::set<std::string>>
 
     void operator()(strset_t* data)
     {
+        auto _settings = settings::instance();
+        if(data->empty() || !_settings || !_settings->get_ctest_notes())
+        {
+            delete data;
+            return;
+        }
+
         std::stringstream ss;
         // loop over filenames
         for(auto&& itr : *data)
@@ -81,6 +88,7 @@ struct ctest_notes_deleter : public std::default_delete<std::set<std::string>>
                           << std::endl;
             ofs << ss.str() << std::endl;
         }
+        delete data;
     }
 };
 

--- a/source/timemory/operations/types/node.hpp
+++ b/source/timemory/operations/types/node.hpp
@@ -81,7 +81,7 @@ private:
         {
             _obj.set_is_on_stack(true);
             _obj.get_is_flat() = _scope.is_flat() || force_flat_v;
-            auto _storage    = static_cast<storage_type*>(_obj.get_storage());
+            auto _storage      = static_cast<storage_type*>(_obj.get_storage());
             assert(_storage != nullptr);
             auto _beg_depth = _storage->depth();
             _obj.set_iterator(_storage->insert(_scope, _obj, _hash));
@@ -150,7 +150,7 @@ private:
             type& targ  = _obj.get_iterator()->obj();
             auto& stats = _obj.get_iterator()->stats();
             _obj.set_depth_change(false);
-            auto _storage     = static_cast<storage_type*>(_obj.get_storage());
+            auto _storage = static_cast<storage_type*>(_obj.get_storage());
             assert(_storage != nullptr);
 
             if(storage_type::is_finalizing())
@@ -180,7 +180,7 @@ private:
                 {
                     _storage->pop();
                     _storage->stack_pop(&_obj);
-                    auto _end_depth   = _storage->depth();
+                    auto _end_depth = _storage->depth();
                     _obj.set_depth_change(_beg_depth > _end_depth);
                 }
             }

--- a/source/timemory/timemory.hpp
+++ b/source/timemory/timemory.hpp
@@ -323,6 +323,8 @@ struct dummy
 #        define TIMEMORY_DEFINE_VARIADIC_TRAIT(...)
 #    endif
 
+#    include "timemory/general/serialization.hpp"
+
 #else
 
 #    if !defined(TIMEMORY_MASTER_HEADER)
@@ -343,6 +345,7 @@ struct dummy
 #    include "timemory/api.hpp"
 #    include "timemory/config.hpp"
 #    include "timemory/enum.h"
+#    include "timemory/general.hpp"
 #    include "timemory/plotting.hpp"
 #    include "timemory/types.hpp"
 #    include "timemory/units.hpp"
@@ -361,31 +364,6 @@ struct dummy
 //
 namespace tim
 {
-//--------------------------------------------------------------------------------------//
-/// args:
-///     1) filename
-///     2) reference an object
-///
-template <typename Tp>
-void
-generic_serialization(const std::string& fname, const Tp& obj)
-{
-    std::ofstream ofs(fname.c_str());
-    if(ofs)
-    {
-        // ensure json write final block during destruction before the file is closed
-        using policy_type = policy::output_archive_t<Tp>;
-        auto oa           = policy_type::get(ofs);
-        oa->setNextName("timemory");
-        oa->startNode();
-        (*oa)(cereal::make_nvp("data", obj));
-        oa->finishNode();
-    }
-    if(ofs)
-        ofs << std::endl;
-    ofs.close();
-}
-//
 // deprecated namespace
 namespace variadic
 {

--- a/source/timemory/utility/utility.hpp
+++ b/source/timemory/utility/utility.hpp
@@ -341,8 +341,7 @@ makedir(std::string _dir, int umask = DEFAULT_UMASK)
         int err = errno;
         if(err != EEXIST)
         {
-            std::cerr << "_mkdir(" << _dir.c_str() << ") returned: " 
-                      << ret << std::endl;
+            std::cerr << "_mkdir(" << _dir.c_str() << ") returned: " << ret << std::endl;
             std::stringstream _sdir;
             _sdir << "mkdir " << _dir;
             return (launch_process(_sdir.str().c_str())) ? 0 : 1;

--- a/source/timemory/variadic/component_bundle.cpp
+++ b/source/timemory/variadic/component_bundle.cpp
@@ -269,10 +269,7 @@ template <typename... Args>
 void
 component_bundle<Tag, Types...>::sample(Args&&... args)
 {
-    sample_type _samples{};
-    if(trait::runtime_enabled<Tag>::get())
-        apply_v::access2<operation_t<operation::sample>>(m_data, _samples,
-                                                         std::forward<Args>(args)...);
+    invoke::invoke<operation::sample, Tag>(m_data, std::forward<Args>(args)...);
 }
 
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/variadic/component_list.cpp
+++ b/source/timemory/variadic/component_list.cpp
@@ -235,9 +235,7 @@ template <typename... Args>
 void
 component_list<Types...>::sample(Args&&... args)
 {
-    sample_type _samples{};
-    apply_v::access2<operation_t<operation::sample>>(m_data, _samples,
-                                                     std::forward<Args>(args)...);
+    invoke::invoke<operation::sample, TIMEMORY_API>(m_data, std::forward<Args>(args)...);
 }
 
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/variadic/component_tuple.cpp
+++ b/source/timemory/variadic/component_tuple.cpp
@@ -219,9 +219,7 @@ template <typename... Args>
 void
 component_tuple<Types...>::sample(Args&&... args)
 {
-    sample_type _samples;
-    apply_v::access2<operation_t<operation::sample>>(m_data, _samples,
-                                                     std::forward<Args>(args)...);
+    invoke::invoke<operation::sample, TIMEMORY_API>(m_data, std::forward<Args>(args)...);
 }
 
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/variadic/lightweight_tuple.cpp
+++ b/source/timemory/variadic/lightweight_tuple.cpp
@@ -213,9 +213,7 @@ template <typename... Args>
 void
 lightweight_tuple<Types...>::sample(Args&&... args)
 {
-    sample_type _samples;
-    apply_v::access2<operation_t<operation::sample>>(m_data, _samples,
-                                                     std::forward<Args>(args)...);
+    invoke::invoke<operation::sample, TIMEMORY_API>(m_data, std::forward<Args>(args)...);
 }
 
 //--------------------------------------------------------------------------------------//

--- a/source/tools/kokkos-connector/kp_timemory_filter.cpp
+++ b/source/tools/kokkos-connector/kp_timemory_filter.cpp
@@ -55,7 +55,7 @@ using section_map_t   = std::unordered_map<uint64_t, section_entry_t>;
 static std::string kernel_regex_expr = "^[A-Za-z]";
 static auto        regex_constants =
     std::regex_constants::ECMAScript | std::regex_constants::optimize;
-static auto        kernel_regex      = std::regex(kernel_regex_expr, regex_constants);
+static auto kernel_regex = std::regex(kernel_regex_expr, regex_constants);
 
 //--------------------------------------------------------------------------------------//
 

--- a/source/tools/timemory-timem/CMakeLists.txt
+++ b/source/tools/timemory-timem/CMakeLists.txt
@@ -5,6 +5,7 @@ if(WIN32)
 endif()
 
 set(CMAKE_BUILD_TYPE "RelWithDebInfo")
+set(CMAKE_POSITION_INDEPENDENT_CODE OFF)
 
 #----------------------------------------------------------------------------------------#
 # Build and install timem tool
@@ -38,6 +39,15 @@ if(TIMEMORY_BUILD_TOOLS_LIBEXPECT)
     endif()
 endif()
 
+find_package(PAPI QUIET)
+if(NOT DEFINED TIMEM_PAPI_TARGET OR NOT TIMEM_PAPI_TARGET)
+    if(PAPI_STATIC_LIBRARIES OR TARGET PAPI::papi-static)
+        set(TIMEM_PAPI_TARGET PAPI::papi-static timemory::timemory-papi-static)
+    else()
+        set(TIMEM_PAPI_TARGET timemory::timemory-papi)
+    endif()
+endif()
+
 # non-MPI version
 add_executable(timem ${_EXCLUDE} timem.cpp timem.hpp)
 
@@ -47,7 +57,7 @@ target_link_libraries(timem PRIVATE
     timemory::timemory-threading
     timemory::timemory-headers
     timemory::timemory-arch
-    timemory::timemory-papi
+    ${TIMEM_PAPI_TARGET}
     timem-libexplain)
 
 add_target_flag_if_avail(timem "-g")
@@ -74,7 +84,7 @@ target_link_libraries(timem-mpi PRIVATE
     timemory::timemory-threading
     timemory::timemory-headers
     timemory::timemory-arch
-    timemory::timemory-papi
+    ${TIMEM_PAPI_TARGET}
     timemory::timemory-mpi
     timem-libexplain)
 

--- a/source/tools/timemory-timem/timem.cpp
+++ b/source/tools/timemory-timem/timem.cpp
@@ -55,6 +55,7 @@ main(int argc, char** argv)
     tim::settings::banner()           = false;
     tim::settings::auto_output()      = false;
     tim::settings::file_output()      = false;
+    tim::settings::ctest_notes()      = false;
     tim::settings::scientific()       = false;
     tim::settings::width()            = 16;
     tim::settings::precision()        = 6;
@@ -232,7 +233,7 @@ main(int argc, char** argv)
 
     auto compose_prefix = [&]() {
         stringstream_t ss;
-        ss << "[" << command().c_str() << "] measurement totals";
+        ss << "[" << command().c_str() << "]> Measurement totals";
         if(use_mpi())
             ss << " (# ranks = " << tim::mpi::size() << "):";
         else if(tim::dmp::size() > 1)
@@ -241,10 +242,6 @@ main(int argc, char** argv)
             ss << ":";
         return ss.str();
     };
-
-    // for(int i = 0; i < _argc; ++i)
-    //    std::cout << _argv[i] << " ";
-    // std::cout << std::endl;
 
     if(_argc > 1)
     {
@@ -262,8 +259,19 @@ main(int argc, char** argv)
     {
         auto ofname = parser.get<string_t>("output");
         if(ofname.empty())
-            ofname = TIMEMORY_JOIN("", argv[0], "-output", '/', command());
-        output_file() = ofname;
+        {
+            auto _cmd = command();
+            auto _pos = _cmd.find_last_of('/');
+            if(_pos != std::string::npos)
+                _cmd = _cmd.substr(_pos + 1);
+            ofname = TIMEMORY_JOIN("", argv[0], "-output", '/', _cmd);
+            fprintf(stderr, "[%s]> No output filename provided. Using '%s'...\n",
+                    command().c_str(), ofname.c_str());
+        }
+        output_file()   = ofname;
+        auto output_dir = output_file().substr(0, output_file().find_last_of('/'));
+        if(output_dir != output_file())
+            tim::makedir(output_dir);
     }
 
     if(tim::settings::papi_events().empty())
@@ -285,6 +293,9 @@ main(int argc, char** argv)
         signal(TIMEM_PID_SIGNAL, childpid_catcher);
     else
         signal_delivered() = true;
+
+    for(int i = 0; i < _argc; ++i)
+        argvector().emplace_back(_argv[i]);
 
     //----------------------------------------------------------------------------------//
     //
@@ -359,7 +370,7 @@ main(int argc, char** argv)
         if(debug() && comm_rank == 0)
         {
             std::stringstream ss;
-            std::cout << "[timem]> parent pids: ";
+            std::cout << "[" << command() << "]> parent pids: ";
             for(const auto& itr : pids)
                 ss << ", " << itr;
             std::cout << ss.str().substr(2) << '\n';
@@ -374,7 +385,7 @@ main(int argc, char** argv)
             cargv_arg0.push_back(_cargv.argv()[0]);
             cargv_argv.push_back(_cargv.argv() + 1);
             if(debug() && comm_rank == 0)
-                fprintf(stderr, "[timem][rank=%i]> cmd :: %s\n", (int) i,
+                fprintf(stderr, "[%s][rank=%i]> cmd :: %s\n", command().c_str(), (int) i,
                         _cargv.args().c_str());
         }
 
@@ -451,13 +462,10 @@ main(int argc, char** argv)
     {
         // ensure always enabled
         tim::settings::enabled() = true;
-        if(!output_file().empty())
+        if(!output_file().empty() && (debug() || verbose() > 1))
         {
             auto fname = output_file();
             fname += "-" + std::to_string(worker_pid()) + ".log";
-            auto output_dir = output_file().substr(0, output_file().find_last_of('/'));
-            if(output_dir != output_file())
-                tim::makedir(output_dir);
             ofs = std::make_unique<std::ofstream>(fname.c_str());
         }
 
@@ -597,49 +605,31 @@ parent_process(pid_t pid)
             continue;
         if(!_measurements.empty() && (use_mpi() || tim::mpi::size() > 1))
             itr.set_rank(i);
-        _oss << "\n" << itr << std::flush;
+        _oss << itr << std::flush;
     }
 
     if(_oss.str().empty())
         return;
 
-    auto _file_out = tim::settings::file_output();
-    auto _text_out = tim::settings::text_output();
-    auto _json_out = tim::settings::json_output();
-
-    if(_file_out)
-    {
-        std::string label = "timem";
-        if(_text_out)
-        {
-            auto          fname = tim::settings::compose_output_filename(label, ".txt");
-            std::ofstream ofs(fname.c_str());
-            if(ofs)
-            {
-                fprintf(stderr, "[timem]> Outputting '%s'...\n", fname.c_str());
-                ofs << _oss.str();
-                ofs.close();
-            }
-            else
-            {
-                std::cerr << "[timem]>  opening output file '" << fname << "'...\n";
-                std::cerr << _oss.str();
-            }
-        }
-
-        if(_json_out)
-        {
-            auto jname = tim::settings::compose_output_filename(label, ".json");
-            fprintf(stderr, "[timem]> Outputting '%s'...\n", jname.c_str());
-            tim::generic_serialization(jname, _measurements);
-        }
-    }
+    if(output_file().empty())
+        std::cerr << '\n';
     else
     {
-        std::cerr << _oss.str() << std::endl;
+        using json_type = tim::cereal::PrettyJSONOutputArchive;
+        // extra function
+        auto _cmdline = [](json_type& ar) {
+            ar(tim::cereal::make_nvp("command_line", argvector()),
+               tim::cereal::make_nvp("config", get_config()));
+        };
+
+        auto fname = output_file();
+        fname += "-" + std::to_string(worker_pid()) + ".json";
+        fprintf(stderr, "\n[%s]> Outputting '%s'...\n", command().c_str(), fname.c_str());
+        tim::generic_serialization<json_type>(fname, _measurements, "timemory", "timem",
+                                              _cmdline);
     }
 
-    std::cerr << std::flush;
+    std::cerr << _oss.str() << std::endl;
 
     // tim::mpi::barrier();
     // tim::mpi::finalize();
@@ -676,8 +666,8 @@ child_process(int argc, char** argv)
             auto shellc = argpv.get_execv(shellp);
 
             if(debug())
-                CONDITIONAL_PRINT_HERE((debug() && verbose() > 1),
-                                       "[timem]> command :: %s", shellc.args().c_str());
+                CONDITIONAL_PRINT_HERE((debug() && verbose() > 1), "[%s]> command :: %s",
+                                       command().c_str(), shellc.args().c_str());
 
             explain(0, shellc.argv()[0], shellc.argv());
 
@@ -721,8 +711,8 @@ child_process(int argc, char** argv)
         auto argpv = tim::argparse::argument_vector(argc, argv);
         auto argpc = argpv.get_execv(1);
         if(debug())
-            CONDITIONAL_PRINT_HERE((debug() && verbose() > 1), "[timem]> command :: '%s'",
-                                   argpc.args().c_str());
+            CONDITIONAL_PRINT_HERE((debug() && verbose() > 1), "[%s]> command :: '%s'",
+                                   command().c_str(), argpc.args().c_str());
         int ret = execvp(argpc.argv()[0], argpc.argv());
         // explain error if enabled
         explain(ret, argpc.argv()[0], argpc.argv());

--- a/source/tools/timemory-timem/timem.hpp
+++ b/source/tools/timemory-timem/timem.hpp
@@ -31,6 +31,7 @@
 #define TIMEM_DEBUG
 #define TIMEMORY_DISABLE_BANNER
 #define TIMEMORY_DISABLE_STORE_ENVIRONMENT
+#define TIMEMORY_DISABLE_CEREAL_CLASS_VERSION
 #define TIMEMORY_DISABLE_COMPONENT_STORAGE_INIT
 
 // disables unnecessary instantiations
@@ -45,8 +46,19 @@ TIMEMORY_FORWARD_DECLARE_COMPONENT(page_rss)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::page_rss, false_type)
 #endif
 
+namespace tim
+{
+namespace trait
+{
+template <>
+struct pretty_archive<void> : true_type
+{};
+}  // namespace trait
+}  // namespace tim
+
 #include "timemory/components/timing/child.hpp"
-#include "timemory/sampling/sampler.hpp"
+#include "timemory/general.hpp"
+#include "timemory/sampling.hpp"
 #include "timemory/timemory.hpp"
 
 TIMEMORY_DEFINE_CONCRETE_TRAIT(custom_label_printing, component::papi_array_t, true_type)
@@ -241,49 +253,22 @@ CUSTOM_BASE_PRINTER_SPECIALIZATION(component::written_char, "char written")
 #if defined(TIMEMORY_USE_PAPI)
 //
 template <>
-struct sample<component::papi_array_t>
-{
-    using EmptyT                 = std::tuple<>;
-    using type                   = papi_array_t;
-    using value_type             = typename type::value_type;
-    using base_type              = typename type::base_type;
-    using this_type              = sample<type>;
-    static constexpr bool enable = trait::sampler<type>::value;
-    using data_type = conditional_t<enable, decltype(std::declval<type>().get()), EmptyT>;
-
-    TIMEMORY_DEFAULT_OBJECT(sample)
-
-    template <typename Up, typename... Args,
-              enable_if_t<std::is_same<Up, this_type>::value, int> = 0>
-    explicit sample(base_type& obj, Up, Args&&...)
-    {
-        obj.value        = type::record();
-        obj.is_transient = false;
-    }
-};
-//
-template <>
 struct start<component::papi_array_t>
 {
-    using type       = papi_array_t;
-    using value_type = typename type::value_type;
-    using base_type  = typename type::base_type;
+    using type = papi_array_t;
 
     template <typename... Args>
-    explicit start(base_type&, Args&&...)
-    {
-        type::configure();
-    }
+    explicit start(type&, Args&&...)
+    {}
 };
 //
 template <>
 struct stop<component::papi_array_t>
 {
-    using type      = component::papi_array_t;
-    using base_type = typename type::base_type;
+    using type = component::papi_array_t;
 
     template <typename... Args>
-    explicit stop(base_type&, Args&&...)
+    explicit stop(type&, Args&&...)
     {}
 };
 //
@@ -392,20 +377,6 @@ public:
         typename base_type::template custom_operation<Op, Tuple>::type;
 
     template <typename... T>
-    struct opsample;
-
-    template <template <typename...> class Tuple, typename... T>
-    struct opsample<Tuple<T...>>
-    {
-        using type =
-            Tuple<operation::timem_sample<T, (trait::sampler<T>::value ||
-                                              trait::file_sampler<T>::value)>...>;
-    };
-
-    template <typename T>
-    using opsample_t = typename opsample<T>::type;
-
-    template <typename... T>
     struct mpi_getter;
 
     template <template <typename...> class Tuple, typename... T>
@@ -445,8 +416,6 @@ public:
     void sample(Args&&... args)
     {
         base_type::sample(std::forward<Args>(args)...);
-        apply<void>::access<opsample_t<data_type>>(this->m_data,
-                                                   std::forward<Args>(args)...);
         if(m_ofs)
             (*m_ofs) << get_local_datetime("[===== %r %F =====]\n") << *this << std::endl;
     }
@@ -489,6 +458,52 @@ public:
     }
 
     bool empty() const { return m_empty; }
+
+    template <typename Archive>
+    void serialize(Archive& ar, const unsigned int)
+    {
+        using data_tuple_type = decay_t<decltype(m_data)>;
+        constexpr auto N      = std::tuple_size<data_tuple_type>::value;
+        serialize_tuple(ar, m_data, make_index_sequence<N>{});
+    }
+
+    template <typename Up, typename Tp = decay_t<Up>>
+    static auto get_metadata_label()
+    {
+        auto _name = metadata<Tp>::name();
+        for(auto&& itr : { "::", "child_" })
+        {
+            auto _pos = std::string::npos;
+            while((_pos = _name.find(itr)) != std::string::npos)
+            {
+                _name = _name.substr(_pos + std::string(itr).length());
+            }
+        }
+        _name = _name.substr(0, _name.find("<"));
+        return _name;
+    }
+
+    template <typename Archive, typename Tp>
+    static auto serialize_entry(Archive& ar, Tp&& _obj)
+    {
+        auto _name = get_metadata_label<Tp>();
+        ar.setNextName(_name.c_str());
+        ar.startNode();
+        ar(cereal::make_nvp("value", _obj.get()));
+        ar(cereal::make_nvp("repr", _obj.get_display()));
+        ar(cereal::make_nvp("laps", _obj.get_laps()));
+        ar(cereal::make_nvp("unit_value", _obj.get_unit()));
+        ar(cereal::make_nvp("unit_repr", _obj.get_display_unit()));
+        ar.finishNode();
+        // ar(cereal::make_nvp(_name, std::forward<Tp>(_obj)));
+    }
+
+    template <typename Archive, typename... Tp, size_t... Idx>
+    static void serialize_tuple(Archive& ar, std::tuple<Tp...>& _data,
+                                index_sequence<Idx...>)
+    {
+        TIMEMORY_FOLD_EXPRESSION(serialize_entry(ar, std::get<Idx>(_data)));
+    }
 
 private:
     // this mpi_get overload merges the results from the different mpi processes
@@ -605,6 +620,22 @@ struct timem_config
     pid_t         worker_pid   = getpid();
     string_t      command      = "";
     std::set<int> signal_types = { SIGALRM };
+    std::vector<std::string> argvector = {};
+
+    template <typename Archive>
+    void serialize(Archive& ar, const unsigned int)
+    {
+        ar(tim::cereal::make_nvp("use_shell", use_shell),
+           tim::cereal::make_nvp("use_mpi", use_mpi),
+           tim::cereal::make_nvp("use_papi", use_papi),
+           tim::cereal::make_nvp("use_sample", use_sample),
+           tim::cereal::make_nvp("debug", debug),
+           tim::cereal::make_nvp("verbose", verbose),
+           tim::cereal::make_nvp("shell", shell),
+           tim::cereal::make_nvp("shell_flags", shell_flags),
+           tim::cereal::make_nvp("sample_freq", sample_freq),
+           tim::cereal::make_nvp("sample_delay", sample_delay));
+    }
 };
 //
 //--------------------------------------------------------------------------------------//
@@ -639,6 +670,7 @@ TIMEM_CONFIG_FUNCTION(command)
 TIMEM_CONFIG_FUNCTION(master_pid)
 TIMEM_CONFIG_FUNCTION(worker_pid)
 TIMEM_CONFIG_FUNCTION(signal_types)
+TIMEM_CONFIG_FUNCTION(argvector)
 //
 //--------------------------------------------------------------------------------------//
 //

--- a/timemory/plotting/table.py
+++ b/timemory/plotting/table.py
@@ -1,0 +1,219 @@
+# MIT License
+#
+# Copyright (c) 2020, The Regents of the University of California,
+# through Lawrence Berkeley National Laboratory (subject to receipt of any
+# required approvals from the U.S. Dept. of Energy).  All rights reserved.
+#
+# Permission is hereby granted, free of charge, to any person obtaining a copy
+# of this software and associated documentation files (the "Software"), to deal
+# in the Software without restriction, including without limitation the rights
+# to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+# copies of the Software, and to permit persons to whom the Software is
+# furnished to do so, subject to the following conditions:
+#
+# The above copyright notice and this permission notice shall be included in all
+# copies or substantial portions of the Software.
+#
+# THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+# IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+# FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+# AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+# LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+# OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+# SOFTWARE.
+
+""" @file plotting.py
+Table generation routines for timemory package
+"""
+
+from __future__ import absolute_import
+from __future__ import division
+
+__author__ = "Jonathan Madsen"
+__copyright__ = "Copyright 2020, The Regents of the University of California"
+__credits__ = ["Jonathan Madsen"]
+__license__ = "MIT"
+__version__ = "@PROJECT_VERSION@"
+__maintainer__ = "Jonathan Madsen"
+__email__ = "jrmadsen@lbl.gov"
+__status__ = "Development"
+__all__ = [
+    "timem",
+]
+
+import os
+from .plotting import make_output_directory, add_plotted_files, plot_parameters
+
+# use the matplotlib import stuff from plotting
+try:
+    import matplotlib.pyplot as plt
+    import base64
+    import io
+    import pickle
+
+except ImportError as e:
+    print(f"{e}")
+    pass
+
+
+verbosity = os.environ.get("TIMEMORY_VERBOSE", 0)
+
+
+def timem(data, fname, args):
+    cmd = "unknown"
+    if "command_line" in data:
+        cmd = data["command_line"][1]
+
+    nranks = len(data["timem"])
+    row_labels = []
+    col_labels = []
+    table_vals = []
+
+    min_data = {}
+    max_data = {}
+    sum_data = {}
+    int_data = {}
+
+    for rank in range(nranks):
+        col_labels.append("Rank {}".format(rank))
+        i = 0
+        for key, entry in data["timem"][rank].items():
+            if rank == 0:
+                unit = entry["unit_repr"]
+                if unit:
+                    unit = " [{}]".format(unit)
+                lbl = "{}{}".format(key.replace("_", " ").title(), unit)
+                row_labels.append(lbl)
+                min_data[i] = entry["repr"]
+                max_data[i] = entry["repr"]
+                sum_data[i] = 0
+            if len(table_vals) < i + 1:
+                table_vals.append([])
+            value = entry["repr"]
+            strval = "{}".format(value)
+            min_data[i] = min([min_data[i], value])
+            max_data[i] = max([max_data[i], value])
+            sum_data[i] += value
+            if "." in strval:
+                table_vals[i].append("{:.3f}".format(value))
+                int_data[i] = False
+            else:
+                table_vals[i].append("{}".format(value))
+                if not i in int_data:
+                    int_data[i] = True
+            i += 1
+
+    if nranks > 1:
+        col_labels = ["Sum", "Mean"] + col_labels + ["Min", "Max"]
+        i = 0
+        for i in range(len(row_labels)):
+            _mean = sum_data[i] / nranks
+            if int_data[i]:
+                table_vals[i] = (
+                    ["{}".format(sum_data[i]), "{:.3f}".format(_mean)]
+                    + table_vals[i]
+                    + ["{}".format(min_data[i]), "{}".format(max_data[i])]
+                )
+            else:
+                table_vals[i] = (
+                    ["{:.3f}".format(sum_data[i]), "{:.3f}".format(_mean)]
+                    + table_vals[i]
+                    + [
+                        "{:.3f}".format(min_data[i]),
+                        "{:.3f}".format(max_data[i]),
+                    ]
+                )
+            i += 1
+
+    # print(f"cols: {col_labels}")
+    # print(f"rows: {row_labels}")
+    # print(f"vals: {table_vals}")
+    #
+    font = {
+        "family": "serif",
+        "color": "black",
+        "weight": "bold",
+        "size": 20,
+    }
+
+    if args.titles is not None:
+        plt.suptitle("{}".format(args.titles[0].title()), **font)
+    else:
+        plt.suptitle(f"{cmd}", **font)
+
+    # Draw table
+    the_table = plt.table(
+        cellText=table_vals,
+        colWidths=[0.2] * len(col_labels),
+        rowLabels=row_labels,
+        colLabels=col_labels,
+        loc="center",
+    )
+    the_table.auto_set_font_size(False)
+    the_table.set_fontsize(16)
+    the_table.scale(2, 2)
+
+    # Removing ticks and spines enables you to get the figure only with table
+    plt.tick_params(
+        axis="x", which="both", bottom=False, top=False, labelbottom=False
+    )
+    plt.tick_params(
+        axis="y", which="both", right=False, left=False, labelleft=False
+    )
+    for pos in ["right", "top", "bottom", "left"]:
+        plt.gca().spines[pos].set_visible(False)
+
+    output_dir = "."
+    try:
+        output_dir = args.output_dir
+    except AttributeError:
+        pass
+
+    if args.display_plot:
+        print("Displaying plot...")
+        plt.show()
+    else:
+        make_output_directory(output_dir)
+        imgfname = (
+            os.path.basename(fname)
+            .replace(".json", ".{}".format(args.img_type))
+            .replace(".py", ".{}".format(args.img_type))
+        )
+        if not ".{}".format(args.img_type) in imgfname:
+            imgfname += ".{}".format(args.img_type)
+        while ".." in imgfname:
+            imgfname = imgfname.replace("..", ".")
+        add_plotted_files(
+            imgfname, os.path.join(output_dir, imgfname), args.echo_dart
+        )
+
+        imgfname = os.path.join(output_dir, imgfname)
+        if verbosity > 0:
+            print("Opening '{}' for output...".format(imgfname))
+        else:
+            lbl = os.path.basename(imgfname).strip(".{}".format(args.img_type))
+            print("[{}]|0> Outputting '{}'...".format(lbl, imgfname))
+        plt.savefig(imgfname, bbox_inches="tight", pad_inches=0.05)
+        plt.close()
+        if verbosity > 0:
+            print("Closed '{}'...".format(imgfname))
+
+    # fig, ax = plt.subplots(figsize=(16, 8))
+
+    # for step, group in df.groupby('step', observed=True):
+    #     d = group['ipc'].rolling('30s').agg(['mean', 'std']).resample('10s').mean()
+    #     mean = d['mean']
+    #     std = d['std']
+    #     mean.plot(ax=ax, label=step, color=color)
+    #     std = d['std']
+    #     ax.fill_between(std.index, mean - 0.5*std, mean + 0.5*std, alpha=0.2,
+    #                     color=color)
+
+    # _ = ax.set_title(f'Instructions Per Cycle (IPC) by step jobid = {jobid}')
+    # _ = ax.set_ylabel('IPC')
+    # _ = ax.legend(ncol=2, title='job step')
+
+    # buf = io.BytesIO()
+    # plt.savefig(buf,  format='png')
+    # buf.seek(0)
+    # return base64.b64encode(buf.read())


### PR DESCRIPTION
- timem supports JSON output
- `timemory.plotting` supports timem JSON + table mode
- replaced use of `measure()` member function with `sample()` member function
- updated `sample()` in bundlers
- updated `operation::sample`
- removed unnecessary templating w.r.t. `cache_type` in the components which support cache_types (e.g. `rusage_cache` and `io_cache`)
- moved `generic_serialization` routine out of `timemory/timemory.hpp` and into `timemory/general/serialization.hpp`

![stat-40553](https://user-images.githubusercontent.com/6001865/101539156-ea8ad280-3952-11eb-9d1c-23068a154648.png)
