### PR TITLE
Miscellanous fixes prior to adding support for CUDA PC Sampling

### DIFF
--- a/cmake/Modules/FindCUPTI.cmake
+++ b/cmake/Modules/FindCUPTI.cmake
@@ -16,6 +16,35 @@ find_path(CUPTI_ROOT_DIR
     PATHS           ${_CUDA_PATHS}
     PATH_SUFFIXES   extras/CUPTI)
 
+find_file(CUPTI_nvperf_host_HEADER
+    NAMES           nvperf_host.h
+    HINTS           ${_CUDA_PATHS}
+    PATHS           ${_CUDA_PATHS}
+    PATH_SUFFIXES   include include/extras/CUPTI)
+
+find_file(CUPTI_nvperf_target_HEADER
+    NAMES           nvperf_target.h
+    HINTS           ${_CUDA_PATHS}
+    PATHS           ${_CUDA_PATHS}
+    PATH_SUFFIXES   include include/extras/CUPTI)
+
+find_file(CUPTI_pcsampling_HEADER
+    NAMES           cupti_pcsampling.h
+    HINTS           ${_CUDA_PATHS}
+    PATHS           ${_CUDA_PATHS}
+    PATH_SUFFIXES   include include/extras/CUPTI)
+
+find_file(CUPTI_pcsampling_util_HEADER
+    NAMES           cupti_pcsampling_util.h
+    HINTS           ${_CUDA_PATHS}
+    PATHS           ${_CUDA_PATHS}
+    PATH_SUFFIXES   include include/extras/CUPTI)
+
+mark_as_advanced(CUPTI_ROOT_DIR
+    CUPTI_nvperf_host_HEADER
+    CUPTI_nvperf_target_HEADER
+    CUPTI_pcsampling_HEADER)
+
 #----------------------------------------------------------------------------------------#
 
 # try to find cupti header
@@ -24,6 +53,8 @@ find_path(CUPTI_INCLUDE_DIR
     HINTS           ${CUPTI_ROOT_DIR} ${_CUDA_INC} ${_CUDA_PATHS}
     PATHS           ${CUPTI_ROOT_DIR} ${_CUDA_INC} ${_CUDA_PATHS}
     PATH_SUFFIXES   extras/CUPTI/include extras/CUPTI extras/include CUTPI/include include)
+
+mark_as_advanced(CUPTI_INCLUDE_DIR)
 
 #----------------------------------------------------------------------------------------#
 
@@ -38,6 +69,8 @@ if(CUPTI_cupti_LIBRARY)
     get_filename_component(CUPTI_cupti_LIBRARY_DIR "${CUPTI_cupti_LIBRARY}" PATH CACHE)
 endif()
 
+mark_as_advanced(CUPTI_cupti_LIBRARY)
+
 #----------------------------------------------------------------------------------------#
 
 # try to find nvperf_host library
@@ -46,6 +79,8 @@ find_library(CUPTI_nvperf_host_LIBRARY
     HINTS           ${CUPTI_ROOT_DIR} ${_CUDA_PATHS}
     PATHS           ${CUPTI_ROOT_DIR} ${_CUDA_PATHS}
     PATH_SUFFIXES   lib lib64 lib/nvidia lib64/nvidia nvidia)
+
+mark_as_advanced(CUPTI_nvperf_host_LIBRARY)
 
 #----------------------------------------------------------------------------------------#
 
@@ -56,6 +91,8 @@ find_library(CUPTI_nvperf_host_STATIC_LIBRARY
     PATHS           ${CUPTI_ROOT_DIR} ${_CUDA_PATHS}
     PATH_SUFFIXES   lib lib64 lib/nvidia lib64/nvidia nvidia)
 
+mark_as_advanced(CUPTI_nvperf_host_STATIC_LIBRARY)
+
 #----------------------------------------------------------------------------------------#
 
 # try to find nvperf_target library
@@ -65,6 +102,19 @@ find_library(CUPTI_nvperf_target_LIBRARY
     PATHS           ${CUPTI_ROOT_DIR} ${_CUDA_PATHS}
     PATH_SUFFIXES   lib lib64 lib/nvidia lib64/nvidia nvidia)
 
