### PR TITLE
Windows thread process cpu clocks

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -137,15 +137,15 @@ build_script:
           ctest . --output-on-failure
       }
       elseif ($env:EXAMPLES -eq "ON") {
-        ./outputs/runtime/"%CONFIG%"/ex_optional_off.exe
-        ./outputs/runtime/"%CONFIG%"/ex_cxx_basic.exe
-        ./outputs/runtime/"%CONFIG%"/ex_optional_on.exe
-        ./outputs/runtime/"%CONFIG%"/ex_cxx_overhead.exe
-        ./outputs/runtime/"%CONFIG%"/ex_cxx_tuple.exe
+        .\outputs\runtime\$env:CONFIG\ex_optional_off.exe
+        .\outputs\runtime\$env:CONFIG\ex_cxx_basic.exe
+        .\outputs\runtime\$env:CONFIG\ex_optional_on.exe
+        .\outputs\runtime\$env:CONFIG\ex_cxx_overhead.exe
+        .\outputs\runtime\$env:CONFIG\ex_cxx_tuple.exe
         if ($env:BUILD_C -eq "ON") {
-          ./outputs/runtime/"%CONFIG%"/ex_c_minimal.exe
-          ./outputs/runtime/"%CONFIG%"/ex_c_minimal_library.exe
-          ./outputs/runtime/"%CONFIG%"/ex_c_timing.exe
+          .\outputs\runtime\$env:CONFIG\ex_c_minimal.exe
+          .\outputs\runtime\$env:CONFIG\ex_c_minimal_library.exe
+          .\outputs\runtime\$env:CONFIG\ex_c_timing.exe
         }
       }
   - ps: |

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -137,15 +137,15 @@ build_script:
           ctest . --output-on-failure
       }
       elseif ($env:EXAMPLES -eq "ON") {
-        "./outputs/runtime/%CONFIG%/ex_optional_off.exe"
-        "./outputs/runtime/%CONFIG%/ex_cxx_basic.exe"
-        "./outputs/runtime/%CONFIG%/ex_optional_on.exe"
-        "./outputs/runtime/%CONFIG%/ex_cxx_overhead.exe"
-        "./outputs/runtime/%CONFIG%/ex_cxx_tuple.exe"
+        ./outputs/runtime/%CONFIG%/ex_optional_off.exe
+        ./outputs/runtime/%CONFIG%/ex_cxx_basic.exe
+        ./outputs/runtime/%CONFIG%/ex_optional_on.exe
+        ./outputs/runtime/%CONFIG%/ex_cxx_overhead.exe
+        ./outputs/runtime/%CONFIG%/ex_cxx_tuple.exe
         if ($env:BUILD_C -eq "ON") {
-          "./outputs/runtime/%CONFIG%/ex_c_minimal.exe"
-          "./outputs/runtime/%CONFIG%/ex_c_minimal_library.exe"
-          "./outputs/runtime/%CONFIG%/ex_c_timing.exe"
+          ./outputs/runtime/%CONFIG%/ex_c_minimal.exe
+          ./outputs/runtime/%CONFIG%/ex_c_minimal_library.exe
+          ./outputs/runtime/%CONFIG%/ex_c_timing.exe
         }
       }
   - ps: |

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -137,15 +137,15 @@ build_script:
           ctest . --output-on-failure
       }
       elseif ($env:EXAMPLES -eq "ON") {
-        .\outputs\runtime\$env:CONFIG\ex_optional_off.exe
-        .\outputs\runtime\$env:CONFIG\ex_cxx_basic.exe
-        .\outputs\runtime\$env:CONFIG\ex_optional_on.exe
-        .\outputs\runtime\$env:CONFIG\ex_cxx_overhead.exe
-        .\outputs\runtime\$env:CONFIG\ex_cxx_tuple.exe
+        iex ".\outputs\runtime\$env:CONFIG\ex_optional_off.exe"
+        iex ".\outputs\runtime\$env:CONFIG\ex_cxx_basic.exe"
+        iex ".\outputs\runtime\$env:CONFIG\ex_optional_on.exe"
+        iex ".\outputs\runtime\$env:CONFIG\ex_cxx_overhead.exe"
+        iex ".\outputs\runtime\$env:CONFIG\ex_cxx_tuple.exe"
         if ($env:BUILD_C -eq "ON") {
-          .\outputs\runtime\$env:CONFIG\ex_c_minimal.exe
-          .\outputs\runtime\$env:CONFIG\ex_c_minimal_library.exe
-          .\outputs\runtime\$env:CONFIG\ex_c_timing.exe
+          iex ".\outputs\runtime\$env:CONFIG\ex_c_minimal.exe"
+          iex ".\outputs\runtime\$env:CONFIG\ex_c_minimal_library.exe"
+          iex ".\outputs\runtime\$env:CONFIG\ex_c_timing.exe"
         }
       }
   - ps: |

