### PR TITLE
Updated TIMEMORY_PROPERTY_SPECIALIZATIONs to use TIMEMORY_ prefixed enums

### DIFF
--- a/source/timemory/components/allinea/types.hpp
+++ b/source/timemory/components/allinea/types.hpp
@@ -50,7 +50,7 @@ TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::allinea_map, false_type)
 //
 //--------------------------------------------------------------------------------------//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(allinea_map, ALLINEA_MAP, "allinea_map", "allinea",
-                                 "forge")
+TIMEMORY_PROPERTY_SPECIALIZATION(allinea_map, TIMEMORY_ALLINEA_MAP, "allinea_map",
+                                 "allinea", "forge")
 //
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/components/caliper/types.hpp
+++ b/source/timemory/components/caliper/types.hpp
@@ -62,10 +62,11 @@ TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::caliper_loop_marker, fal
 //
 //--------------------------------------------------------------------------------------//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(caliper_marker, CALIPER_MARKER, "caliper_marker",
-                                 "caliper", "cali")
-TIMEMORY_PROPERTY_SPECIALIZATION(caliper_config, CALIPER_CONFIG, "caliper_config", "")
-TIMEMORY_PROPERTY_SPECIALIZATION(caliper_loop_marker, CALIPER_LOOP_MARKER,
+TIMEMORY_PROPERTY_SPECIALIZATION(caliper_marker, TIMEMORY_CALIPER_MARKER,
+                                 "caliper_marker", "caliper", "cali")
+TIMEMORY_PROPERTY_SPECIALIZATION(caliper_config, TIMEMORY_CALIPER_CONFIG,
+                                 "caliper_config", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(caliper_loop_marker, TIMEMORY_CALIPER_LOOP_MARKER,
                                  "caliper_loop_marker", "")
 //
 //======================================================================================//

--- a/source/timemory/components/craypat/types.hpp
+++ b/source/timemory/components/craypat/types.hpp
@@ -90,13 +90,15 @@ TIMEMORY_DEFINE_CONCRETE_TRAIT(is_available, component::craypat_flush_buffer, fa
 //
 //--------------------------------------------------------------------------------------//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(craypat_record, CRAYPAT_RECORD, "craypat_record", "")
-TIMEMORY_PROPERTY_SPECIALIZATION(craypat_region, CRAYPAT_REGION, "craypat_region", "")
-TIMEMORY_PROPERTY_SPECIALIZATION(craypat_counters, CRAYPAT_COUNTERS, "craypat_counters",
-                                 "")
-TIMEMORY_PROPERTY_SPECIALIZATION(craypat_heap_stats, CRAYPAT_HEAP_STATS,
+TIMEMORY_PROPERTY_SPECIALIZATION(craypat_record, TIMEMORY_CRAYPAT_RECORD,
+                                 "craypat_record", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(craypat_region, TIMEMORY_CRAYPAT_REGION,
+                                 "craypat_region", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(craypat_counters, TIMEMORY_CRAYPAT_COUNTERS,
+                                 "craypat_counters", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(craypat_heap_stats, TIMEMORY_CRAYPAT_HEAP_STATS,
                                  "craypat_heap_stats", "")
-TIMEMORY_PROPERTY_SPECIALIZATION(craypat_flush_buffer, CRAYPAT_FLUSH_BUFFER,
+TIMEMORY_PROPERTY_SPECIALIZATION(craypat_flush_buffer, TIMEMORY_CRAYPAT_FLUSH_BUFFER,
                                  "craypat_flush_buffer", "")
 //
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/components/cuda/types.hpp
+++ b/source/timemory/components/cuda/types.hpp
@@ -239,8 +239,9 @@ struct python_args<TIMEMORY_MARK_END, component::cuda_event>
 //
 //======================================================================================//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(cuda_event, CUDA_EVENT, "cuda_event", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(cuda_event, TIMEMORY_CUDA_EVENT, "cuda_event", "")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(cuda_profiler, CUDA_PROFILER, "cuda_profiler", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(cuda_profiler, TIMEMORY_CUDA_PROFILER, "cuda_profiler",
+                                 "")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(nvtx_marker, NVTX_MARKER, "nvtx_marker", "nvtx")
+TIMEMORY_PROPERTY_SPECIALIZATION(nvtx_marker, TIMEMORY_NVTX_MARKER, "nvtx_marker", "nvtx")

--- a/source/timemory/components/cupti/types.hpp
+++ b/source/timemory/components/cupti/types.hpp
@@ -145,8 +145,11 @@ TIMEMORY_DEFINE_CONCRETE_TRAIT(custom_serialization, component::cupti_profiler, 
 //
 //======================================================================================//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(cupti_activity, CUPTI_ACTIVITY, "cupti_activity", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(cupti_activity, TIMEMORY_CUPTI_ACTIVITY,
+                                 "cupti_activity", "")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(cupti_counters, CUPTI_COUNTERS, "cupti_counters", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(cupti_counters, TIMEMORY_CUPTI_COUNTERS,
+                                 "cupti_counters", "")
 //
-// TIMEMORY_PROPERTY_SPECIALIZATION(cupti_profiler, CUPTI_PROFILER, "cupti_profiler", "")
+// TIMEMORY_PROPERTY_SPECIALIZATION(cupti_profiler, TIMEMORY_CUPTI_PROFILER,
+// "cupti_profiler", "")

--- a/source/timemory/components/data_tracker/types.hpp
+++ b/source/timemory/components/data_tracker/types.hpp
@@ -132,11 +132,11 @@ struct python_args<TIMEMORY_RECORD, component::data_tracker_floating>
 //
 //--------------------------------------------------------------------------------------//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(data_tracker_integer, DATA_TRACKER_INTEGER,
+TIMEMORY_PROPERTY_SPECIALIZATION(data_tracker_integer, TIMEMORY_DATA_TRACKER_INTEGER,
                                  "data_tracker_integer", "integer_data_tracker")
-TIMEMORY_PROPERTY_SPECIALIZATION(data_tracker_unsigned, DATA_TRACKER_UNSIGNED,
+TIMEMORY_PROPERTY_SPECIALIZATION(data_tracker_unsigned, TIMEMORY_DATA_TRACKER_UNSIGNED,
                                  "data_tracker_unsigned", "unsigned_data_tracker")
-TIMEMORY_PROPERTY_SPECIALIZATION(data_tracker_floating, DATA_TRACKER_FLOATING,
+TIMEMORY_PROPERTY_SPECIALIZATION(data_tracker_floating, TIMEMORY_DATA_TRACKER_FLOATING,
                                  "data_tracker_floating", "floating_data_tracker")
 //
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/components/gotcha/types.hpp
+++ b/source/timemory/components/gotcha/types.hpp
@@ -164,9 +164,10 @@ struct has_gotcha<Tuple<T...>>
 //
 //======================================================================================//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(malloc_gotcha, MALLOC_GOTCHA, "malloc_gotcha", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(malloc_gotcha, TIMEMORY_MALLOC_GOTCHA, "malloc_gotcha",
+                                 "")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(memory_allocations, MEMORY_ALLOCATIONS,
+TIMEMORY_PROPERTY_SPECIALIZATION(memory_allocations, TIMEMORY_MEMORY_ALLOCATIONS,
                                  "memory_allocations", "")
 //
 //======================================================================================//

--- a/source/timemory/components/gperftools/types.hpp
+++ b/source/timemory/components/gperftools/types.hpp
@@ -102,10 +102,12 @@ TIMEMORY_DEFINE_CONCRETE_TRAIT(requires_prefix, component::gperftools_heap_profi
 //
 //======================================================================================//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(gperftools_cpu_profiler, GPERFTOOLS_CPU_PROFILER,
+TIMEMORY_PROPERTY_SPECIALIZATION(gperftools_cpu_profiler,
+                                 TIMEMORY_GPERFTOOLS_CPU_PROFILER,
                                  "gperftools_cpu_profiler", "gperf_cpu_profiler",
                                  "gperf_cpu", "gperftools-cpu")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(gperftools_heap_profiler, GPERFTOOLS_HEAP_PROFILER,
+TIMEMORY_PROPERTY_SPECIALIZATION(gperftools_heap_profiler,
+                                 TIMEMORY_GPERFTOOLS_HEAP_PROFILER,
                                  "gperftools_heap_profiler", "gperf_heap_profiler",
                                  "gperf_heap", "gperftools-heap")

--- a/source/timemory/components/io/types.hpp
+++ b/source/timemory/components/io/types.hpp
@@ -246,9 +246,9 @@ struct units<component::written_bytes>
 }  // namespace trait
 }  // namespace tim
 
-TIMEMORY_PROPERTY_SPECIALIZATION(read_char, READ_CHAR, "read_char", "rchar")
-TIMEMORY_PROPERTY_SPECIALIZATION(written_char, WRITTEN_CHAR, "written_char", "write_char",
-                                 "wchar")
-TIMEMORY_PROPERTY_SPECIALIZATION(read_bytes, READ_BYTES, "read_bytes", "")
-TIMEMORY_PROPERTY_SPECIALIZATION(written_bytes, WRITTEN_BYTES, "written_bytes",
+TIMEMORY_PROPERTY_SPECIALIZATION(read_char, TIMEMORY_READ_CHAR, "read_char", "rchar")
+TIMEMORY_PROPERTY_SPECIALIZATION(written_char, TIMEMORY_WRITTEN_CHAR, "written_char",
+                                 "write_char", "wchar")
+TIMEMORY_PROPERTY_SPECIALIZATION(read_bytes, TIMEMORY_READ_BYTES, "read_bytes", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(written_bytes, TIMEMORY_WRITTEN_BYTES, "written_bytes",
                                  "write_bytes")

--- a/source/timemory/components/likwid/types.hpp
+++ b/source/timemory/components/likwid/types.hpp
@@ -124,11 +124,11 @@ TIMEMORY_DEFINE_CONCRETE_TRAIT(requires_prefix, component::likwid_nvmarker, true
 //
 //======================================================================================//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(likwid_marker, LIKWID_MARKER, "likwid_marker",
+TIMEMORY_PROPERTY_SPECIALIZATION(likwid_marker, TIMEMORY_LIKWID_MARKER, "likwid_marker",
                                  "likwid_perfmon_marker")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(likwid_nvmarker, LIKWID_NVMARKER, "likwid_nvmarker",
-                                 "likwid_nvmon_marker")
+TIMEMORY_PROPERTY_SPECIALIZATION(likwid_nvmarker, TIMEMORY_LIKWID_NVMARKER,
+                                 "likwid_nvmarker", "likwid_nvmon_marker")
 //
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/components/macros.hpp
+++ b/source/timemory/components/macros.hpp
@@ -231,9 +231,13 @@
             using type                        = TYPE;                                    \
             using value_type                  = TIMEMORY_COMPONENT;                      \
             static constexpr value_type value = ENUM;                                    \
-            static const char*          enum_string() { return #ENUM; }                  \
-            static const char*          id() { return ID; }                              \
-            static const idset_t&       ids()                                            \
+            static const char*          enum_string()                                    \
+            {                                                                            \
+                static const char* _enum = #ENUM;                                        \
+                return static_cast<const char*>(&_enum[9]);                              \
+            }                                                                            \
+            static const char*    id() { return ID; }                                    \
+            static const idset_t& ids()                                                  \
             {                                                                            \
                 static auto _instance = []() {                                           \
                     auto _val = idset_t{ ID, __VA_ARGS__ };                              \

--- a/source/timemory/components/ompt/types.hpp
+++ b/source/timemory/components/ompt/types.hpp
@@ -114,8 +114,9 @@ struct is_available<component::ompt_native_data_tracker> : false_type
 //
 //--------------------------------------------------------------------------------------//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(ompt_handle<TIMEMORY_API>, OMPT_HANDLE, "ompt_handle",
-                                 "ompt", "ompt_handle", "openmp", "openmp_tools")
+TIMEMORY_PROPERTY_SPECIALIZATION(ompt_handle<TIMEMORY_API>, TIMEMORY_OMPT_HANDLE,
+                                 "ompt_handle", "ompt", "ompt_handle", "openmp",
+                                 "openmp_tools")
 //
 //======================================================================================//
 //

--- a/source/timemory/components/papi/types.hpp
+++ b/source/timemory/components/papi/types.hpp
@@ -171,5 +171,6 @@ struct base_has_accum<component::papi_rate_tuple<RateT, EventTypes...>> : false_
 //
 //--------------------------------------------------------------------------------------//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(papi_vector, PAPI_VECTOR, "papi_vector", "papi")
-TIMEMORY_PROPERTY_SPECIALIZATION(papi_array_t, PAPI_ARRAY, "papi_array_t", "papi_array")
+TIMEMORY_PROPERTY_SPECIALIZATION(papi_vector, TIMEMORY_PAPI_VECTOR, "papi_vector", "papi")
+TIMEMORY_PROPERTY_SPECIALIZATION(papi_array_t, TIMEMORY_PAPI_ARRAY, "papi_array_t",
+                                 "papi_array")

--- a/source/timemory/components/properties.hpp
+++ b/source/timemory/components/properties.hpp
@@ -201,8 +201,8 @@ struct static_properties<Tp, true>
 /// A macro is provides to simplify this specialization:
 ///
 /// \code{.cpp}
-/// TIMEMORY_PROPERTY_SPECIALIZATION(wall_clock, WALL_CLOCK, "wall_clock", "real_clock",
-///                                 "virtual_clock")
+/// TIMEMORY_PROPERTY_SPECIALIZATION(wall_clock, TIMEMORY_WALL_CLOCK, "wall_clock",
+///                                  "real_clock", "virtual_clock")
 /// \endcode
 ///
 /// In the above, the first parameter is the C++ type, the second is the enumeration

--- a/source/timemory/components/roofline/types.hpp
+++ b/source/timemory/components/roofline/types.hpp
@@ -249,29 +249,29 @@ struct units<component::cpu_roofline<Types...>>
 //
 //======================================================================================//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(cpu_roofline_dp_flops, CPU_ROOFLINE_DP_FLOPS,
+TIMEMORY_PROPERTY_SPECIALIZATION(cpu_roofline_dp_flops, TIMEMORY_CPU_ROOFLINE_DP_FLOPS,
                                  "cpu_roofline_dp_flops", "cpu_roofline_dp",
                                  "cpu_roofline_double")
 
-TIMEMORY_PROPERTY_SPECIALIZATION(cpu_roofline_flops, CPU_ROOFLINE_FLOPS,
+TIMEMORY_PROPERTY_SPECIALIZATION(cpu_roofline_flops, TIMEMORY_CPU_ROOFLINE_FLOPS,
                                  "cpu_roofline_flops", "cpu_roofline")
 
-TIMEMORY_PROPERTY_SPECIALIZATION(cpu_roofline_sp_flops, CPU_ROOFLINE_SP_FLOPS,
+TIMEMORY_PROPERTY_SPECIALIZATION(cpu_roofline_sp_flops, TIMEMORY_CPU_ROOFLINE_SP_FLOPS,
                                  "cpu_roofline_sp_flops", "cpu_roofline_sp",
                                  "cpu_roofline_single")
 
-TIMEMORY_PROPERTY_SPECIALIZATION(gpu_roofline_dp_flops, GPU_ROOFLINE_DP_FLOPS,
+TIMEMORY_PROPERTY_SPECIALIZATION(gpu_roofline_dp_flops, TIMEMORY_GPU_ROOFLINE_DP_FLOPS,
                                  "gpu_roofline_dp_flops", "gpu_roofline_dp",
                                  "gpu_roofline_double")
 
-TIMEMORY_PROPERTY_SPECIALIZATION(gpu_roofline_flops, GPU_ROOFLINE_FLOPS,
+TIMEMORY_PROPERTY_SPECIALIZATION(gpu_roofline_flops, TIMEMORY_GPU_ROOFLINE_FLOPS,
                                  "gpu_roofline_flops", "gpu_roofline")
 
-TIMEMORY_PROPERTY_SPECIALIZATION(gpu_roofline_hp_flops, GPU_ROOFLINE_HP_FLOPS,
+TIMEMORY_PROPERTY_SPECIALIZATION(gpu_roofline_hp_flops, TIMEMORY_GPU_ROOFLINE_HP_FLOPS,
                                  "gpu_roofline_hp_flops", "gpu_roofline_hp",
                                  "gpu_roofline_half")
 
-TIMEMORY_PROPERTY_SPECIALIZATION(gpu_roofline_sp_flops, GPU_ROOFLINE_SP_FLOPS,
+TIMEMORY_PROPERTY_SPECIALIZATION(gpu_roofline_sp_flops, TIMEMORY_GPU_ROOFLINE_SP_FLOPS,
                                  "gpu_roofline_sp_flops", "gpu_roofline_sp",
                                  "gpu_roofline_single")
 //

--- a/source/timemory/components/rusage/types.hpp
+++ b/source/timemory/components/rusage/types.hpp
@@ -324,34 +324,38 @@ struct units<component::current_peak_rss>
 
 //======================================================================================//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(peak_rss, PEAK_RSS, "peak_rss", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(peak_rss, TIMEMORY_PEAK_RSS, "peak_rss", "")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(page_rss, PAGE_RSS, "page_rss", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(page_rss, TIMEMORY_PAGE_RSS, "page_rss", "")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(num_io_in, NUM_IO_IN, "num_io_in", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(num_io_in, TIMEMORY_NUM_IO_IN, "num_io_in", "")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(num_io_out, NUM_IO_OUT, "num_io_out", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(num_io_out, TIMEMORY_NUM_IO_OUT, "num_io_out", "")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(num_minor_page_faults, NUM_MINOR_PAGE_FAULTS,
+TIMEMORY_PROPERTY_SPECIALIZATION(num_minor_page_faults, TIMEMORY_NUM_MINOR_PAGE_FAULTS,
                                  "num_minor_page_faults", "minor_page_faults")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(num_major_page_faults, NUM_MAJOR_PAGE_FAULTS,
+TIMEMORY_PROPERTY_SPECIALIZATION(num_major_page_faults, TIMEMORY_NUM_MAJOR_PAGE_FAULTS,
                                  "num_major_page_faults", "major_page_faults")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(voluntary_context_switch, VOLUNTARY_CONTEXT_SWITCH,
+TIMEMORY_PROPERTY_SPECIALIZATION(voluntary_context_switch,
+                                 TIMEMORY_VOLUNTARY_CONTEXT_SWITCH,
                                  "voluntary_context_switch", "vol_ctx_switch")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(priority_context_switch, PRIORITY_CONTEXT_SWITCH,
+TIMEMORY_PROPERTY_SPECIALIZATION(priority_context_switch,
+                                 TIMEMORY_PRIORITY_CONTEXT_SWITCH,
                                  "priority_context_switch", "prio_ctx_switch")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(virtual_memory, VIRTUAL_MEMORY, "virtual_memory", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(virtual_memory, TIMEMORY_VIRTUAL_MEMORY,
+                                 "virtual_memory", "")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(user_mode_time, USER_MODE_TIME, "user_mode_time", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(user_mode_time, TIMEMORY_USER_MODE_TIME,
+                                 "user_mode_time", "")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(kernel_mode_time, KERNEL_MODE_TIME, "kernel_mode_time",
-                                 "")
+TIMEMORY_PROPERTY_SPECIALIZATION(kernel_mode_time, TIMEMORY_KERNEL_MODE_TIME,
+                                 "kernel_mode_time", "")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(current_peak_rss, CURRENT_PEAK_RSS, "current_peak_rss",
-                                 "")
+TIMEMORY_PROPERTY_SPECIALIZATION(current_peak_rss, TIMEMORY_CURRENT_PEAK_RSS,
+                                 "current_peak_rss", "")
 //
 //======================================================================================//

--- a/source/timemory/components/tau_marker/types.hpp
+++ b/source/timemory/components/tau_marker/types.hpp
@@ -60,4 +60,4 @@ TIMEMORY_DEFINE_CONCRETE_TRAIT(requires_prefix, component::tau_marker, true_type
 //
 //======================================================================================//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(tau_marker, TAU_MARKER, "tau_marker", "tau")
+TIMEMORY_PROPERTY_SPECIALIZATION(tau_marker, TIMEMORY_TAU_MARKER, "tau_marker", "tau")

--- a/source/timemory/components/timing/types.hpp
+++ b/source/timemory/components/timing/types.hpp
@@ -221,28 +221,31 @@ struct derivation_types<component::thread_cpu_util>
 //
 //======================================================================================//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(wall_clock, WALL_CLOCK, "wall_clock", "real_clock",
-                                 "virtual_clock")
+TIMEMORY_PROPERTY_SPECIALIZATION(wall_clock, TIMEMORY_WALL_CLOCK, "wall_clock",
+                                 "real_clock", "virtual_clock")
 
-TIMEMORY_PROPERTY_SPECIALIZATION(system_clock, SYS_CLOCK, "system_clock", "sys_clock")
+TIMEMORY_PROPERTY_SPECIALIZATION(system_clock, TIMEMORY_SYS_CLOCK, "system_clock",
+                                 "sys_clock")
 
-TIMEMORY_PROPERTY_SPECIALIZATION(user_clock, USER_CLOCK, "user_clock", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(user_clock, TIMEMORY_USER_CLOCK, "user_clock", "")
 
-TIMEMORY_PROPERTY_SPECIALIZATION(cpu_clock, CPU_CLOCK, "cpu_clock", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(cpu_clock, TIMEMORY_CPU_CLOCK, "cpu_clock", "")
 
-TIMEMORY_PROPERTY_SPECIALIZATION(monotonic_clock, MONOTONIC_CLOCK, "monotonic_clock", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(monotonic_clock, TIMEMORY_MONOTONIC_CLOCK,
+                                 "monotonic_clock", "")
 
-TIMEMORY_PROPERTY_SPECIALIZATION(monotonic_raw_clock, MONOTONIC_RAW_CLOCK,
+TIMEMORY_PROPERTY_SPECIALIZATION(monotonic_raw_clock, TIMEMORY_MONOTONIC_RAW_CLOCK,
                                  "monotonic_raw_clock", "")
 
-TIMEMORY_PROPERTY_SPECIALIZATION(thread_cpu_clock, THREAD_CPU_CLOCK, "thread_cpu_clock",
-                                 "")
-TIMEMORY_PROPERTY_SPECIALIZATION(process_cpu_clock, PROCESS_CPU_CLOCK,
+TIMEMORY_PROPERTY_SPECIALIZATION(thread_cpu_clock, TIMEMORY_THREAD_CPU_CLOCK,
+                                 "thread_cpu_clock", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(process_cpu_clock, TIMEMORY_PROCESS_CPU_CLOCK,
                                  "process_cpu_clock", "")
 
-TIMEMORY_PROPERTY_SPECIALIZATION(cpu_util, CPU_UTIL, "cpu_util", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(cpu_util, TIMEMORY_CPU_UTIL, "cpu_util", "")
 
-TIMEMORY_PROPERTY_SPECIALIZATION(process_cpu_util, PROCESS_CPU_UTIL, "process_cpu_util",
-                                 "")
+TIMEMORY_PROPERTY_SPECIALIZATION(process_cpu_util, TIMEMORY_PROCESS_CPU_UTIL,
+                                 "process_cpu_util", "")
 
-TIMEMORY_PROPERTY_SPECIALIZATION(thread_cpu_util, THREAD_CPU_UTIL, "thread_cpu_util", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(thread_cpu_util, TIMEMORY_THREAD_CPU_UTIL,
+                                 "thread_cpu_util", "")

--- a/source/timemory/components/trip_count/types.hpp
+++ b/source/timemory/components/trip_count/types.hpp
@@ -40,4 +40,4 @@ TIMEMORY_DEFINE_CONCRETE_TRAIT(report_mean, component::trip_count, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(report_self, component::trip_count, false_type)
 TIMEMORY_DEFINE_CONCRETE_TRAIT(report_units, component::trip_count, false_type)
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(trip_count, TRIP_COUNT, "trip_count", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(trip_count, TIMEMORY_TRIP_COUNT, "trip_count", "")

--- a/source/timemory/components/user_bundle/types.hpp
+++ b/source/timemory/components/user_bundle/types.hpp
@@ -211,27 +211,27 @@ struct reset<component::user_bundle<Idx, Type>>
 //
 //======================================================================================//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(user_global_bundle, USER_GLOBAL_BUNDLE,
+TIMEMORY_PROPERTY_SPECIALIZATION(user_global_bundle, TIMEMORY_USER_GLOBAL_BUNDLE,
                                  "user_global_bundle", "global_bundle",
                                  "user_tuple_bundle", "tuple_bundle", "user_list_bundle",
                                  "list_bundle")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(user_ompt_bundle, USER_OMPT_BUNDLE, "user_ompt_bundle",
-                                 "ompt_bundle")
+TIMEMORY_PROPERTY_SPECIALIZATION(user_ompt_bundle, TIMEMORY_USER_OMPT_BUNDLE,
+                                 "user_ompt_bundle", "ompt_bundle")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(user_mpip_bundle, USER_MPIP_BUNDLE, "user_mpip_bundle",
-                                 "mpip", "mpi_tools", "mpi")
+TIMEMORY_PROPERTY_SPECIALIZATION(user_mpip_bundle, TIMEMORY_USER_MPIP_BUNDLE,
+                                 "user_mpip_bundle", "mpip", "mpi_tools", "mpi")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(user_ncclp_bundle, USER_NCCLP_BUNDLE,
+TIMEMORY_PROPERTY_SPECIALIZATION(user_ncclp_bundle, TIMEMORY_USER_NCCLP_BUNDLE,
                                  "user_ncclp_bundle", "ncclp", "nccl_tools", "nccl")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(user_trace_bundle, USER_TRACE_BUNDLE,
+TIMEMORY_PROPERTY_SPECIALIZATION(user_trace_bundle, TIMEMORY_USER_TRACE_BUNDLE,
                                  "user_trace_bundle", "trace_bundle")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(user_profiler_bundle, USER_PROFILER_BUNDLE,
+TIMEMORY_PROPERTY_SPECIALIZATION(user_profiler_bundle, TIMEMORY_USER_PROFILER_BUNDLE,
                                  "user_profiler_bundle", "profiler_bundle")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(user_kokkosp_bundle, USER_KOKKOSP_BUNDLE,
+TIMEMORY_PROPERTY_SPECIALIZATION(user_kokkosp_bundle, TIMEMORY_USER_KOKKOSP_BUNDLE,
                                  "user_kokkos_bundle", "kokkos_bundle",
                                  "user_kokkosp_bundle", "kokkosp_bundle")
 //

--- a/source/timemory/components/vtune/types.hpp
+++ b/source/timemory/components/vtune/types.hpp
@@ -72,8 +72,9 @@ TIMEMORY_DEFINE_CONCRETE_TRAIT(requires_prefix, component::vtune_frame, true_typ
 //
 //======================================================================================//
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(vtune_event, VTUNE_EVENT, "vtune_event", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(vtune_event, TIMEMORY_VTUNE_EVENT, "vtune_event", "")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(vtune_frame, VTUNE_FRAME, "vtune_frame", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(vtune_frame, TIMEMORY_VTUNE_FRAME, "vtune_frame", "")
 //
-TIMEMORY_PROPERTY_SPECIALIZATION(vtune_profiler, VTUNE_PROFILER, "vtune_profiler", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(vtune_profiler, TIMEMORY_VTUNE_PROFILER,
+                                 "vtune_profiler", "")

--- a/source/timemory/utility/socket.hpp
+++ b/source/timemory/utility/socket.hpp
@@ -80,7 +80,7 @@ public:
     template <typename CallbackT>
     auto listen(const std::string& _channel_name, int _port, CallbackT&& callback,
                 int64_t _max_packets = 0)
-        -> decltype(callback(_channel_name), listen_info_t())
+        -> decltype(callback(_channel_name), listen_info_t{})
     {
         if(tim::socket::manager::init() != 0)
         {


### PR DESCRIPTION
- `TIMEMORY_PROPERTY_SPECIALIZATION(papi_vector, PAPI_VECTOR, ...)`  --> `TIMEMORY_PROPERTY_SPECIALIZATION(papi_vector, TIMEMORY_PAPI_VECTOR, ...)`
- Backwards compatibility is maintained but using `TIMEMORY_PAPI_VECTOR` instead of `PAPI_VECTOR` ensures that there are no conflicts downstream