+mark_as_advanced(CUPTI_nvperf_target_LIBRARY)
+
+#----------------------------------------------------------------------------------------#
+
+# try to find pc sampling utility library
+find_library(CUPTI_pcsampling_util_LIBRARY
+    NAMES           pcsamplingutil
+    HINTS           ${CUPTI_ROOT_DIR} ${_CUDA_PATHS}
+    PATHS           ${CUPTI_ROOT_DIR} ${_CUDA_PATHS}
+    PATH_SUFFIXES   lib lib64 lib/nvidia lib64/nvidia nvidia)
+
+mark_as_advanced(CUPTI_pcsamplingutil_LIBRARY)
+
 #----------------------------------------------------------------------------------------#
 
 # try to find cuda driver library
@@ -73,6 +123,8 @@ find_library(CUPTI_cuda_LIBRARY
     HINTS           ${CUPTI_ROOT_DIR} ${_CUDA_PATHS}
     PATHS           ${CUPTI_ROOT_DIR} ${_CUDA_PATHS}
     PATH_SUFFIXES   lib lib64 lib/nvidia lib64/nvidia nvidia)
+
+mark_as_advanced(CUPTI_cuda_LIBRARY)
 
 #----------------------------------------------------------------------------------------#
 
@@ -90,14 +142,6 @@ endif()
 
 #------------------------------------------------------------------------------#
 
-mark_as_advanced(
-    CUPTI_INCLUDE_DIR
-    CUPTI_cupti_LIBRARY_DIR
-    CUPTI_cupti_LIBRARY
-    CUPTI_cuda_LIBRARY)
-
-#------------------------------------------------------------------------------#
-
 find_package_handle_standard_args(CUPTI DEFAULT_MSG
     CUPTI_INCLUDE_DIR
     CUPTI_cupti_LIBRARY
@@ -110,18 +154,16 @@ if(CUPTI_FOUND)
     set(CUPTI_INCLUDE_DIRS ${CUPTI_INCLUDE_DIR})
     set(CUPTI_LIBRARIES ${CUPTI_cupti_LIBRARY} ${CUPTI_cuda_LIBRARY})
     set(CUPTI_LIBRARY_DIRS ${CUPTI_cupti_LIBRARY_DIR})
-endif()
 
-#------------------------------------------------------------------------------#
-
-if(CUPTI_nvperf_host_LIBRARY)
-    list(APPEND CUPTI_LIBRARIES ${CUPTI_nvperf_host_LIBRARY})
-endif()
-
-#------------------------------------------------------------------------------#
-
-if(CUPTI_nvperf_target_LIBRARY)
-    list(APPEND CUPTI_LIBRARIES ${CUPTI_nvperf_target_LIBRARY})
+    foreach(_COMP nvperf_host nvperf_target pcsampling pcsampling_util)
+        set(CUPTI_${_COMP}_FOUND OFF)
+        if(NOT DEFINED CUPTI_${_COMP}_LIBRARY AND CUPTI_${_COMP}_HEADER)
+            set(CUPTI_${_COMP}_FOUND ON)
+        elseif(CUPTI_${_COMP}_LIBRARY AND CUPTI_${_COMP}_HEADER)
+            set(CUPTI_${_COMP}_FOUND ON)
+            list(APPEND CUPTI_LIBRARIES ${CUPTI_${_COMP}_LIBRARY})
+        endif()
+    endforeach()
 endif()
 
 #------------------------------------------------------------------------------#

--- a/cmake/Modules/Packages.cmake
+++ b/cmake/Modules/Packages.cmake
@@ -815,14 +815,24 @@ if(CUPTI_FOUND)
         INTERFACE_INSTALL_RPATH                 ""
         INTERFACE_INSTALL_RPATH_USE_LINK_PATH   ${HAS_CUDA_DRIVER_LIBRARY})
 
-    if(CUPTI_nvperf_host_LIBRARY AND CUPTI_nvperf_target_LIBRARY)
+    if(CUPTI_nvperf_host_FOUND AND CUPTI_nvperf_target_FOUND)
         timemory_target_compile_definitions(timemory-cupti INTERFACE
             TIMEMORY_USE_CUPTI_NVPERF)