--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -137,15 +137,15 @@ build_script:
           ctest . --output-on-failure
       }
       elseif ($env:EXAMPLES -eq "ON") {
-        ./outputs/runtime/%CONFIG%/ex_optional_off.exe
-        ./outputs/runtime/%CONFIG%/ex_cxx_basic.exe
-        ./outputs/runtime/%CONFIG%/ex_optional_on.exe
-        ./outputs/runtime/%CONFIG%/ex_cxx_overhead.exe
-        ./outputs/runtime/%CONFIG%/ex_cxx_tuple.exe
+        ./outputs/runtime/"%CONFIG%"/ex_optional_off.exe
+        ./outputs/runtime/"%CONFIG%"/ex_cxx_basic.exe
+        ./outputs/runtime/"%CONFIG%"/ex_optional_on.exe
+        ./outputs/runtime/"%CONFIG%"/ex_cxx_overhead.exe
+        ./outputs/runtime/"%CONFIG%"/ex_cxx_tuple.exe
         if ($env:BUILD_C -eq "ON") {
-          ./outputs/runtime/%CONFIG%/ex_c_minimal.exe
-          ./outputs/runtime/%CONFIG%/ex_c_minimal_library.exe
-          ./outputs/runtime/%CONFIG%/ex_c_timing.exe
+          ./outputs/runtime/"%CONFIG%"/ex_c_minimal.exe
+          ./outputs/runtime/"%CONFIG%"/ex_c_minimal_library.exe
+          ./outputs/runtime/"%CONFIG%"/ex_c_timing.exe
         }
       }
   - ps: |

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -309,7 +309,6 @@ if(TIMEMORY_BUILD_EXAMPLES)
 elseif(TIMEMORY_USE_PYTHON AND TIMEMORY_CI)
     message(STATUS "Adding examples/ex-python...")
     # copies over some python scripts
-    add_subdirectory(examples/ex-python)
     function(CONFIGURE_PYTHON_SCRIPT)
         foreach(_TYPE ${ARGN})
             set(FILENAME ex_python_${_TYPE})

--- a/source/timemory/components/timing/types.hpp
+++ b/source/timemory/components/timing/types.hpp
@@ -81,19 +81,6 @@ TIMEMORY_SET_COMPONENT_API(component::thread_cpu_util, project::timemory,
 //
 //--------------------------------------------------------------------------------------//
 //
-//                              AVAILABLE
-//
-//--------------------------------------------------------------------------------------//
-//
-#if defined(_WINDOWS)
-TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::thread_cpu_clock, false_type)
-TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::process_cpu_clock, false_type)
-TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::thread_cpu_util, false_type)
-TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::process_cpu_util, false_type)
-#endif
-//
-//--------------------------------------------------------------------------------------//
-//
 //                              STATISTICS
 //
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/operations/types/serialization.hpp
+++ b/source/timemory/operations/types/serialization.hpp
@@ -68,8 +68,14 @@ struct serialization
         try_catch("is_transient", obj.get_is_transient());
         try_catch("laps", obj.get_laps());
         try_catch("value", obj.get_value());
-        try_catch("accum", obj.get_accum());
-        try_catch("last", obj.get_last());
+        IF_CONSTEXPR(trait::base_has_accum<Tp>::value)
+        {
+            try_catch("accum", obj.get_accum());
+        }
+        IF_CONSTEXPR(trait::base_has_last<Tp>::value)
+        {
+            try_catch("last", obj.get_last());
+        }
         try_catch("repr_data", obj.get());
         try_catch("repr_display", obj.get_display());
         // try_catch("units", type::get_unit());


### PR DESCRIPTION
- adds support for thread-specific CPU clock times and process-specific CPU clock times in Windows.
- thus `thread_cpu_clock`, `thread_cpu_util`, `process_cpu_clock`, and `process_cpu_util` components are now available on Windows

Windows, as per usual, doesn't make this stuff easy...

```cpp
template <typename Tp = double, typename Precision = std::ratio<1>>
TIMEMORY_HOT_INLINE Tp
get_clock_thread_now() noexcept
{
    auto _get_thr_time = [](const FILETIME& kernel_time,
                            const FILETIME& user_time) -> Tp {
        // values are provided in 100 ns units
        constexpr Tp   factor = Precision::den / static_cast<Tp>(std::nano::den / 100);
        ULARGE_INTEGER kernel;
        ULARGE_INTEGER user;
        kernel.HighPart = kernel_time.dwHighDateTime;
        kernel.LowPart  = kernel_time.dwLowDateTime;
        user.HighPart   = user_time.dwHighDateTime;
        user.LowPart    = user_time.dwLowDateTime;
        return (kernel.QuadPart + user.QuadPart) * factor;
    };
    HANDLE   this_thread = GetCurrentThread();
    FILETIME creation_time;
    FILETIME exit_time;
    FILETIME kernel_time;
    FILETIME user_time;
    GetThreadTimes(this_thread, &creation_time, &exit_time, &kernel_time, &user_time);
    return _get_thr_time(kernel_time, user_time);
}
```

@pwm1234-sri You may find this useful.