-        add_rpath(${CUPTI_cupti_LIBRARY} ${CUPTI_nvperf_host_LIBRARY}
-            ${CUPTI_nvperf_target_LIBRARY})
-    else()
-        add_rpath(${CUPTI_cupti_LIBRARY})
+        add_rpath(${CUPTI_nvperf_host_LIBRARY} ${CUPTI_nvperf_target_LIBRARY})
     endif()
+
+    if(CUPTI_pcsampling_FOUND)
+        timemory_target_compile_definitions(timemory-cupti INTERFACE
+            TIMEMORY_USE_CUPTI_PCSAMPLING)
+    endif()
+
+    if(CUPTI_pcsampling_util_FOUND)
+        timemory_target_compile_definitions(timemory-cupti INTERFACE
+            TIMEMORY_USE_CUPTI_PCSAMPLING_UTIL)
+        add_rpath(${CUPTI_pcsampling_util_LIBRARY})
+    endif()
+
+    add_rpath(${CUPTI_cupti_LIBRARY})
 
 else()
     set(TIMEMORY_USE_CUPTI OFF)

--- a/source/timemory/operations/types/decode.hpp
+++ b/source/timemory/operations/types/decode.hpp
@@ -49,26 +49,36 @@ struct decode
 {
     TIMEMORY_DEFAULT_OBJECT(decode)
 
+    static auto tokenized_demangle(std::string inp)
+    {
+        using pair_t = std::pair<std::string, std::string>;
+        for(auto&& itr : { pair_t{ "_Z", " " }, pair_t{ " ", " " } })
+            inp = str_transform(inp, itr.first, itr.second,
+                                [](const std::string& _s) { return demangle(_s); });
+        return inp;
+    }
+
     auto operator()(const char* inp)
     {
-        return demangle_backtrace(demangle_hash_identifier(inp));
+        return tokenized_demangle(demangle_backtrace(demangle_hash_identifier(inp)));
     }
 
     auto operator()(const std::string& inp)
     {
-        return demangle_backtrace(demangle_hash_identifier(inp));
+        return tokenized_demangle(demangle_backtrace(demangle_hash_identifier(inp)));
     }
 
     auto operator()(const graph_hash_map_ptr_t&   _hash_map,
                     const graph_hash_alias_ptr_t& _hash_alias, hash_value_type _hash_id)
     {
-        return demangle_hash_identifier(
-            get_hash_identifier(_hash_map, _hash_alias, _hash_id));
+        return tokenized_demangle(demangle_hash_identifier(
+            get_hash_identifier(_hash_map, _hash_alias, _hash_id)));
     }
 
     auto operator()(hash_value_type _hash_id)
     {
-        return demangle_hash_identifier(get_hash_identifier(_hash_id));
+        return tokenized_demangle(
+            demangle_hash_identifier(get_hash_identifier(_hash_id)));
     }
 };
 //

--- a/source/timemory/operations/types/print.hpp
+++ b/source/timemory/operations/types/print.hpp
@@ -125,7 +125,7 @@ struct print
             if(trait::report<type>::count())
                 utility::write_entry(_os, "COUNT", " ");
             if(trait::report<type>::depth())
-                utility::write_entry(_os, "DEPTH", " ");
+                utility::write_entry(_os, "DEPTH", _depth);
             if(trait::report<type>::metric())
                 utility::write_entry(_os, "METRIC", _empty_data);
             if(trait::report<type>::units())

--- a/source/timemory/operations/types/print.hpp
+++ b/source/timemory/operations/types/print.hpp
@@ -121,18 +121,19 @@ struct print
         }
         else
         {
+            std::vector<std::string> _empty_data(_labels.size(), " ");
             if(trait::report<type>::count())
                 utility::write_entry(_os, "COUNT", " ");
             if(trait::report<type>::depth())
                 utility::write_entry(_os, "DEPTH", " ");
             if(trait::report<type>::metric())
-                utility::write_entry(_os, "METRIC", " ");
+                utility::write_entry(_os, "METRIC", _empty_data);
             if(trait::report<type>::units())
-                utility::write_entry(_os, "UNITS", " ");
+                utility::write_entry(_os, "UNITS", _empty_data);
             if(trait::report<type>::sum())
-                utility::write_entry(_os, "SUM", " ");
+                utility::write_entry(_os, "SUM", _empty_data);
             if(trait::report<type>::mean())
-                utility::write_entry(_os, "MEAN", " ");
+                utility::write_entry(_os, "MEAN", _empty_data);
             if(trait::report<type>::stats())
             {
                 bool use_min    = get_env<bool>("TIMEMORY_PRINT_MIN", true);
@@ -141,16 +142,16 @@ struct print
                 bool use_stddev = get_env<bool>("TIMEMORY_PRINT_STDDEV", true);
 
                 if(use_min)
-                    utility::write_entry(_os, "MIN", " ");
+                    utility::write_entry(_os, "MIN", _empty_data);
                 if(use_max)
-                    utility::write_entry(_os, "MAX", " ");
+                    utility::write_entry(_os, "MAX", _empty_data);
                 if(use_var)
-                    utility::write_entry(_os, "VAR", " ");
+                    utility::write_entry(_os, "VAR", _empty_data);
                 if(use_stddev)
-                    utility::write_entry(_os, "STDDEV", " ");
+                    utility::write_entry(_os, "STDDEV", _empty_data);
             }
             if(trait::report<type>::self())
-                utility::write_entry(_os, "% SELF", " ");
+                utility::write_entry(_os, "% SELF", _empty_data);
         }
     }
 

--- a/source/timemory/utility/types.hpp
+++ b/source/timemory/utility/types.hpp
@@ -128,6 +128,14 @@
 
 //======================================================================================//
 //
+#if !defined(TIMEMORY_TUPLE_ACCESSOR)
+#    define TIMEMORY_TUPLE_ACCESSOR(INDEX, TUPLE, NAME)                                  \
+        auto& NAME() { return std::get<INDEX>(TUPLE); }                                  \
+        const auto& NAME() const { return std::get<INDEX>(TUPLE); }
+#endif
+
+//======================================================================================//
+//
 namespace tim
 {
 //

--- a/source/timemory/utility/utility.hpp
+++ b/source/timemory/utility/utility.hpp
@@ -607,6 +607,55 @@ delimit(const std::string& line, const std::string& delimiters = "\"',;: ",
     return _result;
 }
 
+//
+//--------------------------------------------------------------------------------------//
+///  \brief apply a string transformation to substring inbetween a common delimiter.
+///  e.g.
+//
+template <typename PredicateT = std::function<std::string(const std::string&)>>
+inline std::string
+str_transform(const std::string& input, const std::string& _begin, const std::string& _end,
+              PredicateT&& predicate)
+{
+    size_t      _beg_pos = 0;  // position that is the beginning of the new string
+    size_t      _end_pos = 0;  // position of the delimiter in the string
+    std::string _result  = input;
+    while(_beg_pos < _result.length() && _end_pos < _result.length())
+    {
+        // find the first sequence of characters after the end-position
+        _beg_pos = _result.find(_begin, _end_pos);
+
+        // if sequence wasn't found, we are done
+        if(_beg_pos == std::string::npos)
+            break;
+
+        // starting after the position of the first delimiter, find the end sequence
+        _end_pos = _result.find(_end, _beg_pos + 1);
+
+        // break if not found
+        if(_end_pos == std::string::npos)
+            break;
+
+        // length of the substr being operated on
+        auto _len = _end_pos - _beg_pos;
+
+        // get the substring between the two delimiters (including first delimiter)
+        auto _sub = _result.substr(_beg_pos, _len);
+
+        // apply the transform
+        auto _transformed = predicate(_sub);
+
+        // only replace if necessary
+        if(_sub != _transformed)
+        {
+            _result = _result.replace(_beg_pos, _len, _transformed);
+            // move end to the end of transformed string
+            _end_pos = _beg_pos + _transformed.length();
+        }
+    }
+    return _result;
+}
+
 //--------------------------------------------------------------------------------------//
 //
 inline std::vector<std::string>


### PR DESCRIPTION
- Updates to FindCupti.cmake
- Fix to `operation::print` when `laps == 0` and data is multi-dimensional
- Added support for Ampere arch flag
- `operation::decode` now does a better job of automatically demangling string identifiers when printing
  - this avoids having to demangle during data collection