### PR TITLE
Chaining and auto bundler generalization

### DIFF
--- a/docs/api/type_traits.md
+++ b/docs/api/type_traits.md
@@ -23,6 +23,9 @@ user code.
 .. doxygenstruct:: tim::trait::python_args
    :members:
    :undoc-members:
+.. doxygenstruct:: tim::trait::default_runtime_enabled
+   :members:
+   :undoc-members:
 .. doxygenstruct:: tim::trait::runtime_enabled
    :members:
    :undoc-members:

--- a/examples/ex-cxx-overhead/ex_cxx_overhead.cpp
+++ b/examples/ex-cxx-overhead/ex_cxx_overhead.cpp
@@ -58,6 +58,10 @@ struct basic_pointer
 {};
 struct blank_pointer
 {};
+struct invoke
+{};
+struct chained
+{};
 struct measure
 {};
 }  // namespace mode
@@ -92,18 +96,20 @@ fibonacci(int64_t n)
 
 //======================================================================================//
 
-template <typename Tp, tim::enable_if_t<std::is_same<Tp, mode::none>::value, int> = 0>
+template <typename Tp>
 int64_t
-fibonacci(int64_t n, int64_t)
+fibonacci(int64_t n, int64_t,
+          tim::enable_if_t<std::is_same<Tp, mode::none>::value, int> = 0)
 {
     return fibonacci(n);
 }
 
 //======================================================================================//
 
-template <typename Tp, tim::enable_if_t<std::is_same<Tp, mode::measure>::value, int> = 0>
+template <typename Tp>
 int64_t
-fibonacci(int64_t n, int64_t cutoff)
+fibonacci(int64_t n, int64_t cutoff,
+          tim::enable_if_t<std::is_same<Tp, mode::measure>::value, int> = 0)
 {
     if(n > cutoff)
     {
@@ -116,9 +122,10 @@ fibonacci(int64_t n, int64_t cutoff)
 
 //======================================================================================//
 
-template <typename Tp, tim::enable_if_t<std::is_same<Tp, mode::blank>::value, int> = 0>
+template <typename Tp>
 int64_t
-fibonacci(int64_t n, int64_t cutoff)
+fibonacci(int64_t n, int64_t cutoff,
+          tim::enable_if_t<std::is_same<Tp, mode::blank>::value, int> = 0)
 {
     if(n > cutoff)
     {
@@ -131,30 +138,26 @@ fibonacci(int64_t n, int64_t cutoff)
 
 //======================================================================================//
 
-template <typename Tp, tim::enable_if_t<std::is_same<Tp, mode::basic>::value, int> = 0>
+template <typename Tp>
 int64_t
-fibonacci(int64_t n, int64_t cutoff)
+fibonacci(int64_t n, int64_t cutoff,
+          tim::enable_if_t<std::is_same<Tp, mode::basic>::value, int> = 0)
 {
     if(n > cutoff)
     {
-        // TIMEMORY_BASIC_MARKER(auto_tuple_t, "[", n, "]");
-        auto labeler = [](int _n) { return TIMEMORY_JOIN("", "fibonacci[", _n, "]"); };
-        auto fib     = [](int _n, int _cutoff) {
-            return (_n < 2) ? _n
-                            : (fibonacci<Tp>(_n - 1, _cutoff) +
-                               fibonacci<Tp>(_n - 2, _cutoff));
-        };
-        return tim::runtime::invoke<auto_tuple_t>(labeler(n), fib, n, cutoff);
+        TIMEMORY_BASIC_MARKER(auto_tuple_t, "[", n, "]");
+        return (n < 2) ? n
+                       : (fibonacci<Tp>(n - 1, cutoff) + fibonacci<Tp>(n - 2, cutoff));
     }
     return fibonacci(n);
 }
 
 //======================================================================================//
 
-template <typename Tp,
-          tim::enable_if_t<std::is_same<Tp, mode::blank_pointer>::value, int> = 0>
+template <typename Tp>
 int64_t
-fibonacci(int64_t n, int64_t cutoff)
+fibonacci(int64_t n, int64_t cutoff,
+          tim::enable_if_t<std::is_same<Tp, mode::blank_pointer>::value, int> = 0)
 {
     if(n > cutoff)
     {
@@ -167,10 +170,10 @@ fibonacci(int64_t n, int64_t cutoff)
 
 //======================================================================================//
 
-template <typename Tp,
-          tim::enable_if_t<std::is_same<Tp, mode::basic_pointer>::value, int> = 0>
+template <typename Tp>
 int64_t
-fibonacci(int64_t n, int64_t cutoff)
+fibonacci(int64_t n, int64_t cutoff,
+          tim::enable_if_t<std::is_same<Tp, mode::basic_pointer>::value, int> = 0)
 {
     if(n > cutoff)
     {
@@ -184,14 +187,62 @@ fibonacci(int64_t n, int64_t cutoff)
 //======================================================================================//
 
 template <typename Tp>
+int64_t
+fibonacci(int64_t n, int64_t cutoff,
+          tim::enable_if_t<std::is_same<Tp, mode::chained>::value, int> = 0)
+{
+    if(n > cutoff)
+    {
+        // TIMEMORY_STATIC_BASIC_CALIPER(fib, auto_tuple_t, "");
+        // TIMEMORY_CALIPER_AUTO_SCOPE(fib);
+        static auto _srcloc =
+            TIMEMORY_SOURCE_LOCATION(TIMEMORY_CAPTURE_MODE(basic), "").get_captured();
+        return auto_tuple_t{ _srcloc }
+            .start()
+            .execute([n, cutoff]() {
+                return (n < 2) ? n
+                               : (fibonacci<Tp>(n - 1, cutoff) +
+                                  fibonacci<Tp>(n - 2, cutoff));
+            })
+            .stop()
+            .return_result();
+    }
+    return fibonacci(n);
+}
+
+//======================================================================================//
+
+template <typename Tp>
+int64_t
+fibonacci(int64_t n, int64_t cutoff,
+          tim::enable_if_t<std::is_same<Tp, mode::invoke>::value, int> = 0)
+{
+    if(n > cutoff)
+    {
+        auto labeler = [](int _n) { return TIMEMORY_JOIN("", "fibonacci[", _n, "]"); };
+        auto fib     = [](int _n, int _cutoff) {
+            return (_n < 2) ? _n
+                                : (fibonacci<Tp>(_n - 1, _cutoff) +
+                               fibonacci<Tp>(_n - 2, _cutoff));
+        };
+        return tim::runtime::invoke<auto_tuple_t>(labeler(n), fib, n, cutoff);
+    }
+    return fibonacci(n);
+}
+
+//======================================================================================//
+
+template <typename Tp>
 result_type
 run(int64_t n, int64_t cutoff, bool store = true)
 {
     // bool is_none  = std::is_same<Tp, mode::none>::value;
     bool is_blank = std::is_same<Tp, mode::blank>::value ||
-                    std::is_same<Tp, mode::blank_pointer>::value;
+                    std::is_same<Tp, mode::blank_pointer>::value ||
+                    std::is_same<Tp, mode::chained>::value;
     bool is_basic = std::is_same<Tp, mode::basic>::value ||
-                    std::is_same<Tp, mode::basic_pointer>::value;
+                    std::is_same<Tp, mode::basic_pointer>::value ||
+                    std::is_same<Tp, mode::invoke>::value;
 
     // bool        with_timing = !(is_none);
     // std::string space       = (with_timing) ? " " : "";
@@ -343,6 +394,8 @@ main(int argc, char** argv)
     launch<mode::blank_pointer>(nitr, nfib, cutoff, ex_measure, ex_unique, timer_list);
     launch<mode::basic>(nitr, nfib, cutoff, ex_measure, ex_unique, timer_list);
     launch<mode::basic_pointer>(nitr, nfib, cutoff, ex_measure, ex_unique, timer_list);
+    launch<mode::chained>(nitr, nfib, cutoff, ex_measure, ex_unique, timer_list);
+    launch<mode::invoke>(nitr, nfib, cutoff, ex_measure, ex_unique, timer_list);
 
     TIMEMORY_CALIPER_APPLY(global, stop);
 

--- a/examples/ex-cxx-overhead/ex_cxx_overhead.cpp
+++ b/examples/ex-cxx-overhead/ex_cxx_overhead.cpp
@@ -222,7 +222,7 @@ fibonacci(int64_t n, int64_t cutoff,
         auto labeler = [](int _n) { return TIMEMORY_JOIN("", "fibonacci[", _n, "]"); };
         auto fib     = [](int _n, int _cutoff) {
             return (_n < 2) ? _n
-                                : (fibonacci<Tp>(_n - 1, _cutoff) +
+                            : (fibonacci<Tp>(_n - 1, _cutoff) +
                                fibonacci<Tp>(_n - 2, _cutoff));
         };
         return tim::runtime::invoke<auto_tuple_t>(labeler(n), fib, n, cutoff);

--- a/source/python/libpytimemory-components.cpp
+++ b/source/python/libpytimemory-components.cpp
@@ -671,13 +671,13 @@ generate(py::module& _pymod, std::array<bool, N>& _boolgen,
     _pycomp.def("__repr__", _repr, "String representation");
 
     auto _label = []() {
-        if(metadata_t::value != TIMEMORY_COMPONENTS_END)
+        if(metadata_t::specialized())
             return metadata_t::label();
         return T::label();
     };
 
     auto _desc = []() {
-        if(metadata_t::value != TIMEMORY_COMPONENTS_END)
+        if(metadata_t::specialized())
             return TIMEMORY_JOIN("", metadata_t::description(), ". ",
                                  metadata_t::extra_description());
         return T::description();

--- a/source/tests/apply_tests.cpp
+++ b/source/tests/apply_tests.cpp
@@ -116,3 +116,100 @@ TEST_F(apply_tests, traits)
 }
 
 //--------------------------------------------------------------------------------------//
+
+class chained_tests : public ::testing::Test
+{};
+
+using namespace tim::component;
+static long count_val = 0;
+
+namespace details
+{
+//
+template <typename BundleT = void>
+long
+fibonacci(long);
+//
+template <typename BundleT>
+long
+fibonacci(long n)
+{
+    return BundleT{ "fibonacci" }
+        .start()
+        .execute([n]() {
+            return (n < 2) ? n : (fibonacci<BundleT>(n - 1) + fibonacci<BundleT>(n - 2));
+        })
+        .stop()
+        .return_result();
+}
+//
+template <>
+long
+fibonacci<void>(long n)
+{
+    return (n < 2) ? n : (fibonacci<void>(n - 1) + fibonacci<void>(n - 2));
+}
+//
+template <>
+long
+fibonacci<long>(long n)
+{
+    ++count_val;
+    return (n < 2) ? n : (fibonacci<long>(n - 1) + fibonacci<long>(n - 2));
+}
+//
+}  // namespace details
+//--------------------------------------------------------------------------------------//
+
+TEST_F(chained_tests, fibonacci)
+{
+    using bundle_t     = tim::component_bundle<TIMEMORY_API, trip_count>;
+    using timer_t      = tim::lightweight_tuple<wall_clock, tim::quirk::auto_start>;
+    using auto_timer_t = tim::auto_bundle<TIMEMORY_API, wall_clock>;
+
+    tim::settings::precision() = 6;
+    long nfib                  = 30;
+
+    std::pair<timer_t, long> count_tmp =
+        timer_t{ "count" }.start().execute(details::fibonacci<long>, nfib).stop();
+
+    auto real_ret = timer_t{ "real" }
+                        .start()
+                        .execute(details::fibonacci<void>, nfib)
+                        .stop()
+                        .get_bundle_and_result();
+
+    auto test_ret = auto_timer_t{ "test" }
+                        .execute(details::fibonacci<bundle_t>, nfib)
+                        .stop()
+                        .get_bundle_and_result();
+
+    auto real_timer = real_ret.first;
+    auto test_timer = test_ret.first;
+    auto real_val   = real_ret.second;
+    auto test_val   = test_ret.second;
+
+    EXPECT_EQ(real_val, count_tmp.second);
+    EXPECT_EQ(real_val, test_val);
+
+    auto tc_data  = tim::storage<trip_count>::instance()->get();
+    long meas_val = 0;
+    long laps_val = 0;
+    for(auto& itr : tc_data)
+    {
+        meas_val += itr.data().get();
+        laps_val += itr.data().get_laps();
+    }
+
+    EXPECT_EQ(count_val, meas_val);
+    EXPECT_EQ(count_val, laps_val);
+
+    std::cout << real_timer << std::endl;
+    std::cout << test_timer << std::endl;
+
+    auto tc_storage = tim::storage<trip_count>::instance()->get();
+
+    EXPECT_EQ(tc_storage.size(), nfib);
+}
+
+//--------------------------------------------------------------------------------------//

--- a/source/tests/chained_tests.cpp
+++ b/source/tests/chained_tests.cpp
@@ -22,62 +22,35 @@
 // OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
 // SOFTWARE.
 
-#pragma once
+#include "test_macros.hpp"
 
-#include "timemory/enum.h"
-#include "timemory/utility/utility.hpp"
+TIMEMORY_TEST_DEFAULT_MAIN
 
-#include <string>
+#include "gtest/gtest.h"
 
-namespace tim
+#include "timemory/timemory.hpp"
+
+
+//--------------------------------------------------------------------------------------//
+namespace details
 {
-namespace component
+//--------------------------------------------------------------------------------------//
+//  Get the current tests name
+//
+inline std::string
+get_test_name()
 {
-/// \struct tim::component::metadata
-/// \brief Provides forward declaration support for assigning static metadata properties.
-/// This is most useful for specialization of template components. If this class
-/// is specialized for component, then the component does not need to provide
-/// the static member functions `label()` and `description()`.
-///
-template <typename Tp>
-struct metadata
+    return std::string(::testing::UnitTest::GetInstance()->current_test_suite()->name()) +
+           "." + ::testing::UnitTest::GetInstance()->current_test_info()->name();
+}
+}  // namespace details
+
+//--------------------------------------------------------------------------------------//
+
+class chained_tests : public ::testing::Test
 {
-    using type                                = Tp;
-    using value_type                          = TIMEMORY_COMPONENT;
-    static constexpr TIMEMORY_COMPONENT value = TIMEMORY_COMPONENTS_END;
-    static std::string                  name();
-    static std::string                  label();
-    static std::string                  description();
-    static std::string                  extra_description() { return ""; }
-    static constexpr bool               specialized() { return false; }
+protected:
+    TIMEMORY_TEST_DEFAULT_SUITE_BODY
 };
-//
+
 //--------------------------------------------------------------------------------------//
-//
-template <typename Tp>
-std::string
-metadata<Tp>::name()
-{
-    return try_demangle<Tp>();
-}
-//
-//--------------------------------------------------------------------------------------//
-//
-template <typename Tp>
-std::string
-metadata<Tp>::label()
-{
-    return try_demangle<Tp>();
-}
-//
-//--------------------------------------------------------------------------------------//
-//
-template <typename Tp>
-std::string
-metadata<Tp>::description()
-{
-    return try_demangle<Tp>();
-}
-//
-}  // namespace component
-}  // namespace tim

--- a/source/tests/chained_tests.cpp
+++ b/source/tests/chained_tests.cpp
@@ -30,7 +30,6 @@ TIMEMORY_TEST_DEFAULT_MAIN
 
 #include "timemory/timemory.hpp"
 
-
 //--------------------------------------------------------------------------------------//
 namespace details
 {

--- a/source/tests/component_bundle_tests.cpp
+++ b/source/tests/component_bundle_tests.cpp
@@ -234,14 +234,14 @@ TEST_F(component_bundle_tests, get)
     auto lhs = lhs_t(TIMEMORY_JOIN("/", details::get_test_name(), "lhs"));
     auto rhs = rhs_t(TIMEMORY_JOIN("/", details::get_test_name(), "rhs"));
 
-    tim::invoke::disjoint::start(std::forward_as_tuple(lhs, rhs));
-    tim::invoke::disjoint::mark_begin(std::forward_as_tuple(lhs, rhs));
+    tim::invoke::start(std::tie(lhs, rhs));
+    tim::invoke::mark_begin(std::tie(lhs, rhs));
 
     std::this_thread::sleep_for(std::chrono::seconds(1));
     details::consume(1000);
 
-    tim::invoke::disjoint::mark_end(std::forward_as_tuple(lhs, rhs));
-    tim::invoke::disjoint::stop(std::forward_as_tuple(lhs, rhs));
+    tim::invoke::mark_end(std::tie(lhs, rhs));
+    tim::invoke::stop(std::tie(lhs, rhs));
 
     auto cb = lhs.get();
     auto ab = rhs.get();

--- a/source/tests/variadic_tests.cpp
+++ b/source/tests/variadic_tests.cpp
@@ -279,42 +279,30 @@ TEST_F(variadic_tests, get)
     using comp_t1 = tim::remove_duplicates_t<join_t1>;
     using comp_t2 = tim::remove_duplicates_t<join_t2>;
 
+    using comp_t2_base_type      = typename comp_t2::base_type;
+    using comp_t2_component_type = typename comp_t2::component_type;
+    using comp_t2_tuple_type     = typename comp_t2::tuple_type;
+    using comp_t2_data_type      = typename comp_t2::data_type;
+    using comp_t2_bundle_type    = typename comp_t2::bundle_type;
+    using comp_t2_this_type      = typename comp_t2::this_type;
+
+#define PRINT_TYPE(TYPE)                                                                 \
+    std::cout << std::right << std::setw(24) << #TYPE << " = " << tim::demangle<TYPE>()  \
+              << "\n";
+
+    std::cout << "\n" << std::flush;
+    PRINT_TYPE(comp_t2_base_type)
+    PRINT_TYPE(comp_t2_component_type)
+    PRINT_TYPE(comp_t2_tuple_type)
+    PRINT_TYPE(comp_t2_data_type)
+    PRINT_TYPE(comp_t2_bundle_type)
+    PRINT_TYPE(comp_t2_this_type)
+    std::cout << "\n" << std::flush;
+
     using list_t0 = tim::component_list<lhs_l, rhs_l>;
     using list_t1 = tim::auto_list<lhs_l, rhs_l, user_clock>;
     using list_t2 = tim::auto_list<rhs_l, user_clock>;
     using list_t3 = tim::auto_list<lhs_l, list_t2>;
-
-    list_t0::get_initializer() = [](auto& cl) { cl.template init<wall_clock>(); };
-    list_t1::get_initializer() = [](auto& cl) { cl.template init<wall_clock>(); };
-    list_t2::get_initializer() = [](auto& cl) { cl.template init<wall_clock>(); };
-    list_t3::get_initializer() = [](auto& cl) { cl.template init<wall_clock>(); };
-
-    auto ct0 = comp_t0("ct0");
-    auto ct1 = comp_t1("ct1");
-    auto ct2 = comp_t2("ct2");
-    auto cl0 = list_t0("cl0");
-    auto cl1 = list_t1("cl1");
-    auto cl2 = list_t2("cl2");
-    auto cl3 = list_t3("cl3");
-
-    namespace disjoint = tim::invoke::disjoint;
-
-    disjoint::start(std::forward_as_tuple(ct0, ct1, ct2, cl0, cl1, cl2, cl3));
-    disjoint::mark_begin(std::forward_as_tuple(ct0, ct1, ct2, cl0, cl1, cl2, cl3));
-
-    std::this_thread::sleep_for(std::chrono::seconds(1));
-
-    disjoint::mark_end(std::forward_as_tuple(ct0, ct1, ct2, cl0, cl1, cl2, cl3));
-    disjoint::stop(std::forward_as_tuple(ct0, ct1, ct2, cl0, cl1, cl2, cl3));
-
-    auto dt0 = ct0.get();
-    auto dt1 = ct1.get();
-    auto dt2 = ct2.get();
-
-    auto dl0 = cl0.get();
-    auto dl1 = cl1.get();
-    auto dl2 = cl2.get();
-    auto dl3 = cl3.get();
 
     std::cout << "\n" << std::flush;
 
@@ -340,6 +328,48 @@ TEST_F(variadic_tests, get)
     std::cout << "list_t3 = " << tim::demangle<list_t3>() << "\n";
     std::cout << "\n" << std::flush;
 
+    list_t0::get_initializer() = [](auto& cl) { cl.template init<wall_clock>(); };
+    list_t1::get_initializer() = [](auto& cl) { cl.template init<wall_clock>(); };
+    list_t2::get_initializer() = [](auto& cl) { cl.template init<wall_clock>(); };
+    list_t3::get_initializer() = [](auto& cl) { cl.template init<wall_clock>(); };
+
+    auto ct0 = comp_t0("ct0");
+    auto ct1 = comp_t1("ct1");
+    auto ct2 = comp_t2("ct2");
+    auto cl0 = list_t0("cl0");
+    auto cl1 = list_t1("cl1");
+    auto cl2 = list_t2("cl2");
+    auto cl3 = list_t3("cl3");
+
+    // auto ct3 =
+    //    tim::auto_tuple<tim::component::wall_clock, tim::component::system_clock,
+    //                    tim::component::cpu_clock, tim::component::user_clock>{ "ct3" };
+
+    namespace disjoint = tim::invoke::disjoint;
+
+    disjoint::start(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3));
+    // disjoint::mark_begin(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3));
+
+    // disjoint::store(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3), 10);
+    // disjoint::mark(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3), 10);
+
+    std::this_thread::sleep_for(std::chrono::seconds(1));
+
+    // disjoint::record(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3), 10);
+    // disjoint::measure(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3));
+
+    // disjoint::mark_end(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3));
+    disjoint::stop(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3));
+
+    auto dt0 = ct0.get();
+    auto dt1 = ct1.get();
+    auto dt2 = ct2.get();
+
+    auto dl0 = cl0.get();
+    auto dl1 = cl1.get();
+    auto dl2 = cl2.get();
+    auto dl3 = cl3.get();
+
     std::cout << "dt0 = " << tim::demangle<decltype(dt0)>() << "\n";
     std::cout << "dt1 = " << tim::demangle<decltype(dt1)>() << "\n";
     std::cout << "dt2 = " << tim::demangle<decltype(dt2)>() << "\n";
@@ -353,6 +383,10 @@ TEST_F(variadic_tests, get)
 
     tim::invoke::print(std::cout, ct0, ct1, ct2, cl0, cl1, cl2, cl3);
 
+    std::cout << '\n';
+    disjoint::invoke(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3),
+                     [](auto& itr) { std::cout << itr << std::endl; });
+
     EXPECT_NEAR(std::get<0>(dt0), 1.0, 0.1);
     EXPECT_NEAR(std::get<0>(dt1), 1.0, 0.1);
     EXPECT_NEAR(std::get<0>(dt2), 1.0, 0.1);
@@ -361,6 +395,37 @@ TEST_F(variadic_tests, get)
     EXPECT_NEAR(std::get<0>(dl1), 1.0, 0.1);
     EXPECT_NEAR(std::get<0>(dl2), 1.0, 0.1);
     EXPECT_NEAR(std::get<0>(dl3), 1.0, 0.1);
+
+    disjoint::reset(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3));
+    disjoint::set_prefix(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3), "set_prefix");
+    disjoint::set_scope(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3),
+                        tim::scope::flat{} + tim::scope::timeline{});
+    disjoint::push(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3));
+
+    disjoint::assemble(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3));
+    disjoint::audit(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3), 10);
+    disjoint::derive(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3));
+
+    disjoint::add_secondary(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3));
+    disjoint::pop(std::tie(ct0, ct1, ct2, cl0, cl1, cl2, cl3));
+
+    dt0 = ct0.get();
+    dt1 = ct1.get();
+    dt2 = ct2.get();
+
+    dl0 = cl0.get();
+    dl1 = cl1.get();
+    dl2 = cl2.get();
+    dl3 = cl3.get();
+
+    EXPECT_NEAR(std::get<0>(dt0), 0.0, 1.e-3);
+    EXPECT_NEAR(std::get<0>(dt1), 0.0, 1.e-3);
+    EXPECT_NEAR(std::get<0>(dt2), 0.0, 1.e-3);
+
+    EXPECT_NEAR(std::get<0>(dl0), 0.0, 1.e-3);
+    EXPECT_NEAR(std::get<0>(dl1), 0.0, 1.e-3);
+    EXPECT_NEAR(std::get<0>(dl2), 0.0, 1.e-3);
+    EXPECT_NEAR(std::get<0>(dl3), 0.0, 1.e-3);
 }
 
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/compat/macros.h
+++ b/source/timemory/compat/macros.h
@@ -28,6 +28,7 @@
 #define _TIM_STRINGIZE2(X) #X
 #define _TIM_VAR_NAME_COMBINE(X, Y) X##Y
 #define _TIM_VARIABLE(Y) _TIM_VAR_NAME_COMBINE(timemory_variable_, Y)
+#define _TIM_SCOPE_DTOR(Y) _TIM_VAR_NAME_COMBINE(timemory_scoped_dtor_, Y)
 #define _TIM_TYPEDEF(Y) _TIM_VAR_NAME_COMBINE(timemory_typedef_, Y)
 #define _TIM_STORAGE_INIT(Y) _TIM_VAR_NAME_COMBINE(timemory_storage_initializer_, Y)
 

--- a/source/timemory/components/base/data.hpp
+++ b/source/timemory/components/base/data.hpp
@@ -463,11 +463,11 @@ struct base_state
 {
     TIMEMORY_DEFAULT_OBJECT(base_state)
 
-    TIMEMORY_INLINE auto& get_is_running() { return is_running; }
-    TIMEMORY_INLINE auto& get_is_on_stack() { return is_on_stack; }
-    TIMEMORY_INLINE auto& get_is_transient() { return is_transient; }
-    TIMEMORY_INLINE auto& get_is_flat() { return is_flat; }
-    TIMEMORY_INLINE auto& get_depth_change() { return depth_change; }
+    TIMEMORY_INLINE auto get_is_running() { return is_running; }
+    TIMEMORY_INLINE auto get_is_on_stack() { return is_on_stack; }
+    TIMEMORY_INLINE auto get_is_transient() { return is_transient; }
+    TIMEMORY_INLINE auto get_is_flat() { return is_flat; }
+    TIMEMORY_INLINE auto get_depth_change() { return depth_change; }
 
     TIMEMORY_NODISCARD TIMEMORY_INLINE auto get_is_running() const { return is_running; }
     TIMEMORY_NODISCARD TIMEMORY_INLINE auto get_is_on_stack() const

--- a/source/timemory/components/base/declaration.hpp
+++ b/source/timemory/components/base/declaration.hpp
@@ -253,14 +253,14 @@ public:
     using data_type::set_last;
     using data_type::set_value;
 
-protected:
-    static base_storage_type* get_storage();
-
     TIMEMORY_INLINE decltype(auto) load() { return data_type::load(get_is_transient()); }
     TIMEMORY_NODISCARD TIMEMORY_INLINE decltype(auto) load() const
     {
         return data_type::load(get_is_transient());
     }
+
+protected:
+    static base_storage_type* get_storage();
 
     TIMEMORY_INLINE Type& plus_oper(const base_type& rhs);
     TIMEMORY_INLINE Type& minus_oper(const base_type& rhs);

--- a/source/timemory/components/data_tracker/components.hpp
+++ b/source/timemory/components/data_tracker/components.hpp
@@ -44,11 +44,13 @@
 
 #include <cassert>
 #include <cstdint>
+#include <limits>
 #include <memory>
 #include <sstream>
 #include <string>
 #include <type_traits>
 #include <unordered_map>
+#include <utility>
 
 //======================================================================================//
 //
@@ -58,236 +60,313 @@ namespace component
 {
 /// \struct tim::component::data_tracker
 /// \brief This component is provided to facilitate data tracking. The first
-/// template parameter is the type of data to be tracked, the second is a custom
-/// tag, the third is the implementation for how to track the data.
+/// template parameter is the type of data to be tracked, the second is a custom tag
+/// for differentiating trackers which handle the same data types but record
+/// different high-level data.
+///
 /// Usage:
 /// \code{.cpp}
-/// struct iteration_count_tag;
+/// // declarations
 ///
-/// using tracker_type = data_tracker<uint64_t, iteration_count_tag>;
-/// using tuple_t      = tim::auto_tuple<wall_clock, tracker_type>;
+/// struct myproject {};
+///
+/// using itr_tracker_type   = data_tracker<uint64_t, myproject>;
+/// using err_tracker_type   = data_tracker<double, myproject>;
+///
+/// // add statistics capabilities
+/// TIMEMORY_STATISTICS_TYPE(itr_tracker_type, int64_t)
+/// TIMEMORY_STATISTICS_TYPE(err_tracker_type, double)
+///
+/// // set the label and descriptions
+/// TIMEMORY_METADATA_SPECIALIZATION(
+///     itr_tracker_type, "myproject_iterations", "short desc", "long description")
+///
+/// TIMEMORY_METADATA_SPECIALIZATION(
+///     err_tracker_type, "myproject_convergence", "short desc", "long description")
+///
+/// // this is the generic bundle pairing a timer with an iteration tracker
+/// // using this and not updating the iteration tracker will create entries
+/// // in the call-graph with zero iterations.
+/// using bundle_t           = tim::auto_tuple<wall_clock, itr_tracker_type>;
+///
+/// // this is a dedicated bundle for adding data-tracker entries. This style
+/// // can also be used with the iteration tracker or you can bundle
+/// // both trackers together. The auto_tuple will call start on construction
+/// // and stop on destruction so once can construct a nameless temporary of the
+/// // this bundle type and call store(...) on the nameless tmp. This will
+/// // ensure that the statistics are updated for each entry
+/// //
+/// using err_bundle_t       = tim::auto_tuple<err_tracker_type>;
+///
+/// // usage in a function is implied below
 ///
 /// double err             = std::numeric_limits<double>::max();
 /// const double tolerance = 1.0e-6;
 ///
-/// tuple_t t("iteration_time");
+/// bundle_t t("iteration_time");
 ///
 /// while(err > tolerance)
 /// {
-///     t.store(std::plus<uint64_t>{}, 1);
+///     // store the starting error
+///     double initial_err = err;
+///
+///     // add 1 for each iteration. Stats only updated when t is destroyed or t.stop() is
+///     // called t.store(std::plus<uint64_t>{}, 1);
+///
 ///     // ... do something ...
+///
+///     // construct a nameless temporary which records the change in the error and
+///     // update the statistics <-- "foo" will have mean/min/max/stddev of the
+///     // error
+///     err_bundle_t{ "foo" }.store(err - initial_err);
+///
+///     // NOTE: std::plus is used with t above bc it has multiple components so std::plus
+///     // helps ensure 1 doesn't get added to some other component with `store(int)`
+///     // In above err_bundle_t, there is only one component so there is not concern.
 /// }
 /// \endcode
+///
+/// When creating new data trackers, it is recommended to have this in header:
+///
+/// \code{.cpp}
+/// TIMEMORY_DECLARE_EXTERN_COMPONENT(custom_data_tracker_t, true, data_type)
+/// \endcode
+///
+/// And this in *one* source file (preferably one that is not re-compiled often)
+///
+/// \code{.cpp}
+/// TIMEMORY_INSTANTIATE_EXTERN_COMPONENT(custom_data_tracker_t, true, data_type)
+/// TIMEMORY_INITIALIZE_STORAGE(custom_data_tracker_t)
+/// \endcode
+///
+/// where `custom_data_tracker_t` is the custom data tracker type (or an alias to the
+/// type) and `data_type` is the data type being tracked.
 ///
 template <typename InpT, typename Tag>
 struct data_tracker : public base<data_tracker<InpT, Tag>, InpT>
 {
+    using value_type   = InpT;
+    using this_type    = data_tracker<InpT, Tag>;
+    using base_type    = base<this_type, value_type>;
+    using handler_type = data::handler<InpT, Tag>;
+
     friend struct data::handler<InpT, Tag>;
-
-    using value_type      = InpT;
-    using this_type       = data_tracker<InpT, Tag>;
-    using base_type       = base<this_type, value_type>;
-    using handler_type    = data::handler<InpT, Tag>;
-    using secondary_map_t = std::unordered_map<std::string, this_type>;
-    using secondary_ptr_t = std::shared_ptr<secondary_map_t>;
-    using string_t        = std::string;
-    using start_t =
-        operation::generic_operator<this_type, operation::start<this_type>, Tag>;
-    using stop_t =
-        operation::generic_operator<this_type, operation::stop<this_type>, Tag>;
-    using compute_type = math::compute<InpT, typename trait::units<this_type>::type>;
-
     friend struct operation::record<this_type>;
     friend struct operation::start<this_type>;
     friend struct operation::stop<this_type>;
     friend struct operation::set_started<this_type>;
     friend struct operation::set_stopped<this_type>;
 
-    static std::string& label()
+private:
+    // private aliases
+    template <typename T, typename U = int>
+    using enable_if_acceptable_t =
+        enable_if_t<concepts::is_acceptable_conversion<T, InpT>::value, U>;
+
+    template <typename FuncT, typename T, typename U = int>
+    using enable_if_acceptable_and_func_t =
+        enable_if_t<concepts::is_acceptable_conversion<T, InpT>::value &&
+                        std::is_function<FuncT>::value,
+                    U>;
+
+    using value_ptr_t     = std::shared_ptr<value_type>;
+    using secondary_map_t = std::unordered_map<std::string, this_type>;
+    using secondary_ptr_t = std::shared_ptr<secondary_map_t>;
+    using start_t =
+        operation::generic_operator<this_type, operation::start<this_type>, Tag>;
+    using stop_t =
+        operation::generic_operator<this_type, operation::stop<this_type>, Tag>;
+    using compute_type = math::compute<InpT, typename trait::units<this_type>::type>;
+
+public:
+    //----------------------------------------------------------------------------------//
+    //
+    //  standard interface
+    //
+    //----------------------------------------------------------------------------------//
+    /// a reference is returned here so that it can be easily updated
+    static std::string& label();
+
+    /// a reference is returned here so that it can be easily updated
+    static std::string& description();
+
+    /// this returns a reference so that it can be easily modified
+    static auto& get_unit()
     {
-        static std::string _instance = []() {
-            if(metadata<this_type>::value != TIMEMORY_COMPONENTS_END)
-                return metadata<this_type>::label();
-            std::stringstream ss;
-            ss << demangle<Tag>() << "_" << demangle<InpT>();
-            auto _lbl = ss.str();
-            for(auto&& itr : { "tim::component::", "tim::" })
-            {
-                auto _pos = std::string::npos;
-                while((_pos = _lbl.find(itr)) != std::string::npos)
-                    _lbl = _lbl.erase(_pos, std::string(itr).length());
-            }
-            for(auto&& itr : { "::", " ", "_" })
-            {
-                auto _pos = std::string::npos;
-                while((_pos = _lbl.find(itr)) != std::string::npos)
-                    _lbl = _lbl.replace(_pos, std::string(itr).length(), "-");
-            }
-            return _lbl;
-        }();
-        return _instance;
+        static auto _unit = base_type::get_unit();
+        return _unit;
     }
 
-    static std::string& description()
-    {
-        static std::string _instance = []() {
-            if(metadata<this_type>::value != TIMEMORY_COMPONENTS_END)
-            {
-                auto meta_desc = metadata<this_type>::description();
-                if(settings::verbose() > 0 || settings::debug())
-                {
-                    auto meta_extra_desc = metadata<this_type>::extra_description();
-                    meta_desc += ". ";
-                    meta_desc += meta_extra_desc;
-                }
-                return meta_desc;
-            }
-            std::stringstream ss;
-            ss << "Data tracker for data of type " << demangle<InpT>() << " for "
-               << demangle<Tag>();
-            return ss.str();
-        }();
-        return _instance;
-    }
-
+    // default set of ctor and assign
     TIMEMORY_DEFAULT_OBJECT(data_tracker)
 
     void start() {}
     void stop() {}
 
-    template <typename T,
-              enable_if_t<concepts::is_acceptable_conversion<T, InpT>::value, int> = 0>
-    void store(const T& val)
-    {
-        handler_type::store(*this, compute_type::divide(val, get_unit()));
-    }
-
-    template <typename T,
-              enable_if_t<concepts::is_acceptable_conversion<T, InpT>::value, int> = 0>
-    void store(handler_type&&, const T& val)
-    {
-        handler_type::store(*this, compute_type::divide(val, get_unit()));
-    }
-
-    template <typename FuncT, typename T,
-              enable_if_t<concepts::is_acceptable_conversion<T, InpT>::value, int> = 0>
-    auto store(FuncT&& f, const T& val)
-        -> decltype(std::declval<handler_type>().store(*this, std::forward<FuncT>(f),
-                                                       val),
-                    void())
-    {
-        handler_type::store(*this, std::forward<FuncT>(f),
-                            compute_type::divide(val, get_unit()));
-    }
-
-    template <typename FuncT, typename T,
-              enable_if_t<concepts::is_acceptable_conversion<T, InpT>::value, int> = 0>
-    auto store(handler_type&&, FuncT&& f, const T& val)
-        -> decltype(std::declval<handler_type>().store(*this, std::forward<FuncT>(f),
-                                                       val),
-                    void())
-    {
-        handler_type::store(*this, std::forward<FuncT>(f),
-                            compute_type::divide(val, get_unit()));
-    }
-
-    template <typename T,
-              enable_if_t<concepts::is_acceptable_conversion<T, InpT>::value, int> = 0>
-    void mark_begin(const T& val)
-    {
-        handler_type::begin(*this, compute_type::divide(val, get_unit()));
-    }
-
-    template <typename T,
-              enable_if_t<concepts::is_acceptable_conversion<T, InpT>::value, int> = 0>
-    void mark_end(const T& val)
-    {
-        handler_type::end(*this, compute_type::divide(val, get_unit()));
-    }
-
-    template <typename T,
-              enable_if_t<concepts::is_acceptable_conversion<T, InpT>::value, int> = 0>
-    void mark_begin(handler_type&&, const T& val)
-    {
-        handler_type::begin(*this, compute_type::divide(val, get_unit()));
-    }
-
-    template <typename T,
-              enable_if_t<concepts::is_acceptable_conversion<T, InpT>::value, int> = 0>
-    void mark_end(handler_type&&, const T& val)
-    {
-        handler_type::end(*this, compute_type::divide(val, get_unit()));
-    }
-
+    /// get the data in the final form after unit conversion
     TIMEMORY_NODISCARD auto get() const { return handler_type::get(*this); }
+
+    /// get the data in a form suitable for display
     TIMEMORY_NODISCARD auto get_display() const
     {
         return handler_type::get_display(*this);
     }
 
+    /// map of the secondary entries. When TIMEMORY_ADD_SECONDARY is enabled
+    /// contents of this map will be added as direct children of the current
+    /// node in the call-graph.
+    auto get_secondary() { return (m_secondary) ? *m_secondary : secondary_map_t{}; }
+
+    using base_type::get_depth_change;
+    using base_type::get_is_flat;
+    using base_type::get_is_on_stack;
+    using base_type::get_is_running;
+    using base_type::get_is_transient;
+    using base_type::get_iterator;
+    using base_type::get_opaque_data;
+    using base_type::get_value;
+    using base_type::laps;
+    using base_type::load;
+
+    //----------------------------------------------------------------------------------//
+    //
+    //  store
+    //
+    //----------------------------------------------------------------------------------//
+    /// store some data. Uses \ref tim::data::handler for the type.
+    template <typename T>
+    void store(const T& val, enable_if_acceptable_t<T, int> = 0);
+
+    /// overload which takes a handler to ensure proper overload resolution
+    template <typename T>
+    void store(handler_type&&, const T& val, enable_if_acceptable_t<T, int> = 0);
+
+    /// overload which uses a lambda to bypass the default behavior of how the
+    /// handler updates the values
+    template <typename FuncT, typename T>
+    auto store(FuncT&& f, const T& val, enable_if_acceptable_t<T, int> = 0)
+        -> decltype(std::declval<handler_type>().store(*this, std::forward<FuncT>(f),
+                                                       val),
+                    void());
+
+    /// overload which uses a lambda to bypass the default behavior of how the
+    /// handler updates the values and takes a handler to ensure proper overload
+    /// resolution
+    template <typename FuncT, typename T>
+    auto store(handler_type&&, FuncT&& f, const T& val,
+               enable_if_acceptable_t<T, int> = 0)
+        -> decltype(std::declval<handler_type>().store(*this, std::forward<FuncT>(f),
+                                                       val),
+                    void());
+
+    //----------------------------------------------------------------------------------//
+    //
+    //  mark begin
+    //
+    //----------------------------------------------------------------------------------//
+    /// The combination of `mark_begin(...)` and `mark_end(...)` can be used to
+    /// store some initial data which may be needed later. When `mark_end(...)` is
+    /// called, the value is updated with the difference of the value provided to
+    /// `mark_end` and the temporary stored during `mark_begin`.
+    template <typename T>
+    void mark_begin(const T& val, enable_if_acceptable_t<T, int> = 0);
+
+    /// overload which takes a handler to ensure proper overload resolution
+    template <typename T>
+    void mark_begin(handler_type&&, const T& val, enable_if_acceptable_t<T, int> = 0);
+
+    /// overload which uses a lambda to bypass the default behavior of how the
+    /// handler updates the values
+    template <typename FuncT, typename T>
+    void mark_begin(FuncT&& f, const T& val, enable_if_acceptable_t<T, int> = 0);
+
+    /// overload which uses a lambda to bypass the default behavior of how the
+    /// handler updates the values and takes a handler to ensure proper
+    /// overload resolution
+    template <typename FuncT, typename T>
+    void mark_begin(handler_type&&, FuncT&& f, const T& val,
+                    enable_if_acceptable_t<T, int> = 0);
+
+    //----------------------------------------------------------------------------------//
+    //
+    //  mark end
+    //
+    //----------------------------------------------------------------------------------//
+    /// The combination of `mark_begin(...)` and `mark_end(...)` can be used to
+    /// store some initial data which may be needed later. When `mark_end(...)` is
+    /// called, the value is updated with the difference of the value provided to
+    /// `mark_end` and the temporary stored during `mark_begin`. It may be valid
+    /// to call `mark_end` without calling `mark_begin` but the result will effectively
+    /// be a more expensive version of calling `store`.
+    template <typename T>
+    void mark_end(const T& val, enable_if_acceptable_t<T, int> = 0);
+
+    /// overload which takes a handler to ensure proper overload resolution
+    template <typename T>
+    void mark_end(handler_type&&, const T& val, enable_if_acceptable_t<T, int> = 0);
+
+    /// overload which uses a lambda to bypass the default behavior of how the
+    /// handler updates the values
+    template <typename FuncT, typename T>
+    void mark_end(FuncT&& f, const T& val, enable_if_acceptable_t<T, int> = 0);
+
+    /// overload which uses a lambda to bypass the default behavior of how the
+    /// handler updates the values and takes a handler to ensure proper
+    /// overload resolution
+    template <typename FuncT, typename T>
+    void mark_end(handler_type&&, FuncT&& f, const T& val,
+                  enable_if_acceptable_t<T, int> = 0);
+
+    //----------------------------------------------------------------------------------//
+    //
+    //  add secondary
+    //
+    //----------------------------------------------------------------------------------//
+    /// add a secondary value to the current node in the call-graph.
+    /// When TIMEMORY_ADD_SECONDARY is enabled contents of this map will be added as
+    /// direct children of the current node in the call-graph. This is useful
+    /// for finer-grained details that might not always be desirable to display
+    template <typename T>
+    this_type* add_secondary(const std::string& _key, const T& val,
+                             enable_if_acceptable_t<T, int> = 0);
+
+    /// overload which takes a handler to ensure proper overload resolution
+    template <typename T>
+    this_type* add_secondary(const std::string& _key, handler_type&& h, const T& val,
+                             enable_if_acceptable_t<T, int> = 0);
+
+    /// overload which uses a lambda to bypass the default behavior of how the
+    /// handler updates the values
+    template <typename FuncT, typename T>
+    this_type* add_secondary(const std::string& _key, FuncT&& f, const T& val,
+                             enable_if_acceptable_and_func_t<FuncT, T, int> = 0);
+
+    /// overload which uses a lambda to bypass the default behavior of how the
+    /// handler updates the values and takes a handler to ensure proper
+    /// overload resolution
+    template <typename FuncT, typename T>
+    this_type* add_secondary(const std::string& _key, handler_type&& h, FuncT&& f,
+                             const T& val,
+                             enable_if_acceptable_and_func_t<FuncT, T, int> = 0);
+
+    //----------------------------------------------------------------------------------//
+    //
+    //  non-standard interface
+    //
+    //----------------------------------------------------------------------------------//
+
+    /// set the current value
     void set_value(const value_type& v) { value = v; }
 
-    template <typename T,
-              enable_if_t<concepts::is_acceptable_conversion<T, InpT>::value, int> = 0>
-    this_type* add_secondary(const string_t& _key, const T& val)
-    {
-        this_type _tmp;
-        start_t   _start(_tmp);
-        _tmp.store(val);
-        stop_t _stop(_tmp);
-        auto&  _map = *get_secondary_map();
-        _map.insert({ _key, _tmp });
-        return &(_map[_key]);
-    }
+    /// set the current value via move
+    void set_value(value_type&& v) { value = std::move(v); }
 
-    template <typename T,
-              enable_if_t<concepts::is_acceptable_conversion<T, InpT>::value, int> = 0>
-    this_type* add_secondary(const string_t& _key, handler_type&& h, const T& val)
-    {
-        this_type _tmp;
-        start_t   _start(_tmp);
-        _tmp.store(std::forward<handler_type>(h), val);
-        stop_t _stop(_tmp);
-        auto&  _map = *get_secondary_map();
-        _map.insert({ _key, _tmp });
-        return &(_map[_key]);
-    }
-
-    template <typename FuncT, typename T,
-              enable_if_t<concepts::is_acceptable_conversion<T, InpT>::value &&
-                              std::is_function<FuncT>::value,
-                          int> = 0>
-    this_type* add_secondary(const string_t& _key, FuncT&& f, const T& val)
-    {
-        this_type _tmp;
-        start_t   _start(_tmp);
-        _tmp.store(std::forward<FuncT>(f), val);
-        stop_t _stop(_tmp);
-        auto&  _map = *get_secondary_map();
-        _map.insert({ _key, _tmp });
-        return &(_map[_key]);
-    }
-
-    template <typename FuncT, typename T,
-              enable_if_t<concepts::is_acceptable_conversion<T, InpT>::value &&
-                              std::is_function<FuncT>::value,
-                          int> = 0>
-    this_type* add_secondary(const string_t& _key, handler_type&& h, FuncT&& f,
-                             const T& val)
-    {
-        this_type _tmp;
-        start_t   _start(_tmp);
-        _tmp.store(std::forward<handler_type>(h), std::forward<FuncT>(f), val);
-        stop_t _stop(_tmp);
-        auto&  _map = *get_secondary_map();
-        _map.insert({ _key, _tmp });
-        return &(_map[_key]);
-    }
-
-    using base_type::get_unit;
-    using base_type::load;
     using base_type::value;
 
+private:
+    /// map of the secondary entries. When TIMEMORY_ADD_SECONDARY is enabled
+    /// contents of this map will be added as direct children of the current
+    /// node in the call-graph
     auto get_secondary_map()
     {
         if(!m_secondary)
@@ -295,9 +374,17 @@ struct data_tracker : public base<data_tracker<InpT, Tag>, InpT>
         return m_secondary;
     }
 
-    auto get_secondary() { return (m_secondary) ? *m_secondary : secondary_map_t{}; }
+    void allocate_temporary() const
+    {
+        if(!m_last)
+            const_cast<this_type*>(this)->m_last = std::make_shared<value_type>();
+    }
+
+    value_type&       get_temporary() { return (allocate_temporary(), *m_last); }
+    const value_type& get_temporary() const { return (allocate_temporary(), *m_last); }
 
 private:
+    value_ptr_t     m_last{ nullptr };
     secondary_ptr_t m_secondary{ nullptr };
 };
 //
@@ -320,6 +407,233 @@ using data_tracker_unsigned = data_tracker<size_t, TIMEMORY_API>;
 /// \brief Specialization of \ref tim::component::data_tracker for storing floating point
 /// data
 using data_tracker_floating = data_tracker<double, TIMEMORY_API>;
+//
+//
+template <typename InpT, typename Tag>
+inline std::string&
+data_tracker<InpT, Tag>::label()
+{
+    static std::string _instance = []() {
+        if(metadata<this_type>::specialized())
+            return metadata<this_type>::label();
+        return TIMEMORY_JOIN("_", typeid(Tag).name(), typeid(InpT).name());
+    }();
+    return _instance;
+}
+//
+template <typename InpT, typename Tag>
+std::string&
+data_tracker<InpT, Tag>::description()
+{
+    static std::string _instance = []() {
+        if(metadata<this_type>::specialized())
+        {
+            auto meta_desc = metadata<this_type>::description();
+            if(settings::verbose() > 0 || settings::debug())
+            {
+                auto meta_extra_desc = metadata<this_type>::extra_description();
+                meta_desc += ". ";
+                meta_desc += meta_extra_desc;
+            }
+            return meta_desc;
+        }
+        std::stringstream ss;
+        ss << "Data tracker for data of type " << demangle<InpT>() << " for "
+           << demangle<Tag>();
+        return ss.str();
+    }();
+    return _instance;
+}
+//
+template <typename InpT, typename Tag>
+template <typename T>
+void
+data_tracker<InpT, Tag>::store(const T& val, enable_if_acceptable_t<T, int>)
+{
+    handler_type::store(*this, compute_type::divide(val, get_unit()));
+    if(!get_is_running())
+        ++laps;
+}
+//
+template <typename InpT, typename Tag>
+template <typename T>
+void
+data_tracker<InpT, Tag>::store(handler_type&&, const T& val,
+                               enable_if_acceptable_t<T, int>)
+{
+    handler_type::store(*this, compute_type::divide(val, get_unit()));
+    if(!get_is_running())
+        ++laps;
+}
+//
+template <typename InpT, typename Tag>
+template <typename FuncT, typename T>
+auto
+data_tracker<InpT, Tag>::store(FuncT&& f, const T& val, enable_if_acceptable_t<T, int>)
+    -> decltype(std::declval<handler_type>().store(*this, std::forward<FuncT>(f), val),
+                void())
+{
+    handler_type::store(*this, std::forward<FuncT>(f),
+                        compute_type::divide(val, get_unit()));
+    if(!get_is_running())
+        ++laps;
+}
+//
+template <typename InpT, typename Tag>
+template <typename FuncT, typename T>
+auto
+data_tracker<InpT, Tag>::store(handler_type&&, FuncT&& f, const T& val,
+                               enable_if_acceptable_t<T, int>)
+    -> decltype(std::declval<handler_type>().store(*this, std::forward<FuncT>(f), val),
+                void())
+{
+    handler_type::store(*this, std::forward<FuncT>(f),
+                        compute_type::divide(val, get_unit()));
+    if(!get_is_running())
+        ++laps;
+}
+//
+template <typename InpT, typename Tag>
+template <typename T>
+void
+data_tracker<InpT, Tag>::mark_begin(const T& val, enable_if_acceptable_t<T, int>)
+{
+    handler_type::begin(get_temporary(), compute_type::divide(val, get_unit()));
+}
+//
+template <typename InpT, typename Tag>
+template <typename T>
+void
+data_tracker<InpT, Tag>::mark_end(const T& val, enable_if_acceptable_t<T, int>)
+{
+    handler_type::end(*this, compute_type::divide(val, get_unit()));
+    if(!get_is_running())
+        ++laps;
+}
+//
+template <typename InpT, typename Tag>
+template <typename T>
+void
+data_tracker<InpT, Tag>::mark_begin(handler_type&&, const T& val,
+                                    enable_if_acceptable_t<T, int>)
+{
+    handler_type::begin(get_temporary(), compute_type::divide(val, get_unit()));
+}
+//
+template <typename InpT, typename Tag>
+template <typename T>
+void
+data_tracker<InpT, Tag>::mark_end(handler_type&&, const T& val,
+                                  enable_if_acceptable_t<T, int>)
+{
+    handler_type::end(*this, compute_type::divide(val, get_unit()));
+    if(!get_is_running())
+        ++laps;
+}
+//
+template <typename InpT, typename Tag>
+template <typename FuncT, typename T>
+void
+data_tracker<InpT, Tag>::mark_begin(FuncT&& f, const T& val,
+                                    enable_if_acceptable_t<T, int>)
+{
+    handler_type::begin(get_temporary(), std::forward<FuncT>(f),
+                        compute_type::divide(val, get_unit()));
+}
+//
+template <typename InpT, typename Tag>
+template <typename FuncT, typename T>
+void
+data_tracker<InpT, Tag>::mark_end(FuncT&& f, const T& val, enable_if_acceptable_t<T, int>)
+{
+    handler_type::end(*this, std::forward<FuncT>(f),
+                      compute_type::divide(val, get_unit()));
+    if(!get_is_running())
+        ++laps;
+}
+//
+template <typename InpT, typename Tag>
+template <typename FuncT, typename T>
+void
+data_tracker<InpT, Tag>::mark_begin(handler_type&&, FuncT&& f, const T& val,
+                                    enable_if_acceptable_t<T, int>)
+{
+    handler_type::begin(get_temporary(), std::forward<FuncT>(f),
+                        compute_type::divide(val, get_unit()));
+}
+//
+template <typename InpT, typename Tag>
+template <typename FuncT, typename T>
+void
+data_tracker<InpT, Tag>::mark_end(handler_type&&, FuncT&& f, const T& val,
+                                  enable_if_acceptable_t<T, int>)
+{
+    handler_type::end(*this, std::forward<FuncT>(f),
+                      compute_type::divide(val, get_unit()));
+    if(!get_is_running())
+        ++laps;
+}
+//
+template <typename InpT, typename Tag>
+template <typename T>
+data_tracker<InpT, Tag>*
+data_tracker<InpT, Tag>::add_secondary(const std::string& _key, const T& val,
+                                       enable_if_acceptable_t<T, int>)
+{
+    this_type _tmp;
+    start_t   _start(_tmp);
+    _tmp.store(val);
+    stop_t _stop(_tmp);
+    auto&  _map = *get_secondary_map();
+    _map.insert({ _key, _tmp });
+    return &(_map[_key]);
+}
+//
+template <typename InpT, typename Tag>
+template <typename T>
+data_tracker<InpT, Tag>*
+data_tracker<InpT, Tag>::add_secondary(const std::string& _key, handler_type&& h,
+                                       const T& val, enable_if_acceptable_t<T, int>)
+{
+    this_type _tmp;
+    start_t   _start(_tmp);
+    _tmp.store(std::forward<handler_type>(h), val);
+    stop_t _stop(_tmp);
+    auto&  _map = *get_secondary_map();
+    _map.insert({ _key, _tmp });
+    return &(_map[_key]);
+}
+//
+template <typename InpT, typename Tag>
+template <typename FuncT, typename T>
+data_tracker<InpT, Tag>*
+data_tracker<InpT, Tag>::add_secondary(const std::string& _key, FuncT&& f, const T& val,
+                                       enable_if_acceptable_and_func_t<FuncT, T, int>)
+{
+    this_type _tmp;
+    start_t   _start(_tmp);
+    _tmp.store(std::forward<FuncT>(f), val);
+    stop_t _stop(_tmp);
+    auto&  _map = *get_secondary_map();
+    _map.insert({ _key, _tmp });
+    return &(_map[_key]);
+}
+//
+template <typename InpT, typename Tag>
+template <typename FuncT, typename T>
+data_tracker<InpT, Tag>*
+data_tracker<InpT, Tag>::add_secondary(const std::string& _key, handler_type&& h,
+                                       FuncT&& f, const T& val,
+                                       enable_if_acceptable_and_func_t<FuncT, T, int>)
+{
+    this_type _tmp;
+    start_t   _start(_tmp);
+    _tmp.store(std::forward<handler_type>(h), std::forward<FuncT>(f), val);
+    stop_t _stop(_tmp);
+    auto&  _map = *get_secondary_map();
+    _map.insert({ _key, _tmp });
+    return &(_map[_key]);
+}
 //
 }  // namespace component
 }  // namespace tim

--- a/source/timemory/components/macros.hpp
+++ b/source/timemory/components/macros.hpp
@@ -231,6 +231,7 @@
             using type                        = TYPE;                                    \
             using value_type                  = TIMEMORY_COMPONENT;                      \
             static constexpr value_type value = ENUM;                                    \
+            static constexpr bool       specialized() { return true; }                   \
             static const char*          enum_string()                                    \
             {                                                                            \
                 static const char* _enum = #ENUM;                                        \
@@ -267,6 +268,8 @@
         {                                                                                \
             using type                  = TYPE;                                          \
             static constexpr bool value = ::tim::trait::is_available<TYPE>::value;       \
+                                                                                         \
+            static constexpr bool specialized() { return true; }                         \
         };                                                                               \
         }                                                                                \
         }
@@ -290,8 +293,10 @@
         template <>                                                                      \
         struct metadata<TYPE>                                                            \
         {                                                                                \
-            using type                        = TYPE;                                    \
-            using value_type                  = TIMEMORY_COMPONENT;                      \
+            using type       = TYPE;                                                     \
+            using value_type = TIMEMORY_COMPONENT;                                       \
+                                                                                         \
+            static constexpr bool       specialized() { return true; }                   \
             static constexpr value_type value = properties<TYPE>::value;                 \
             static std::string          name() { return LABEL; }                         \
             static std::string          label() { return LABEL; }                        \

--- a/source/timemory/components/properties.hpp
+++ b/source/timemory/components/properties.hpp
@@ -218,6 +218,7 @@ struct properties : static_properties<Tp>
     using value_type                          = TIMEMORY_COMPONENT;
     static constexpr TIMEMORY_COMPONENT value = TIMEMORY_COMPONENTS_END;
 
+    static constexpr bool        specialized() { return false; }
     static constexpr const char* enum_string() { return "TIMEMORY_COMPONENTS_END"; }
     static constexpr const char* id() { return ""; }
     static idset_t               ids() { return idset_t{}; }

--- a/source/timemory/macros/attributes.hpp
+++ b/source/timemory/macros/attributes.hpp
@@ -147,3 +147,21 @@
 #if !defined(TIMEMORY_HOT_INLINE)
 #    define TIMEMORY_HOT_INLINE TIMEMORY_HOT TIMEMORY_INLINE
 #endif
+
+//======================================================================================//
+//
+#if !defined(TIMEMORY_DATA_ALIGNMENT)
+#    define TIMEMORY_DATA_ALIGNMENT 8
+#endif
+
+#if !defined(TIMEMORY_PACKED_ALIGNMENT)
+#    if defined(_WIN32)  // Windows 32- and 64-bit
+#        define TIMEMORY_PACKED_ALIGNMENT __declspec(align(ACTIVITY_RECORD_ALIGNMENT))
+#    elif defined(__GNUC__)  // GCC
+#        define TIMEMORY_PACKED_ALIGNMENT                                                \
+            __attribute__((__packed__))                                                  \
+                __attribute__((aligned(ACTIVITY_RECORD_ALIGNMENT)))
+#    else  // all other compilers
+#        define TIMEMORY_PACKED_ALIGNMENT
+#    endif
+#endif

--- a/source/timemory/mpl/apply.hpp
+++ b/source/timemory/mpl/apply.hpp
@@ -25,7 +25,6 @@
 #pragma once
 
 #include "timemory/macros/attributes.hpp"
-#include "timemory/mpl/function_traits.hpp"
 #include "timemory/mpl/math.hpp"
 #include "timemory/mpl/stl.hpp"
 

--- a/source/timemory/mpl/math.hpp
+++ b/source/timemory/mpl/math.hpp
@@ -1072,7 +1072,7 @@ private:
 
     template <typename V>
     static TIMEMORY_INLINE auto min(const type& _l, const V& _r, int)
-        -> decltype(::tim::math::min(_l, _r, get_index_sequence<type>::value, 0),
+        -> decltype(::tim::math::min(_l, _r, get_index_sequence<type>::value),
                     ::tim::math::min(_l, _r))
     {
         return ::tim::math::min(_l, _r);
@@ -1080,7 +1080,7 @@ private:
 
     template <typename V>
     static TIMEMORY_INLINE auto max(const type& _l, const V& _r, int)
-        -> decltype(::tim::math::max(_l, _r, get_index_sequence<type>::value, 0),
+        -> decltype(::tim::math::max(_l, _r, get_index_sequence<type>::value),
                     ::tim::math::max(_l, _r))
     {
         return ::tim::math::max(_l, _r);

--- a/source/timemory/mpl/type_traits.hpp
+++ b/source/timemory/mpl/type_traits.hpp
@@ -178,6 +178,15 @@ private:
 };
 
 //--------------------------------------------------------------------------------------//
+/// \struct tim::trait::default_runtime_enabled
+/// \brief trait whose compile-time constant field `value` designates the default runtime
+/// value of \ref tim::trait::runtime_enabled. Standard setting is true.
+///
+template <typename T>
+struct default_runtime_enabled : true_type
+{};
+
+//--------------------------------------------------------------------------------------//
 /// \struct tim::trait::runtime_enabled
 /// \brief trait that signifies that an implementation is enabled at runtime. The
 /// value returned from get() is for the specific setting for the type, the
@@ -221,7 +230,8 @@ struct runtime_enabled
 private:
     static TIMEMORY_HOT TIMEMORY_INLINE bool& get_runtime_value()
     {
-        static bool _instance = is_available<T>::value;
+        static bool _instance =
+            is_available<T>::value && default_runtime_enabled<T>::value;
         return _instance;
     }
 };

--- a/source/timemory/mpl/types.hpp
+++ b/source/timemory/mpl/types.hpp
@@ -126,6 +126,9 @@ template <typename T>
 using runtime_configurable = concepts::is_runtime_configurable<T>;
 
 template <typename T = void>
+struct default_runtime_enabled;
+
+template <typename T = void>
 struct runtime_enabled;
 
 template <typename T>

--- a/source/timemory/operations/types/generic.hpp
+++ b/source/timemory/operations/types/generic.hpp
@@ -74,7 +74,7 @@ public:
     template <typename Up, typename... Args, typename Rp = type,
               enable_if_t<trait::is_available<Rp>::value, int> = 0,
               enable_if_t<std::is_pointer<Up>::value, int>     = 0>
-    TIMEMORY_ALWAYS_INLINE explicit generic_operator(Up obj, Args&&... args)
+    TIMEMORY_INLINE explicit generic_operator(Up obj, Args&&... args)
     {
         check<Up>();
         if(obj)
@@ -84,7 +84,7 @@ public:
     template <typename Up, typename... Args, typename Rp = type,
               enable_if_t<trait::is_available<Rp>::value, int> = 0,
               enable_if_t<std::is_pointer<Up>::value, int>     = 0>
-    TIMEMORY_ALWAYS_INLINE explicit generic_operator(Up obj, Up rhs, Args&&... args)
+    TIMEMORY_INLINE explicit generic_operator(Up obj, Up rhs, Args&&... args)
     {
         check<Up>();
         if(obj && rhs)
@@ -94,41 +94,41 @@ public:
     //----------------------------------------------------------------------------------//
 private:
     template <typename Up, typename... Args>
-    TIMEMORY_ALWAYS_INLINE auto pointer_sfinae(Up obj, int, int, Args&&... args)
+    TIMEMORY_INLINE auto pointer_sfinae(Up obj, int, int, Args&&... args)
         -> decltype(Op(*obj, std::forward<Args>(args)...), void())
     {
         Op _tmp(*obj, std::forward<Args>(args)...);
     }
 
     template <typename Up, typename... Args>
-    TIMEMORY_ALWAYS_INLINE auto pointer_sfinae(Up obj, int, long, Args&&...)
+    TIMEMORY_INLINE auto pointer_sfinae(Up obj, int, long, Args&&...)
         -> decltype(Op{ *obj }, void())
     {
         Op _tmp{ *obj };
     }
 
     template <typename Up, typename... Args>
-    TIMEMORY_ALWAYS_INLINE void pointer_sfinae(Up, long, long, Args&&...)
+    TIMEMORY_INLINE void pointer_sfinae(Up, long, long, Args&&...)
     {}
 
     //----------------------------------------------------------------------------------//
 
     template <typename Up, typename... Args>
-    TIMEMORY_ALWAYS_INLINE auto pointer_sfinae(Up obj, Up rhs, int, int, Args&&... args)
+    TIMEMORY_INLINE auto pointer_sfinae(Up obj, Up rhs, int, int, Args&&... args)
         -> decltype(Op(*obj, *rhs, std::forward<Args>(args)...), void())
     {
         Op(*obj, *rhs, std::forward<Args>(args)...);
     }
 
     template <typename Up, typename... Args>
-    TIMEMORY_ALWAYS_INLINE auto pointer_sfinae(Up obj, Up rhs, int, long, Args&&...)
+    TIMEMORY_INLINE auto pointer_sfinae(Up obj, Up rhs, int, long, Args&&...)
         -> decltype(Op(*obj, *rhs), void())
     {
         Op(*obj, *rhs);
     }
 
     template <typename Up, typename... Args>
-    TIMEMORY_ALWAYS_INLINE void pointer_sfinae(Up, Up, long, long, Args&&...)
+    TIMEMORY_INLINE void pointer_sfinae(Up, Up, long, long, Args&&...)
     {}
 
     //----------------------------------------------------------------------------------//
@@ -140,7 +140,7 @@ public:
     template <typename Up, typename... Args, typename Rp = Tp,
               enable_if_t<trait::is_available<Rp>::value, int> = 0,
               enable_if_t<!std::is_pointer<Up>::value, int>    = 0>
-    TIMEMORY_ALWAYS_INLINE explicit generic_operator(Up& obj, Args&&... args)
+    TIMEMORY_INLINE explicit generic_operator(Up& obj, Args&&... args)
     {
         check<Up>();
         sfinae(obj, 0, 0, std::forward<Args>(args)...);
@@ -149,7 +149,7 @@ public:
     template <typename Up, typename... Args, typename Rp = Tp,
               enable_if_t<trait::is_available<Rp>::value, int> = 0,
               enable_if_t<!std::is_pointer<Up>::value, int>    = 0>
-    TIMEMORY_ALWAYS_INLINE explicit generic_operator(Up& obj, Up& rhs, Args&&... args)
+    TIMEMORY_INLINE explicit generic_operator(Up& obj, Up& rhs, Args&&... args)
     {
         check<Up>();
         sfinae(obj, rhs, 0, 0, std::forward<Args>(args)...);
@@ -158,14 +158,14 @@ public:
     //----------------------------------------------------------------------------------//
 private:
     template <typename Up, typename... Args>
-    TIMEMORY_ALWAYS_INLINE auto sfinae(Up& obj, int, int, Args&&... args)
+    TIMEMORY_INLINE auto sfinae(Up& obj, int, int, Args&&... args)
         -> decltype(Op(obj, std::forward<Args>(args)...), void())
     {
         Op _tmp(obj, std::forward<Args>(args)...);
     }
 
     template <typename Up, typename... Args>
-    TIMEMORY_ALWAYS_INLINE auto sfinae(Up& obj, int, long, Args&&...)
+    TIMEMORY_INLINE auto sfinae(Up& obj, int, long, Args&&...)
         -> decltype(Op{ obj }, void())
     {
         Op _tmp{ obj };
@@ -173,7 +173,7 @@ private:
 
     template <typename Up, typename... Args,
               enable_if_t<std::is_pointer<Up>::value, int> = 0>
-    TIMEMORY_ALWAYS_INLINE void sfinae(Up& obj, long, long, Args&&... args)
+    TIMEMORY_INLINE void sfinae(Up& obj, long, long, Args&&... args)
     {
         // some operations want a raw pointer, e.g. generic_deleter
         pointer_sfinae(obj, 0, 0, std::forward<Args>(args)...);
@@ -181,20 +181,20 @@ private:
 
     template <typename Up, typename... Args,
               enable_if_t<!std::is_pointer<Up>::value, int> = 0>
-    TIMEMORY_ALWAYS_INLINE void sfinae(Up&, long, long, Args&&...)
+    TIMEMORY_INLINE void sfinae(Up&, long, long, Args&&...)
     {}
 
     //----------------------------------------------------------------------------------//
 
     template <typename Up, typename... Args>
-    TIMEMORY_ALWAYS_INLINE auto sfinae(Up& obj, Up& rhs, int, int, Args&&... args)
+    TIMEMORY_INLINE auto sfinae(Up& obj, Up& rhs, int, int, Args&&... args)
         -> decltype(Op(obj, rhs, std::forward<Args>(args)...), void())
     {
         Op(obj, rhs, std::forward<Args>(args)...);
     }
 
     template <typename Up, typename... Args>
-    TIMEMORY_ALWAYS_INLINE auto sfinae(Up& obj, Up& rhs, int, long, Args&&...)
+    TIMEMORY_INLINE auto sfinae(Up& obj, Up& rhs, int, long, Args&&...)
         -> decltype(Op(obj, rhs), void())
     {
         Op(obj, rhs);
@@ -202,7 +202,7 @@ private:
 
     template <typename Up, typename... Args,
               enable_if_t<std::is_pointer<Up>::value, int> = 0>
-    TIMEMORY_ALWAYS_INLINE void sfinae(Up& obj, Up& rhs, long, long, Args&&... args)
+    TIMEMORY_INLINE void sfinae(Up& obj, Up& rhs, long, long, Args&&... args)
     {
         // some operations want a raw pointer, e.g. generic_deleter
         pointer_sfinae(obj, rhs, 0, 0, std::forward<Args>(args)...);
@@ -210,7 +210,7 @@ private:
 
     template <typename Up, typename... Args,
               enable_if_t<!std::is_pointer<Up>::value, int> = 0>
-    TIMEMORY_ALWAYS_INLINE void sfinae(Up&, Up&, long, long, Args&&...)
+    TIMEMORY_INLINE void sfinae(Up&, Up&, long, long, Args&&...)
     {}
 
     //----------------------------------------------------------------------------------//
@@ -222,7 +222,7 @@ public:
     // if the type is not available, never do anything
     template <typename Up, typename... Args, typename Rp = Tp,
               enable_if_t<!trait::is_available<Rp>::value, int> = 0>
-    TIMEMORY_ALWAYS_INLINE generic_operator(Up&, Args&&...)
+    TIMEMORY_INLINE generic_operator(Up&, Args&&...)
     {}
 };
 //
@@ -239,7 +239,7 @@ struct generic_deleter
 
     TIMEMORY_DELETED_OBJECT(generic_deleter)
 
-    TIMEMORY_ALWAYS_INLINE explicit generic_deleter(type*& obj)
+    TIMEMORY_INLINE explicit generic_deleter(type*& obj)
     {
         DEBUG_PRINT_HERE("%s %s :: %p", "deleting pointer lvalue",
                          demangle<type>().c_str(), (void*) obj);
@@ -248,7 +248,7 @@ struct generic_deleter
     }
 
     template <typename Up, enable_if_t<std::is_pointer<Up>::value, int> = 0>
-    TIMEMORY_ALWAYS_INLINE explicit generic_deleter(Up&& obj)
+    TIMEMORY_INLINE explicit generic_deleter(Up&& obj)
     {
         DEBUG_PRINT_HERE("%s %s :: %p", "deleting pointer rvalue",
                          demangle<type>().c_str(), (void*) obj);
@@ -257,15 +257,14 @@ struct generic_deleter
     }
 
     template <typename... Deleter>
-    TIMEMORY_ALWAYS_INLINE explicit generic_deleter(
-        std::unique_ptr<type, Deleter...>& obj)
+    TIMEMORY_INLINE explicit generic_deleter(std::unique_ptr<type, Deleter...>& obj)
     {
         DEBUG_PRINT_HERE("%s %s :: %p", "deleting unique_ptr", demangle<type>().c_str(),
                          (void*) obj.get());
         obj.reset();
     }
 
-    TIMEMORY_ALWAYS_INLINE explicit generic_deleter(std::shared_ptr<type> obj)
+    TIMEMORY_INLINE explicit generic_deleter(std::shared_ptr<type> obj)
     {
         DEBUG_PRINT_HERE("%s %s :: %p", "deleting shared_ptr", demangle<type>().c_str(),
                          (void*) obj.get());
@@ -273,7 +272,7 @@ struct generic_deleter
     }
 
     template <typename Up, enable_if_t<!std::is_pointer<Up>::value, int> = 0>
-    TIMEMORY_ALWAYS_INLINE explicit generic_deleter(Up&&)
+    TIMEMORY_INLINE explicit generic_deleter(Up&&)
     {
         DEBUG_PRINT_HERE("%s %s", "type is not deleted", demangle<type>().c_str());
     }
@@ -293,14 +292,14 @@ struct generic_counter
     TIMEMORY_DELETED_OBJECT(generic_counter)
 
     template <typename Up, enable_if_t<std::is_pointer<Up>::value, int> = 0>
-    TIMEMORY_ALWAYS_INLINE explicit generic_counter(const Up& obj, uint64_t& count)
+    TIMEMORY_INLINE explicit generic_counter(const Up& obj, uint64_t& count)
     {
         // static_assert(std::is_same<Up, type>::value, "Error! Up != type");
         count += (trait::runtime_enabled<type>::get() && obj) ? 1 : 0;
     }
 
     template <typename Up, enable_if_t<!std::is_pointer<Up>::value, int> = 0>
-    TIMEMORY_ALWAYS_INLINE explicit generic_counter(const Up&, uint64_t& count)
+    TIMEMORY_INLINE explicit generic_counter(const Up&, uint64_t& count)
     {
         // static_assert(std::is_same<Up, type>::value, "Error! Up != type");
         count += (trait::runtime_enabled<type>::get()) ? 1 : 0;

--- a/source/timemory/operations/types/mark.hpp
+++ b/source/timemory/operations/types/mark.hpp
@@ -106,16 +106,16 @@ private:
     //  The equivalent of supports args
     template <typename Up, typename... Args>
     auto sfinae(Up& obj, int, int, Args&&... args)
-        -> decltype(obj.mark_begin(std::forward<Args>(args)...), void())
+        -> decltype(obj.mark_begin(std::forward<Args>(args)...))
     {
-        obj.mark_begin(std::forward<Args>(args)...);
+        return obj.mark_begin(std::forward<Args>(args)...);
     }
 
     //  Member function is provided
     template <typename Up, typename... Args>
-    auto sfinae(Up& obj, int, long, Args&&...) -> decltype(obj.mark_begin(), void())
+    auto sfinae(Up& obj, int, long, Args&&...) -> decltype(obj.mark_begin())
     {
-        obj.mark_begin();
+        return obj.mark_begin();
     }
 
     //  No member function
@@ -148,16 +148,16 @@ private:
     //  The equivalent of supports args
     template <typename Up, typename... Args>
     auto sfinae(Up& obj, int, int, Args&&... args)
-        -> decltype(obj.mark_end(std::forward<Args>(args)...), void())
+        -> decltype(obj.mark_end(std::forward<Args>(args)...))
     {
-        obj.mark_end(std::forward<Args>(args)...);
+        return obj.mark_end(std::forward<Args>(args)...);
     }
 
     //  Member function is provided
     template <typename Up, typename... Args>
-    auto sfinae(Up& obj, int, long, Args&&...) -> decltype(obj.mark_end(), void())
+    auto sfinae(Up& obj, int, long, Args&&...) -> decltype(obj.mark_end())
     {
-        obj.mark_end();
+        return obj.mark_end();
     }
 
     //  No member function

--- a/source/timemory/operations/types/start.hpp
+++ b/source/timemory/operations/types/start.hpp
@@ -128,7 +128,7 @@ private:
     template <typename Up, typename... Args>
     TIMEMORY_HOT_INLINE auto sfinae(Up& obj, true_type&&, Args&&... args)
     {
-        start<Tp> _tmp(obj, std::forward<Args>(args)...);
+        start<Tp>{ obj, std::forward<Args>(args)... };
     }
 
     //  does not satisfy mpl condition
@@ -158,7 +158,7 @@ private:
     template <typename Up, typename... Args>
     TIMEMORY_HOT_INLINE auto sfinae(Up& obj, true_type&&, Args&&... args)
     {
-        start<Tp> _tmp(obj, std::forward<Args>(args)...);
+        start<Tp>{ obj, std::forward<Args>(args)... };
     }
 
     //  does not satisfy mpl condition
@@ -188,7 +188,7 @@ private:
     template <typename Up, typename... Args>
     TIMEMORY_HOT_INLINE auto sfinae(Up& obj, true_type&&, Args&&... args)
     {
-        start<Tp> _tmp(obj, std::forward<Args>(args)...);
+        start<Tp>{ obj, std::forward<Args>(args)... };
     }
 
     //  does not satisfy mpl condition

--- a/source/timemory/operations/types/store.hpp
+++ b/source/timemory/operations/types/store.hpp
@@ -45,10 +45,10 @@ struct store
 {
     using type = Tp;
 
-    TIMEMORY_DELETED_OBJECT(store)
+    TIMEMORY_DEFAULT_OBJECT(store)
 
     template <typename... Args>
-    explicit store(type& obj, Args&&... args)
+    TIMEMORY_HOT_INLINE explicit store(type& obj, Args&&... args)
     {
         if(!trait::runtime_enabled<type>::get())
             return;
@@ -56,29 +56,36 @@ struct store
         sfinae(obj, 0, 0, std::forward<Args>(args)...);
     }
 
+    template <typename... Args>
+    TIMEMORY_HOT_INLINE auto operator()(type& obj, Args&&... args)
+    {
+        return sfinae(obj, 0, 0, std::forward<Args>(args)...);
+    }
+
 private:
     //----------------------------------------------------------------------------------//
     //  The equivalent of supports args and an implementation provided
     //
     template <typename Up, typename... Args>
-    auto sfinae(Up& obj, int, int, Args&&... args)
-        -> decltype(obj.store(std::forward<Args>(args)...), void())
+    TIMEMORY_HOT_INLINE auto sfinae(Up& obj, int, int, Args&&... args)
+        -> decltype(obj.store(std::forward<Args>(args)...))
     {
-        obj.store(std::forward<Args>(args)...);
+        return obj.store(std::forward<Args>(args)...);
     }
 
     //----------------------------------------------------------------------------------//
     //
     template <typename Up, typename... Args>
-    auto sfinae(Up& obj, int, long, Args&&...) -> decltype(obj.store(), void())
+    TIMEMORY_HOT_INLINE auto sfinae(Up& obj, int, long, Args&&...)
+        -> decltype(obj.store())
     {
-        obj.store();
+        return obj.store();
     }
 
     //----------------------------------------------------------------------------------//
     //
     template <typename Up, typename... Args>
-    void sfinae(Up&, long, long, Args&&...)
+    TIMEMORY_INLINE void sfinae(Up&, long, long, Args&&...)
     {}
 };
 //

--- a/source/timemory/runtime/invoker.hpp
+++ b/source/timemory/runtime/invoker.hpp
@@ -25,7 +25,6 @@
 #pragma once
 
 #include "timemory/macros/language.hpp"
-#include "timemory/mpl/function_traits.hpp"
 #include "timemory/utility/types.hpp"
 
 namespace tim

--- a/source/timemory/storage/definition.hpp
+++ b/source/timemory/storage/definition.hpp
@@ -447,8 +447,12 @@ storage<Type, true>::stack_clear()
         std::unordered_set<Type*> _stack = m_stack;
         for(auto& itr : _stack)
         {
-            operation::stop<Type>{ *itr };
-            operation::pop_node<Type>{ *itr };
+            operation::generic_operator<Type, operation::start<Type>, TIMEMORY_API>{
+                *itr
+            };
+            operation::generic_operator<Type, operation::pop_node<Type>, TIMEMORY_API>{
+                *itr
+            };
         }
     }
     m_stack.clear();

--- a/source/timemory/utility/mangler.hpp
+++ b/source/timemory/utility/mangler.hpp
@@ -31,6 +31,7 @@
 #pragma once
 
 #include "timemory/mpl/apply.hpp"
+#include "timemory/mpl/function_traits.hpp"
 #include "timemory/utility/type_id.hpp"
 #include "timemory/utility/utility.hpp"
 

--- a/source/timemory/utility/transient_function.hpp
+++ b/source/timemory/utility/transient_function.hpp
@@ -1,0 +1,123 @@
+// MIT License
+//
+// Copyright (c) 2020, The Regents of the University of California,
+// through Lawrence Berkeley National Laboratory (subject to receipt of any
+// required approvals from the U.S. Dept. of Energy).  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+// For std::decay
+#include <type_traits>
+
+namespace tim
+{
+namespace utility
+{
+template <typename>
+struct transient_function;  // intentionally not defined
+
+/// \struct tim::utility::transient_function
+/// \brief A light-weight alternative to std::function. Pass any callback - including
+/// capturing lambdas - cheaply and quickly as a function argument
+///
+///  - No instantiation of called function at each call site
+///  - Simple to use - use transient_function<> as the function argument
+///  - Low cost, cheap setup, one indirect function call to invoke
+///  - No risk of dynamic allocation (unlike std::function)
+///  - Not persistent: synchronous calls only
+///
+template <typename RetT, typename... Args>
+struct transient_function<RetT(Args...)>
+{
+    using dispatch_type             = RetT (*)(void*, Args...);
+    using target_function_reference = RetT(Args...);
+
+    // dispatch_type() is instantiated by the transient_function constructor,
+    // which will store a pointer to the function in m_dispatch.
+    template <typename Up>
+    static RetT dispatcher(void* target, Args&&... args)
+    {
+        return (*(Up*) target)(std::forward<Args>(args)...);
+    }
+
+    template <typename Tp>
+    transient_function(Tp&& target)
+    : m_dispatch(&dispatcher<std::decay_t<Tp>>)
+    , m_target(&target)
+    {}
+
+    // Specialize for reference-to-function, to ensure that a valid pointer is
+    // stored.
+    transient_function(target_function_reference target)
+    : m_dispatch(dispatcher<target_function_reference>)
+    {
+        static_assert(
+            sizeof(void*) == sizeof target,
+            "It will not be possible to pass functions by reference on this platform. "
+            "Please use explicit function pointers i.e. foo(target) -> foo(&target)");
+        m_target = (void*) target;
+    }
+
+    RetT operator()(Args&&... args) const
+    {
+        return m_dispatch(m_target, std::forward<Args>(args)...);
+    }
+
+private:
+    // A pointer to the static function that will call the wrapped invokable object
+    dispatch_type m_dispatch = nullptr;
+    void*         m_target   = nullptr;  // pointer to the invokable object
+};
+//
+}  // namespace utility
+//
+namespace scope
+{
+//
+//--------------------------------------------------------------------------------------//
+//
+/// \struct tim::scope::destructor
+/// \brief provides an object which can be returned from functions that will execute
+/// the lambda provided during construction when it is destroyed
+///
+struct transient_destructor
+{
+    template <typename FuncT>
+    transient_destructor(FuncT&& _func)
+    : m_functor(std::forward<FuncT>(_func))
+    {}
+
+    // delete copy operations
+    transient_destructor(const transient_destructor&) = delete;
+    transient_destructor& operator=(const transient_destructor&) = delete;
+
+    // allow move operations
+    transient_destructor(transient_destructor&& rhs) noexcept = default;
+    transient_destructor& operator=(transient_destructor&& rhs) noexcept = default;
+
+    ~transient_destructor() { m_functor(); }
+
+private:
+    utility::transient_function<void()> m_functor = []() {};
+};
+}  // namespace scope
+//
+}  // namespace tim

--- a/source/timemory/variadic/auto_base_bundle.cpp
+++ b/source/timemory/variadic/auto_base_bundle.cpp
@@ -1,0 +1,553 @@
+// MIT License
+//
+// Copyright (c) 2020, The Regents of the University of California,
+// through Lawrence Berkeley National Laboratory (subject to receipt of any
+// required approvals from the U.S. Dept. of Energy).  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#ifndef TIMEMORY_VARIADIC_AUTO_BASE_BUNDLE_CPP_
+#define TIMEMORY_VARIADIC_AUTO_BASE_BUNDLE_CPP_ 1
+
+#include "timemory/variadic/auto_base_bundle.hpp"
+
+namespace tim
+{
+//--------------------------------------------------------------------------------------//
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... T>
+auto_base_bundle<Tag, CompT, BundleT>::auto_base_bundle(const std::string&  key,
+                                                        quirk::config<T...> _config,
+                                                        transient_func_t    init_func)
+: m_enabled(settings::enabled())
+, m_report_at_exit(quirk_config<quirk::exit_report, T...>::value)
+, m_reference_object(nullptr)
+, m_temporary(key, m_enabled, _config)
+{
+    if(m_enabled)
+    {
+        internal_init(init_func);
+        IF_CONSTEXPR(!quirk_config<quirk::explicit_start, T...>::value)
+        {
+            m_temporary.start();
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... T>
+auto_base_bundle<Tag, CompT, BundleT>::auto_base_bundle(const captured_location_t& loc,
+                                                        quirk::config<T...> _config,
+                                                        transient_func_t    init_func)
+: m_enabled(settings::enabled())
+, m_report_at_exit(quirk_config<quirk::exit_report, T...>::value)
+, m_reference_object(nullptr)
+, m_temporary(loc, m_enabled, _config)
+{
+    if(m_enabled)
+    {
+        internal_init(init_func);
+        IF_CONSTEXPR(!quirk_config<quirk::explicit_start, T...>::value)
+        {
+            m_temporary.start();
+        }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+
+template <typename Tag, typename CompT, typename BundleT>
+auto_base_bundle<Tag, CompT, BundleT>::auto_base_bundle(const std::string& key,
+                                                        scope::config      _scope,
+                                                        bool               report_at_exit,
+                                                        transient_func_t   init_func)
+: m_enabled(settings::enabled())
+, m_report_at_exit(report_at_exit || quirk_config<quirk::exit_report>::value)
+, m_reference_object(nullptr)
+, m_temporary(key, m_enabled, _scope)
+{
+    if(m_enabled)
+    {
+        internal_init(init_func);
+        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+
+template <typename Tag, typename CompT, typename BundleT>
+auto_base_bundle<Tag, CompT, BundleT>::auto_base_bundle(const captured_location_t& loc,
+                                                        scope::config              _scope,
+                                                        bool             report_at_exit,
+                                                        transient_func_t init_func)
+: m_enabled(settings::enabled())
+, m_report_at_exit(report_at_exit || quirk_config<quirk::exit_report>::value)
+, m_reference_object(nullptr)
+, m_temporary(loc, m_enabled, _scope)
+{
+    if(m_enabled)
+    {
+        internal_init(init_func);
+        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+
+template <typename Tag, typename CompT, typename BundleT>
+auto_base_bundle<Tag, CompT, BundleT>::auto_base_bundle(size_t hash, scope::config _scope,
+                                                        bool             report_at_exit,
+                                                        transient_func_t init_func)
+: m_enabled(settings::enabled())
+, m_report_at_exit(report_at_exit || quirk_config<quirk::exit_report>::value)
+, m_reference_object(nullptr)
+, m_temporary(hash, m_enabled, _scope)
+{
+    if(m_enabled)
+    {
+        internal_init(init_func);
+        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+
+template <typename Tag, typename CompT, typename BundleT>
+auto_base_bundle<Tag, CompT, BundleT>::auto_base_bundle(component_type& tmp,
+                                                        scope::config   _scope,
+                                                        bool            report_at_exit)
+: m_report_at_exit(report_at_exit || quirk_config<quirk::exit_report>::value)
+, m_reference_object(&tmp)
+, m_temporary(component_type(tmp.clone(true, _scope)))
+{
+    if(m_enabled)
+    {
+        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename Arg, typename... Args>
+auto_base_bundle<Tag, CompT, BundleT>::auto_base_bundle(const std::string& key,
+                                                        bool store, scope::config _scope,
+                                                        transient_func_t init_func,
+                                                        Arg&& arg, Args&&... args)
+: m_enabled(store && settings::enabled())
+, m_report_at_exit(settings::destructor_report() ||
+                   quirk_config<quirk::exit_report>::value)
+, m_reference_object(nullptr)
+, m_temporary(key, m_enabled, _scope)
+{
+    if(m_enabled)
+    {
+        internal_init(init_func, std::forward<Arg>(arg), std::forward<Args>(args)...);
+        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename Arg, typename... Args>
+auto_base_bundle<Tag, CompT, BundleT>::auto_base_bundle(const captured_location_t& loc,
+                                                        bool store, scope::config _scope,
+                                                        transient_func_t init_func,
+                                                        Arg&& arg, Args&&... args)
+: m_enabled(store && settings::enabled())
+, m_report_at_exit(settings::destructor_report() ||
+                   quirk_config<quirk::exit_report>::value)
+, m_reference_object(nullptr)
+, m_temporary(loc, m_enabled, _scope)
+{
+    if(m_enabled)
+    {
+        internal_init(init_func, std::forward<Arg>(arg), std::forward<Args>(args)...);
+        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename Arg, typename... Args>
+auto_base_bundle<Tag, CompT, BundleT>::auto_base_bundle(size_t hash, bool store,
+                                                        scope::config    _scope,
+                                                        transient_func_t init_func,
+                                                        Arg&& arg, Args&&... args)
+: m_enabled(store && settings::enabled())
+, m_report_at_exit(settings::destructor_report() ||
+                   quirk_config<quirk::exit_report>::value)
+, m_reference_object(nullptr)
+, m_temporary(hash, m_enabled, _scope)
+{
+    if(m_enabled)
+    {
+        internal_init(init_func, std::forward<Arg>(arg), std::forward<Args>(args)...);
+        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
+    }
+}
+
+//--------------------------------------------------------------------------------------//
+
+template <typename Tag, typename CompT, typename BundleT>
+auto_base_bundle<Tag, CompT, BundleT>::~auto_base_bundle()
+{
+    IF_CONSTEXPR(!quirk_config<quirk::explicit_stop>::value)
+    {
+        if(m_enabled)
+        {
+            // stop the timer
+            m_temporary.stop();
+
+            // report timer at exit
+            if(m_report_at_exit)
+            {
+                std::stringstream ss;
+                ss << m_temporary;
+                if(ss.str().length() > 0)
+                    std::cout << ss.str() << std::endl;
+            }
+
+            if(m_reference_object)
+            {
+                *m_reference_object += m_temporary;
+            }
+        }
+    }
+}
+
+//
+template <typename Tag, typename CompT, typename BundleT>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::push()
+{
+    if(m_enabled)
+        m_temporary.push();
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::pop()
+{
+    if(m_enabled)
+        m_temporary.pop();
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... Args>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::measure(Args&&... args)
+{
+    if(m_enabled)
+        m_temporary.measure(std::forward<Args>(args)...);
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... Args>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::record(Args&&... args)
+{
+    if(m_enabled)
+        m_temporary.record(std::forward<Args>(args)...);
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... Args>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::sample(Args&&... args)
+{
+    if(m_enabled)
+        m_temporary.sample(std::forward<Args>(args)...);
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... Args>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::start(Args&&... args)
+{
+    if(m_enabled)
+        m_temporary.start(std::forward<Args>(args)...);
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... Args>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::stop(Args&&... args)
+{
+    if(m_enabled)
+        m_temporary.stop(std::forward<Args>(args)...);
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... Args>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::assemble(Args&&... args)
+{
+    if(m_enabled)
+        m_temporary.assemble(std::forward<Args>(args)...);
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... Args>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::derive(Args&&... args)
+{
+    if(m_enabled)
+        m_temporary.derive(std::forward<Args>(args)...);
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... Args>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::mark(Args&&... args)
+{
+    if(m_enabled)
+        m_temporary.mark(std::forward<Args>(args)...);
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... Args>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::mark_begin(Args&&... args)
+{
+    if(m_enabled)
+        m_temporary.mark_begin(std::forward<Args>(args)...);
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... Args>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::mark_end(Args&&... args)
+{
+    if(m_enabled)
+        m_temporary.mark_end(std::forward<Args>(args)...);
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... Args>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::store(Args&&... args)
+{
+    if(m_enabled)
+        m_temporary.store(std::forward<Args>(args)...);
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... Args>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::audit(Args&&... args)
+{
+    if(m_enabled)
+        m_temporary.audit(std::forward<Args>(args)...);
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... Args>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::add_secondary(Args&&... args)
+{
+    if(m_enabled)
+        m_temporary.add_secondary(std::forward<Args>(args)...);
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... Args>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::reset(Args&&... args)
+{
+    if(m_enabled)
+        m_temporary.reset(std::forward<Args>(args)...);
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... Args>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::set_scope(Args&&... args)
+{
+    if(m_enabled)
+        m_temporary.set_scope(std::forward<Args>(args)...);
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... Args>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::set_prefix(Args&&... args)
+{
+    if(m_enabled)
+        m_temporary.set_prefix(std::forward<Args>(args)...);
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <template <typename> class OpT, typename... Args>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::invoke(Args&&... _args)
+{
+    if(m_enabled)
+        m_temporary.template invoke<OpT>(std::forward<Args>(_args)...);
+    return static_cast<this_type&>(*this);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+bool
+auto_base_bundle<Tag, CompT, BundleT>::enabled() const
+{
+    return m_enabled;
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+bool
+auto_base_bundle<Tag, CompT, BundleT>::report_at_exit() const
+{
+    return m_report_at_exit;
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+bool
+auto_base_bundle<Tag, CompT, BundleT>::store() const
+{
+    return m_temporary.store();
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+int64_t
+auto_base_bundle<Tag, CompT, BundleT>::laps() const
+{
+    return m_temporary.laps();
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+uint64_t
+auto_base_bundle<Tag, CompT, BundleT>::hash() const
+{
+    return m_temporary.hash();
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+std::string
+auto_base_bundle<Tag, CompT, BundleT>::key() const
+{
+    return m_temporary.key();
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+typename auto_base_bundle<Tag, CompT, BundleT>::data_type&
+auto_base_bundle<Tag, CompT, BundleT>::data()
+{
+    return m_temporary.data();
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+const typename auto_base_bundle<Tag, CompT, BundleT>::data_type&
+auto_base_bundle<Tag, CompT, BundleT>::data() const
+{
+    return m_temporary.data();
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+void
+auto_base_bundle<Tag, CompT, BundleT>::report_at_exit(bool val)
+{
+    m_report_at_exit = val;
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+void
+auto_base_bundle<Tag, CompT, BundleT>::rekey(const std::string& _key)
+{
+    m_temporary.rekey(_key);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::rekey(captured_location_t _loc)
+{
+    m_temporary.rekey(_loc);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+BundleT&
+auto_base_bundle<Tag, CompT, BundleT>::rekey(uint64_t _hash)
+{
+    m_temporary.rekey(_hash);
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+scope::transient_destructor
+auto_base_bundle<Tag, CompT, BundleT>::get_scope_destructor()
+{
+    return scope::transient_destructor{ [&]() { this->stop(); } };
+}
+
+//
+template <typename Tag, typename CompT, typename BundleT>
+template <typename... Tail>
+void
+auto_base_bundle<Tag, CompT, BundleT>::disable()
+{
+    m_temporary.template disable<Tail...>();
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+void
+auto_base_bundle<Tag, CompT, BundleT>::internal_init(transient_func_t _init)
+{
+    if(m_enabled)
+        _init(static_cast<this_type&>(*this));
+}
+
+template <typename Tag, typename CompT, typename BundleT>
+template <typename Arg, typename... Args>
+void
+auto_base_bundle<Tag, CompT, BundleT>::internal_init(transient_func_t _init, Arg&& _arg,
+                                                     Args&&... _args)
+{
+    if(m_enabled)
+    {
+        _init(static_cast<this_type&>(*this));
+        m_temporary.construct(std::forward<Arg>(_arg), std::forward<Args>(_args)...);
+    }
+}
+
+}  // namespace tim
+
+#endif

--- a/source/timemory/variadic/auto_base_bundle.hpp
+++ b/source/timemory/variadic/auto_base_bundle.hpp
@@ -1,0 +1,333 @@
+// MIT License
+//
+// Copyright (c) 2020, The Regents of the University of California,
+// through Lawrence Berkeley National Laboratory (subject to receipt of any
+// required approvals from the U.S. Dept. of Energy).  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+//
+
+#pragma once
+
+#include "timemory/general/source_location.hpp"
+#include "timemory/mpl/filters.hpp"
+#include "timemory/settings/declaration.hpp"
+#include "timemory/utility/macros.hpp"
+#include "timemory/utility/transient_function.hpp"
+#include "timemory/utility/utility.hpp"
+#include "timemory/variadic/component_bundle.hpp"
+#include "timemory/variadic/macros.hpp"
+#include "timemory/variadic/types.hpp"
+
+#include <cstdint>
+#include <string>
+
+namespace tim
+{
+//--------------------------------------------------------------------------------------//
+/// \class tim::auto_base_bundle
+/// \tparam Tag unique identifying type for the bundle which when \ref
+/// tim::trait::is_available<Tag> is false at compile-time or \ref
+/// tim::trait::runtime_enabled<Tag>() is false at runtime, then none of the components
+/// will be collected
+/// \tparam BundleT Bundle to wrap around
+///
+template <typename Tag, typename CompT, typename BundleT>
+class auto_base_bundle<Tag, CompT, BundleT>
+: public concepts::wrapper
+, public concepts::variadic
+, public concepts::auto_wrapper
+, public concepts::tagged
+{
+    static_assert(concepts::is_api<Tag>::value,
+                  "Error! The first template parameter of an 'BundleT' must "
+                  "statisfy the 'is_api' concept");
+
+public:
+    using this_type           = BundleT;
+    using auto_type           = this_type;
+    using base_type           = convert_t<BundleT, CompT>;
+    using component_type      = typename base_type::component_type;
+    using tuple_type          = typename component_type::tuple_type;
+    using data_type           = typename component_type::data_type;
+    using sample_type         = typename component_type::sample_type;
+    using bundle_type         = typename component_type::bundle_type;
+    using initializer_type    = std::function<void(this_type&)>;
+    using transient_func_t    = utility::transient_function<void(this_type&)>;
+    using captured_location_t = typename component_type::captured_location_t;
+    using value_type          = component_type;
+
+    static constexpr bool has_gotcha_v      = component_type::has_gotcha_v;
+    static constexpr bool has_user_bundle_v = component_type::has_user_bundle_v;
+
+public:
+    template <typename T, typename... U>
+    using quirk_config =
+        mpl::impl::quirk_config<T, convert_t<BundleT, type_list<>>, U...>;
+
+public:
+    //
+    static void init_storage() { component_type::init_storage(); }
+    //
+    static initializer_type& get_initializer()
+    {
+        static initializer_type _instance = [](this_type&) {};
+        return _instance;
+    }
+    //
+    static initializer_type& get_finalizer()
+    {
+        static initializer_type _instance = [](this_type&) {};
+        return _instance;
+    }
+
+public:
+    template <typename... T>
+    explicit auto_base_bundle(const std::string&, quirk::config<T...>,
+                              transient_func_t = this_type::get_initializer());
+
+    template <typename... T>
+    explicit auto_base_bundle(const captured_location_t&, quirk::config<T...>,
+                              transient_func_t = this_type::get_initializer());
+
+    explicit auto_base_bundle(const std::string&, scope::config = scope::get_default(),
+                              bool report_at_exit = settings::destructor_report(),
+                              transient_func_t    = this_type::get_initializer());
+
+    explicit auto_base_bundle(const captured_location_t&,
+                              scope::config       = scope::get_default(),
+                              bool report_at_exit = settings::destructor_report(),
+                              transient_func_t    = this_type::get_initializer());
+
+    explicit auto_base_bundle(size_t, scope::config = scope::get_default(),
+                              bool report_at_exit = settings::destructor_report(),
+                              transient_func_t    = this_type::get_initializer());
+
+    explicit auto_base_bundle(component_type& tmp, scope::config = scope::get_default(),
+                              bool report_at_exit = settings::destructor_report());
+
+    template <typename Arg, typename... Args>
+    auto_base_bundle(const std::string&, bool store, scope::config _scope,
+                     transient_func_t, Arg&&, Args&&...);
+
+    template <typename Arg, typename... Args>
+    auto_base_bundle(const captured_location_t&, bool store, scope::config _scope,
+                     transient_func_t, Arg&&, Args&&...);
+
+    template <typename Arg, typename... Args>
+    auto_base_bundle(size_t, bool store, scope::config _scope, transient_func_t, Arg&&,
+                     Args&&...);
+
+    ~auto_base_bundle();
+
+    // copy and move
+    auto_base_bundle(const auto_base_bundle&)     = default;
+    auto_base_bundle(auto_base_bundle&&) noexcept = default;
+    auto_base_bundle& operator=(const auto_base_bundle&) = default;
+    auto_base_bundle& operator=(auto_base_bundle&&) noexcept = default;
+
+    static constexpr std::size_t size() { return component_type::size(); }
+
+public:
+    // public member functions
+    component_type&       get_component() { return m_temporary; }
+    const component_type& get_component() const { return m_temporary; }
+
+    /// implicit conversion to underlying component_type
+    operator component_type&() { return m_temporary; }
+    /// implicit conversion to const ref of underlying component_type
+    operator const component_type&() const { return m_temporary; }
+
+    /// query the number of (compile-time) fixed components
+    static constexpr auto fixed_count() { return component_type::fixed_count(); }
+    /// query the number of (run-time) optional components
+    static constexpr auto optional_count() { return component_type::optional_count(); }
+    /// count number of active components in an instance
+    auto count() { return (m_enabled) ? m_temporary.count() : 0; }
+    /// when chaining together operations, this enables executing a function inside the
+    /// chain
+    template <typename FuncT, typename... Args>
+    decltype(auto) execute(FuncT&& func, Args&&... args)
+    {
+        return bundle::execute(static_cast<this_type&>(*this),
+                               std::forward<FuncT>(func)(std::forward<Args>(args)...));
+    }
+
+    /// push components into call-stack storage
+    this_type& push();
+
+    /// pop components off call-stack storage
+    this_type& pop();
+
+    /// execute a measurement
+    template <typename... Args>
+    this_type& measure(Args&&... args);
+
+    /// record some data
+    template <typename... Args>
+    this_type& record(Args&&... args);
+
+    /// execute a sample
+    template <typename... Args>
+    this_type& sample(Args&&... args);
+
+    /// invoke start member function on all components
+    template <typename... Args>
+    this_type& start(Args&&... args);
+
+    /// invoke stop member function on all components
+    template <typename... Args>
+    this_type& stop(Args&&... args);
+
+    /// invoke assemble member function on all components to determine if measurements can
+    /// be derived from other components in a bundle
+    template <typename... Args>
+    this_type& assemble(Args&&... args);
+
+    /// invoke derive member function on all components to extract measurements from other
+    /// components in the bundle
+    template <typename... Args>
+    this_type& derive(Args&&... args);
+
+    /// invoke mark member function on all components
+    template <typename... Args>
+    this_type& mark(Args&&... args);
+
+    /// invoke mark_begin member function on all components
+    template <typename... Args>
+    this_type& mark_begin(Args&&... args);
+
+    /// invoke mark_begin member function on all components
+    template <typename... Args>
+    this_type& mark_end(Args&&... args);
+
+    /// invoke store member function on all components
+    template <typename... Args>
+    this_type& store(Args&&... args);
+
+    /// invoke audit member function on all components
+    template <typename... Args>
+    this_type& audit(Args&&... args);
+
+    /// add secondary data
+    template <typename... Args>
+    this_type& add_secondary(Args&&... args);
+
+    /// reset the data
+    template <typename... Args>
+    this_type& reset(Args&&... args);
+
+    /// modify the scope of the push operation
+    template <typename... Args>
+    this_type& set_scope(Args&&... args);
+
+    /// set the key
+    template <typename... Args>
+    this_type& set_prefix(Args&&... args);
+
+    /// invoke the provided operation on all components
+    template <template <typename> class OpT, typename... Args>
+    this_type& invoke(Args&&... _args);
+
+    /// invoke get member function on all components to get their data
+    template <typename... Args>
+    auto get(Args&&... args) const
+    {
+        return m_temporary.get(std::forward<Args>(args)...);
+    }
+
+    /// invoke get member function on all components to get data labeled with component
+    /// name
+    template <typename... Args>
+    auto get_labeled(Args&&... args) const
+    {
+        return m_temporary.get_labeled(std::forward<Args>(args)...);
+    }
+
+    TIMEMORY_NODISCARD bool enabled() const;
+    TIMEMORY_NODISCARD bool report_at_exit() const;
+    TIMEMORY_NODISCARD bool store() const;
+    TIMEMORY_NODISCARD int64_t laps() const;
+    TIMEMORY_NODISCARD uint64_t hash() const;
+    TIMEMORY_NODISCARD std::string key() const;
+
+    data_type&       data();
+    const data_type& data() const;
+
+    void report_at_exit(bool val);
+
+    // the string one is expensive so force hashing
+    void       rekey(const std::string& _key);
+    this_type& rekey(captured_location_t _loc);
+    this_type& rekey(uint64_t _hash);
+
+    // returns an stack-object for calling stop
+    scope::transient_destructor get_scope_destructor();
+
+public:
+    template <typename Tp, typename... Args>
+    auto init(Args&&... args)
+    {
+        m_temporary.template init<Tp>(std::forward<Args>(args)...);
+    }
+
+    template <typename... Tp, typename... Args>
+    auto initialize(Args&&... args)
+    {
+        m_temporary.template initialize<Tp...>(std::forward<Args>(args)...);
+    }
+
+    template <typename... Tail>
+    void disable();
+
+    template <typename Tp>
+    decltype(auto) get()
+    {
+        return m_temporary.template get<Tp>();
+    }
+
+    template <typename Tp>
+    decltype(auto) get() const
+    {
+        return m_temporary.template get<Tp>();
+    }
+
+    void get(void*& ptr, size_t hash) { m_temporary.get(ptr, hash); }
+
+    template <typename T>
+    auto get_component()
+        -> decltype(std::declval<component_type>().template get_component<T>())
+    {
+        return m_temporary.template get_component<T>();
+    }
+
+protected:
+    void internal_init(transient_func_t _init);
+
+    template <typename Arg, typename... Args>
+    void internal_init(transient_func_t _init, Arg&& _arg, Args&&... _args);
+
+protected:
+    bool            m_enabled          = true;
+    bool            m_report_at_exit   = false;
+    component_type* m_reference_object = nullptr;
+    component_type  m_temporary;
+};
+//
+}  // namespace tim

--- a/source/timemory/variadic/auto_base_bundle.hpp
+++ b/source/timemory/variadic/auto_base_bundle.hpp
@@ -100,24 +100,24 @@ public:
 public:
     template <typename... T>
     explicit auto_base_bundle(const std::string&, quirk::config<T...>,
-                              transient_func_t = this_type::get_initializer());
+                              transient_func_t = get_initializer());
 
     template <typename... T>
     explicit auto_base_bundle(const captured_location_t&, quirk::config<T...>,
-                              transient_func_t = this_type::get_initializer());
+                              transient_func_t = get_initializer());
 
     explicit auto_base_bundle(const std::string&, scope::config = scope::get_default(),
                               bool report_at_exit = settings::destructor_report(),
-                              transient_func_t    = this_type::get_initializer());
+                              transient_func_t    = get_initializer());
 
     explicit auto_base_bundle(const captured_location_t&,
                               scope::config       = scope::get_default(),
                               bool report_at_exit = settings::destructor_report(),
-                              transient_func_t    = this_type::get_initializer());
+                              transient_func_t    = get_initializer());
 
     explicit auto_base_bundle(size_t, scope::config = scope::get_default(),
                               bool report_at_exit = settings::destructor_report(),
-                              transient_func_t    = this_type::get_initializer());
+                              transient_func_t    = get_initializer());
 
     explicit auto_base_bundle(component_type& tmp, scope::config = scope::get_default(),
                               bool report_at_exit = settings::destructor_report());

--- a/source/timemory/variadic/auto_bundle.hpp
+++ b/source/timemory/variadic/auto_bundle.hpp
@@ -23,22 +23,15 @@
 // SOFTWARE.
 //
 
-/** \file "timemory/variadic/auto_bundle.hpp"
- */
-
 #pragma once
 
-#include "timemory/general/source_location.hpp"
-#include "timemory/mpl/filters.hpp"
-#include "timemory/settings/declaration.hpp"
-#include "timemory/utility/macros.hpp"
-#include "timemory/utility/utility.hpp"
-#include "timemory/variadic/component_bundle.hpp"
-#include "timemory/variadic/macros.hpp"
+#include "timemory/variadic/auto_base_bundle.hpp"
 #include "timemory/variadic/types.hpp"
 
-#include <cstdint>
-#include <string>
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+#include <utility>
 
 namespace tim
 {
@@ -73,7 +66,6 @@ namespace tim
 ///             tim::delimit(tim::get_env<string_t>("FOO_COMPONENTS", "wall_clock")));
 ///
 ///         :im::initialize(b, env_enum);
-///};
 ///     };
 /// }
 /// void bar()
@@ -101,528 +93,56 @@ namespace tim
 /// storage will happen on the stack and when the destructor is called, it will add itself
 /// to the call-graph
 ///
-
 template <typename Tag, typename... Types>
 class auto_bundle<Tag, Types...>
-: public concepts::wrapper
-, public concepts::variadic
-, public concepts::auto_wrapper
+: public auto_base_bundle<Tag, component_bundle<Tag>, auto_bundle<Tag, Types...>>
 , public concepts::mixed_wrapper
-, public concepts::tagged
 {
-    static_assert(concepts::is_api<Tag>::value,
-                  "Error! The first template parameter of an 'auto_bundle' must "
-                  "statisfy the 'is_api' concept");
+    using poly_base =
+        auto_base_bundle<Tag, component_bundle<Tag>, auto_bundle<Tag, Types...>>;
 
 public:
-    using this_type           = auto_bundle<Tag, Types...>;
-    using base_type           = component_bundle<Tag, Types...>;
-    using auto_type           = this_type;
-    using component_type      = typename base_type::component_type;
-    using tuple_type          = typename component_type::tuple_type;
-    using data_type           = typename component_type::data_type;
-    using sample_type         = typename component_type::sample_type;
-    using bundle_type         = typename component_type::bundle_type;
-    using string_t            = std::string;
-    using initializer_type    = std::function<void(this_type&)>;
-    using captured_location_t = typename component_type::captured_location_t;
-    using type       = convert_t<typename component_type::type, auto_bundle<Tag>>;
-    using value_type = component_type;
+    using this_type      = auto_bundle<Tag, Types...>;
+    using base_type      = component_bundle<Tag, Types...>;
+    using auto_type      = this_type;
+    using component_type = typename base_type::component_type;
+    using type           = convert_t<typename component_type::type, auto_bundle<Tag>>;
 
-    static constexpr bool has_gotcha_v      = component_type::has_gotcha_v;
-    static constexpr bool has_user_bundle_v = component_type::has_user_bundle_v;
-
-public:
-    template <typename T, typename... U>
-    using quirk_config = mpl::impl::quirk_config<T, type_list<Types...>, U...>;
-
-public:
-    //
-    //----------------------------------------------------------------------------------//
-    //
-    static void init_storage() { component_type::init_storage(); }
-    //
-    //----------------------------------------------------------------------------------//
-    //
-    static initializer_type& get_initializer()
-    {
-        static initializer_type _instance = [](this_type&) {};
-        return _instance;
-    }
-    //
-    //----------------------------------------------------------------------------------//
-    //
-    static initializer_type& get_finalizer()
-    {
-        static initializer_type _instance = [](this_type&) {};
-        return _instance;
-    }
-
-public:
-    template <typename... T, typename Init = initializer_type>
-    explicit auto_bundle(const string_t&, quirk::config<T...>,
-                         const Init& = this_type::get_initializer());
-
-    template <typename... T, typename Init = initializer_type>
-    explicit auto_bundle(const captured_location_t&, quirk::config<T...>,
-                         const Init& = this_type::get_initializer());
-
-    template <typename Init = initializer_type>
-    explicit auto_bundle(const string_t&, scope::config = scope::get_default(),
-                         bool report_at_exit = settings::destructor_report(),
-                         const Init&         = this_type::get_initializer());
-
-    template <typename Init = initializer_type>
-    explicit auto_bundle(const captured_location_t&, scope::config = scope::get_default(),
-                         bool report_at_exit = settings::destructor_report(),
-                         const Init&         = this_type::get_initializer());
-
-    template <typename Init = initializer_type>
-    explicit auto_bundle(size_t, scope::config = scope::get_default(),
-                         bool report_at_exit = settings::destructor_report(),
-                         const Init&         = this_type::get_initializer());
-
-    explicit auto_bundle(component_type& tmp, scope::config = scope::get_default(),
-                         bool            report_at_exit = settings::destructor_report());
-
-    template <typename Init, typename Arg, typename... Args>
-    auto_bundle(const string_t&, bool store, scope::config _scope, const Init&, Arg&&,
-                Args&&...);
-
-    template <typename Init, typename Arg, typename... Args>
-    auto_bundle(const captured_location_t&, bool store, scope::config _scope, const Init&,
-                Arg&&, Args&&...);
-
-    template <typename Init, typename Arg, typename... Args>
-    auto_bundle(size_t, bool store, scope::config _scope, const Init&, Arg&&, Args&&...);
-
-    ~auto_bundle();
+    template <typename... Args>
+    explicit auto_bundle(Args&&... args);
 
     // copy and move
+    ~auto_bundle()                      = default;
     auto_bundle(const auto_bundle&)     = default;
     auto_bundle(auto_bundle&&) noexcept = default;
     auto_bundle& operator=(const auto_bundle&) = default;
     auto_bundle& operator=(auto_bundle&&) noexcept = default;
 
-    static constexpr std::size_t size() { return component_type::size(); }
+    static constexpr std::size_t size() { return poly_base::size(); }
 
 public:
-    // public member functions
-    component_type&       get_component() { return m_temporary; }
-    const component_type& get_component() const { return m_temporary; }
-
-    /// implicit conversion to underlying component_type
-    operator component_type&() { return m_temporary; }
-    /// implicit conversion to const ref of underlying component_type
-    operator const component_type&() const { return m_temporary; }
-
-    /// query the number of (compile-time) fixed components
-    static constexpr auto fixed_count() { return component_type::fixed_count(); }
-    /// query the number of (run-time) optional components
-    static constexpr auto optional_count() { return component_type::optional_count(); }
-    /// count number of active components in an instance
-    auto count() { return (m_enabled) ? m_temporary.count() : 0; }
-    /// push components into call-stack storage
-    void push()
-    {
-        if(m_enabled)
-            m_temporary.push();
-    }
-    /// pop components off call-stack storage
-    void pop()
-    {
-        if(m_enabled)
-            m_temporary.pop();
-    }
-    /// execute a measurement
-    template <typename... Args>
-    void measure(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.measure(std::forward<Args>(args)...);
-    }
-    /// execute a sample
-    template <typename... Args>
-    void sample(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.sample(std::forward<Args>(args)...);
-    }
-    /// invoke start member function on all components
-    template <typename... Args>
-    void start(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.start(std::forward<Args>(args)...);
-    }
-    /// invoke stop member function on all components
-    template <typename... Args>
-    void stop(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.stop(std::forward<Args>(args)...);
-    }
-    /// invoke assemble member function on all components to determine if measurements can
-    /// be derived from other components in a bundle
-    template <typename... Args>
-    void assemble(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.assemble(std::forward<Args>(args)...);
-    }
-    /// invoke derive member function on all components to extract measurements from other
-    /// components in the bundle
-    template <typename... Args>
-    void derive(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.derive(std::forward<Args>(args)...);
-    }
-    /// invoke mark member function on all components
-    template <typename... Args>
-    void mark(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.mark(std::forward<Args>(args)...);
-    }
-    /// invoke mark_begin member function on all components
-    template <typename... Args>
-    void mark_begin(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.mark_begin(std::forward<Args>(args)...);
-    }
-    /// invoke mark_begin member function on all components
-    template <typename... Args>
-    void mark_end(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.mark_end(std::forward<Args>(args)...);
-    }
-    /// invoke store member function on all components
-    template <typename... Args>
-    void store(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.store(std::forward<Args>(args)...);
-    }
-    /// invoke audit member function on all components
-    template <typename... Args>
-    void audit(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.audit(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void add_secondary(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.add_secondary(std::forward<Args>(args)...);
-    }
-    /// invoke the provided operation on all components
-    template <template <typename> class OpT, typename... Args>
-    void invoke(Args&&... _args)
-    {
-        if(m_enabled)
-            m_temporary.template invoke<OpT>(std::forward<Args>(_args)...);
-    }
-    /// invoke get member function on all components to get their data
-    template <typename... Args>
-    auto get(Args&&... args) const
-    {
-        return m_temporary.get(std::forward<Args>(args)...);
-    }
-    /// invoke get member function on all components to get data labeled with component
-    /// name
-    template <typename... Args>
-    auto get_labeled(Args&&... args) const
-    {
-        return m_temporary.get_labeled(std::forward<Args>(args)...);
-    }
-
-    TIMEMORY_NODISCARD bool enabled() const { return m_enabled; }
-    void                    report_at_exit(bool val) { m_report_at_exit = val; }
-    TIMEMORY_NODISCARD bool report_at_exit() const { return m_report_at_exit; }
-
-    TIMEMORY_NODISCARD bool store() const { return m_temporary.store(); }
-    data_type&              data() { return m_temporary.data(); }
-    const data_type&        data() const { return m_temporary.data(); }
-    TIMEMORY_NODISCARD int64_t laps() const { return m_temporary.laps(); }
-    auto                       key() const { return m_temporary.key(); }
-    TIMEMORY_NODISCARD uint64_t hash() const { return m_temporary.hash(); }
-    void                        rekey(const string_t& _key) { m_temporary.rekey(_key); }
-
-public:
-    template <typename Tp, typename... Args>
-    auto init(Args&&... args)
-    {
-        m_temporary.template init<Tp>(std::forward<Args>(args)...);
-    }
-
-    template <typename... Tp, typename... Args>
-    auto initialize(Args&&... args)
-    {
-        m_temporary.template initialize<Tp...>(std::forward<Args>(args)...);
-    }
-
-    template <typename... Tail>
-    void disable()
-    {
-        m_temporary.template disable<Tail...>();
-    }
-
-    template <typename Tp>
-    decltype(auto) get()
-    {
-        return m_temporary.template get<Tp>();
-    }
-
-    template <typename Tp>
-    decltype(auto) get() const
-    {
-        return m_temporary.template get<Tp>();
-    }
-
-    void get(void*& ptr, size_t hash) { m_temporary.get(ptr, hash); }
-
-    template <typename T>
-    auto get_component()
-        -> decltype(std::declval<component_type>().template get_component<T>())
-    {
-        return m_temporary.template get_component<T>();
-    }
-
-protected:
-    template <typename Func>
-    void internal_init(Func&& _init)
-    {
-        if(m_enabled)
-            _init(*this);
-    }
-
-    template <typename Func, typename Arg, typename... Args>
-    void internal_init(Func&& _init, Arg&& _arg, Args&&... _args)
-    {
-        if(m_enabled)
-        {
-            _init(*this);
-            m_temporary.construct(std::forward<Arg>(_arg), std::forward<Args>(_args)...);
-        }
-    }
-
-public:
+    this_type&           print(std::ostream& os, bool _endl = false) const;
     friend std::ostream& operator<<(std::ostream& os, const this_type& obj)
     {
-        os << obj.m_temporary;
+        obj.print(os, false);
         return os;
     }
-
-protected:
-    bool            m_enabled          = true;
-    bool            m_report_at_exit   = false;
-    component_type* m_reference_object = nullptr;
-    component_type  m_temporary;
 };
-
-//--------------------------------------------------------------------------------------//
-
+//
 template <typename Tag, typename... Types>
-template <typename... T, typename Init>
-auto_bundle<Tag, Types...>::auto_bundle(const string_t& key, quirk::config<T...> _config,
-                                        const Init& init_func)
-: m_enabled(settings::enabled())
-, m_report_at_exit(quirk_config<quirk::exit_report, T...>::value)
-, m_reference_object(nullptr)
-, m_temporary(key, m_enabled, _config)
-{
-    if(m_enabled)
-    {
-        internal_init(init_func);
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start, T...>::value)
-        {
-            m_temporary.start();
-        }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
+template <typename... Args>
+auto_bundle<Tag, Types...>::auto_bundle(Args&&... args)
+: poly_base{ std::forward<Args>(args)... }
+{}
+//
 template <typename Tag, typename... Types>
-template <typename... T, typename Init>
-auto_bundle<Tag, Types...>::auto_bundle(const captured_location_t& loc,
-                                        quirk::config<T...>        _config,
-                                        const Init&                init_func)
-: m_enabled(settings::enabled())
-, m_report_at_exit(quirk_config<quirk::exit_report, T...>::value)
-, m_reference_object(nullptr)
-, m_temporary(loc, m_enabled, _config)
+auto_bundle<Tag, Types...>&
+auto_bundle<Tag, Types...>::print(std::ostream& os, bool _endl) const
 {
-    if(m_enabled)
-    {
-        internal_init(init_func);
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start, T...>::value)
-        {
-            m_temporary.start();
-        }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename Tag, typename... Types>
-template <typename Init>
-auto_bundle<Tag, Types...>::auto_bundle(const string_t& key, scope::config _scope,
-                                        bool report_at_exit, const Init& init_func)
-: m_enabled(settings::enabled())
-, m_report_at_exit(report_at_exit || quirk_config<quirk::exit_report>::value)
-, m_reference_object(nullptr)
-, m_temporary(key, m_enabled, _scope)
-{
-    if(m_enabled)
-    {
-        internal_init(init_func);
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename Tag, typename... Types>
-template <typename Init>
-auto_bundle<Tag, Types...>::auto_bundle(const captured_location_t& loc,
-                                        scope::config _scope, bool report_at_exit,
-                                        const Init& init_func)
-: m_enabled(settings::enabled())
-, m_report_at_exit(report_at_exit || quirk_config<quirk::exit_report>::value)
-, m_reference_object(nullptr)
-, m_temporary(loc, m_enabled, _scope)
-{
-    if(m_enabled)
-    {
-        internal_init(init_func);
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename Tag, typename... Types>
-template <typename Init>
-auto_bundle<Tag, Types...>::auto_bundle(size_t hash, scope::config _scope,
-                                        bool report_at_exit, const Init& init_func)
-: m_enabled(settings::enabled())
-, m_report_at_exit(report_at_exit || quirk_config<quirk::exit_report>::value)
-, m_reference_object(nullptr)
-, m_temporary(hash, m_enabled, _scope)
-{
-    if(m_enabled)
-    {
-        internal_init(init_func);
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename Tag, typename... Types>
-auto_bundle<Tag, Types...>::auto_bundle(component_type& tmp, scope::config _scope,
-                                        bool report_at_exit)
-: m_report_at_exit(report_at_exit || quirk_config<quirk::exit_report>::value)
-, m_reference_object(&tmp)
-, m_temporary(component_type(tmp.clone(true, _scope)))
-{
-    if(m_enabled)
-    {
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename Tag, typename... Types>
-template <typename Init, typename Arg, typename... Args>
-auto_bundle<Tag, Types...>::auto_bundle(const string_t& key, bool store,
-                                        scope::config _scope, const Init& init_func,
-                                        Arg&& arg, Args&&... args)
-: m_enabled(store && settings::enabled())
-, m_report_at_exit(settings::destructor_report() ||
-                   quirk_config<quirk::exit_report>::value)
-, m_reference_object(nullptr)
-, m_temporary(key, m_enabled, _scope)
-{
-    if(m_enabled)
-    {
-        internal_init(init_func, std::forward<Arg>(arg), std::forward<Args>(args)...);
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename Tag, typename... Types>
-template <typename Init, typename Arg, typename... Args>
-auto_bundle<Tag, Types...>::auto_bundle(const captured_location_t& loc, bool store,
-                                        scope::config _scope, const Init& init_func,
-                                        Arg&& arg, Args&&... args)
-: m_enabled(store && settings::enabled())
-, m_report_at_exit(settings::destructor_report() ||
-                   quirk_config<quirk::exit_report>::value)
-, m_reference_object(nullptr)
-, m_temporary(loc, m_enabled, _scope)
-{
-    if(m_enabled)
-    {
-        internal_init(init_func, std::forward<Arg>(arg), std::forward<Args>(args)...);
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename Tag, typename... Types>
-template <typename Init, typename Arg, typename... Args>
-auto_bundle<Tag, Types...>::auto_bundle(size_t hash, bool store, scope::config _scope,
-                                        const Init& init_func, Arg&& arg, Args&&... args)
-: m_enabled(store && settings::enabled())
-, m_report_at_exit(settings::destructor_report() ||
-                   quirk_config<quirk::exit_report>::value)
-, m_reference_object(nullptr)
-, m_temporary(hash, m_enabled, _scope)
-{
-    if(m_enabled)
-    {
-        internal_init(init_func, std::forward<Arg>(arg), std::forward<Args>(args)...);
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename Tag, typename... Types>
-auto_bundle<Tag, Types...>::~auto_bundle()
-{
-    IF_CONSTEXPR(!quirk_config<quirk::explicit_stop>::value)
-    {
-        if(m_enabled)
-        {
-            // stop the timer
-            m_temporary.stop();
-
-            // report timer at exit
-            if(m_report_at_exit)
-            {
-                std::stringstream ss;
-                ss << m_temporary;
-                if(ss.str().length() > 0)
-                    std::cout << ss.str() << std::endl;
-            }
-
-            if(m_reference_object)
-            {
-                *m_reference_object += m_temporary;
-            }
-        }
-    }
+    os << poly_base::m_temporary;
+    if(_endl)
+        os << '\n';
+    return const_cast<this_type&>(*this);
 }
 //
 //======================================================================================//
@@ -642,9 +162,7 @@ get_labeled(const auto_bundle<Tag, Types...>& _obj)
 {
     return get_labeled(_obj.get_component());
 }
-
-//======================================================================================//
-
+//
 }  // namespace tim
 
 //======================================================================================//
@@ -710,5 +228,3 @@ get(tim::auto_bundle<Tag, Types...>&& obj)
 //--------------------------------------------------------------------------------------//
 //
 }  // namespace std
-//
-//======================================================================================//

--- a/source/timemory/variadic/auto_list.hpp
+++ b/source/timemory/variadic/auto_list.hpp
@@ -23,23 +23,15 @@
 // SOFTWARE.
 //
 
-/** \file timemory/variadic/auto_list.hpp
- * \headerfile timemory/variadic/auto_list.hpp "timemory/variadic/auto_list.hpp"
- */
-
 #pragma once
 
-#include "timemory/mpl/filters.hpp"
-#include "timemory/runtime/types.hpp"
-#include "timemory/settings/declaration.hpp"
-#include "timemory/utility/macros.hpp"
-#include "timemory/utility/utility.hpp"
-#include "timemory/variadic/component_list.hpp"
-#include "timemory/variadic/macros.hpp"
+#include "timemory/variadic/auto_base_bundle.hpp"
 #include "timemory/variadic/types.hpp"
 
-#include <cstdint>
-#include <string>
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+#include <utility>
 
 namespace tim
 {
@@ -94,367 +86,73 @@ namespace tim
 /// when the destructor is called, it will add itself to the call-graph
 template <typename... Types>
 class auto_list
-: public concepts::wrapper
-, public concepts::variadic
-, public concepts::auto_wrapper
+: public auto_base_bundle<TIMEMORY_API, component_list<>, auto_list<Types...>>
 , public concepts::heap_wrapper
 {
-public:
-    using this_type           = auto_list<Types...>;
-    using base_type           = component_list<Types...>;
-    using auto_type           = this_type;
-    using component_type      = typename base_type::component_type;
-    using data_type           = typename component_type::data_type;
-    using tuple_type          = typename component_type::tuple_type;
-    using sample_type         = typename component_type::sample_type;
-    using type                = convert_t<typename component_type::type, auto_list<>>;
-    using initializer_type    = std::function<void(this_type&)>;
-    using string_t            = std::string;
-    using captured_location_t = typename component_type::captured_location_t;
-
-    static constexpr bool has_gotcha_v      = component_type::has_gotcha_v;
-    static constexpr bool has_user_bundle_v = component_type::has_user_bundle_v;
+    using poly_base =
+        auto_base_bundle<TIMEMORY_API, component_list<>, auto_list<Types...>>;
 
 public:
-    //----------------------------------------------------------------------------------//
-    //
-    static void init_storage() { component_type::init_storage(); }
+    using this_type      = auto_list<Types...>;
+    using base_type      = component_list<Types...>;
+    using auto_type      = this_type;
+    using component_type = typename base_type::component_type;
+    using type           = convert_t<typename component_type::type, auto_list<>>;
 
-    //----------------------------------------------------------------------------------//
-    //
-    /// \fn auto& get_initializer()
-    /// \brief
-    static auto& get_initializer()
-    {
-        static auto env_enum = enumerate_components(
-            tim::delimit(tim::get_env<string_t>("TIMEMORY_AUTO_LIST_INIT", "")));
-
-        static initializer_type _instance = [=](this_type& cl) {
-            ::tim::initialize(cl, env_enum);
-        };
-        return _instance;
-    }
-
-public:
-    template <typename Func = initializer_type>
-    explicit auto_list(const string_t&, scope::config = scope::get_default(),
-                       bool report_at_exit = settings::destructor_report(),
-                       const Func&         = get_initializer());
-
-    template <typename Func = initializer_type>
-    explicit auto_list(const captured_location_t&, scope::config = scope::get_default(),
-                       bool report_at_exit = settings::destructor_report(),
-                       const Func&         = get_initializer());
-
-    template <typename Func = initializer_type>
-    explicit auto_list(size_t, scope::config = scope::get_default(),
-                       bool report_at_exit = settings::destructor_report(),
-                       const Func&         = get_initializer());
-
-    explicit auto_list(component_type& tmp, scope::config = scope::get_default(),
-                       bool            report_at_exit = settings::destructor_report());
-    ~auto_list();
+    template <typename... Args>
+    explicit auto_list(Args&&... args);
 
     // copy and move
-    auto_list(const this_type&)     = default;
-    auto_list(this_type&&) noexcept = default;
+    ~auto_list()                    = default;
+    auto_list(const auto_list&)     = default;
+    auto_list(auto_list&&) noexcept = default;
     auto_list& operator=(const auto_list&) = default;
     auto_list& operator=(auto_list&&) noexcept = default;
 
-    static constexpr std::size_t size() { return component_type::size(); }
+    static constexpr std::size_t size() { return poly_base::size(); }
 
 public:
-    // public member functions
-    component_type&       get_component() { return m_temporary; }
-    const component_type& get_component() const { return m_temporary; }
-
-    operator component_type&() { return m_temporary; }
-    operator const component_type&() const { return m_temporary; }
-
-    // partial interface to underlying component_list
-    void push()
-    {
-        if(m_enabled)
-            m_temporary.push();
-    }
-    void pop()
-    {
-        if(m_enabled)
-            m_temporary.pop();
-    }
-    template <typename... Args>
-    void measure(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.measure(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void sample(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.sample(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void start(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.start(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void stop(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.stop(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void assemble(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.assemble(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void derive(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.derive(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void mark(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.mark(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void mark_begin(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.mark_begin(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void mark_end(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.mark_end(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void store(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.store(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void audit(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.audit(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void add_secondary(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.add_secondary(std::forward<Args>(args)...);
-    }
-    template <template <typename> class OpT, typename... Args>
-    void invoke(Args&&... _args)
-    {
-        if(m_enabled)
-            m_temporary.template invoke<OpT>(std::forward<Args>(_args)...);
-    }
-    template <typename... Args>
-    auto get(Args&&... args) const
-    {
-        return m_temporary.get(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    auto get_labeled(Args&&... args) const
-    {
-        return m_temporary.get_labeled(std::forward<Args>(args)...);
-    }
-
-    TIMEMORY_NODISCARD bool enabled() const { return m_enabled; }
-    void                    report_at_exit(bool val) { m_report_at_exit = val; }
-    TIMEMORY_NODISCARD bool report_at_exit() const { return m_report_at_exit; }
-
-    TIMEMORY_NODISCARD bool store() const { return m_temporary.store(); }
-    data_type&              data() { return m_temporary.data(); }
-    const data_type&        data() const { return m_temporary.data(); }
-    TIMEMORY_NODISCARD int64_t laps() const { return m_temporary.laps(); }
-    auto                       key() const { return m_temporary.key(); }
-    TIMEMORY_NODISCARD uint64_t hash() const { return m_temporary.hash(); }
-    void                        rekey(const string_t& _key) { m_temporary.rekey(_key); }
-
-public:
-    template <typename Tp>
-    decltype(auto) get()
-    {
-        return m_temporary.template get<Tp>();
-    }
-
-    template <typename Tp>
-    decltype(auto) get() const
-    {
-        return m_temporary.template get<Tp>();
-    }
-
-    void get(void*& ptr, size_t _hash) { m_temporary.get(ptr, _hash); }
-
-    template <typename T>
-    auto get_component()
-        -> decltype(std::declval<component_type>().template get_component<T>())
-    {
-        return m_temporary.template get_component<T>();
-    }
-
-    template <typename Tp, typename... Args>
-    void init(Args&&... _args)
-    {
-        m_temporary.template init<Tp>(std::forward<Args>(_args)...);
-    }
-
-    template <typename... Tp, typename... Args>
-    void initialize(Args&&... _args)
-    {
-        m_temporary.template initialize<Tp...>(std::forward<Args>(_args)...);
-    }
-
-    template <typename... Tail>
-    void disable()
-    {
-        m_temporary.template disable<Tail...>();
-    }
-
-public:
+    this_type&           print(std::ostream& os, bool _endl = false) const;
     friend std::ostream& operator<<(std::ostream& os, const this_type& obj)
     {
-        os << obj.m_temporary;
+        obj.print(os, false);
         return os;
     }
-
-private:
-    bool            m_enabled        = true;
-    bool            m_report_at_exit = false;
-    component_type  m_temporary;
-    component_type* m_reference_object = nullptr;
 };
-
+//
+template <typename... Types>
+template <typename... Args>
+auto_list<Types...>::auto_list(Args&&... args)
+: poly_base{ std::forward<Args>(args)... }
+{}
+//
+template <typename... Types>
+auto_list<Types...>&
+auto_list<Types...>::print(std::ostream& os, bool _endl) const
+{
+    os << poly_base::m_temporary;
+    if(_endl)
+        os << '\n';
+    return const_cast<this_type&>(*this);
+}
+//
 //======================================================================================//
-
-template <typename... Types>
-template <typename Func>
-auto_list<Types...>::auto_list(const string_t& key, scope::config _scope,
-                               bool report_at_exit, const Func& _func)
-: m_enabled(settings::enabled())
-, m_report_at_exit(report_at_exit)
-, m_temporary(key, m_enabled, _scope)
-, m_reference_object(nullptr)
-{
-    if(m_enabled)
-    {
-        _func(*this);
-        m_temporary.start();
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename... Types>
-template <typename Func>
-auto_list<Types...>::auto_list(const captured_location_t& loc, scope::config _scope,
-                               bool report_at_exit, const Func& _func)
-: m_enabled(settings::enabled())
-, m_report_at_exit(report_at_exit)
-, m_temporary(loc, m_enabled, _scope)
-, m_reference_object(nullptr)
-{
-    if(m_enabled)
-    {
-        _func(*this);
-        m_temporary.start();
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename... Types>
-template <typename Func>
-auto_list<Types...>::auto_list(size_t _hash, scope::config _scope, bool report_at_exit,
-                               const Func& _func)
-: m_enabled(settings::enabled())
-, m_report_at_exit(report_at_exit)
-, m_temporary(_hash, m_enabled, _scope)
-, m_reference_object(nullptr)
-{
-    if(m_enabled)
-    {
-        _func(*this);
-        m_temporary.start();
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename... Types>
-auto_list<Types...>::auto_list(component_type& tmp, scope::config _scope,
-                               bool report_at_exit)
-: m_report_at_exit(report_at_exit)
-, m_temporary(tmp.clone(true, _scope))
-, m_reference_object(&tmp)
-{
-    if(m_enabled)
-    {
-        m_temporary.start();
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename... Types>
-auto_list<Types...>::~auto_list()
-{
-    if(m_enabled)
-    {
-        // stop the timer
-        m_temporary.stop();
-
-        // report timer at exit
-        if(m_report_at_exit)
-        {
-            std::stringstream ss;
-            ss << m_temporary;
-            if(ss.str().length() > 0)
-                std::cout << ss.str() << std::endl;
-        }
-
-        if(m_reference_object)
-        {
-            *m_reference_object += m_temporary;
-        }
-    }
-}
-
-//======================================================================================//
-
+//
 template <typename... Types>
 auto
 get(const auto_list<Types...>& _obj)
 {
     return get(_obj.get_component());
 }
-
-//--------------------------------------------------------------------------------------//
-
+//
 template <typename... Types>
 auto
 get_labeled(const auto_list<Types...>& _obj)
 {
     return get_labeled(_obj.get_component());
 }
-
-//======================================================================================//
-
+//
 }  // namespace tim
-
-//======================================================================================//
 
 //--------------------------------------------------------------------------------------//
 // variadic versions

--- a/source/timemory/variadic/auto_tuple.hpp
+++ b/source/timemory/variadic/auto_tuple.hpp
@@ -73,8 +73,8 @@ public:
     using component_type = typename base_type::component_type;
     using type           = convert_t<available_t<concat<Types...>>, auto_tuple<>>;
 
-    template <typename Tp, typename... Args>
-    explicit auto_tuple(Tp&&, Args&&... args);
+    template <typename... Args>
+    explicit auto_tuple(Args&&... args);
 
     // copy and move
     ~auto_tuple()                     = default;
@@ -95,9 +95,9 @@ public:
 };
 //
 template <typename... Types>
-template <typename Tp, typename... Args>
-auto_tuple<Types...>::auto_tuple(Tp&& inp, Args&&... args)
-: poly_base{ std::forward<Tp>(inp), std::forward<Args>(args)... }
+template <typename... Args>
+auto_tuple<Types...>::auto_tuple(Args&&... args)
+: poly_base{ std::forward<Args>(args)... }
 {}
 //
 template <typename... Types>

--- a/source/timemory/variadic/auto_tuple.hpp
+++ b/source/timemory/variadic/auto_tuple.hpp
@@ -23,23 +23,15 @@
 // SOFTWARE.
 //
 
-/** \file timemory/variadic/auto_tuple.hpp
- * \headerfile timemory/variadic/auto_tuple.hpp "timemory/variadic/auto_tuple.hpp"
- */
-
 #pragma once
 
-#include "timemory/general/source_location.hpp"
-#include "timemory/mpl/filters.hpp"
-#include "timemory/settings/declaration.hpp"
-#include "timemory/utility/macros.hpp"
-#include "timemory/utility/utility.hpp"
-#include "timemory/variadic/component_tuple.hpp"
-#include "timemory/variadic/macros.hpp"
+#include "timemory/variadic/auto_base_bundle.hpp"
 #include "timemory/variadic/types.hpp"
 
-#include <cstdint>
-#include <string>
+#include <cstddef>
+#include <tuple>
+#include <type_traits>
+#include <utility>
 
 namespace tim
 {
@@ -68,494 +60,72 @@ namespace tim
 ///
 template <typename... Types>
 class auto_tuple
-: public concepts::wrapper
-, public concepts::variadic
-, public concepts::auto_wrapper
+: public auto_base_bundle<TIMEMORY_API, component_tuple<>, auto_tuple<Types...>>
 , public concepts::stack_wrapper
 {
-public:
-    using this_type           = auto_tuple<Types...>;
-    using base_type           = component_tuple<Types...>;
-    using auto_type           = this_type;
-    using component_type      = typename base_type::component_type;
-    using tuple_type          = typename component_type::tuple_type;
-    using data_type           = typename component_type::data_type;
-    using sample_type         = typename component_type::sample_type;
-    using type                = convert_t<typename component_type::type, auto_tuple<>>;
-    using string_t            = string_view_t;
-    using initializer_type    = std::function<void(this_type&)>;
-    using captured_location_t = typename component_type::captured_location_t;
-    using value_type          = component_type;
-
-    static constexpr bool has_gotcha_v      = component_type::has_gotcha_v;
-    static constexpr bool has_user_bundle_v = component_type::has_user_bundle_v;
+    using poly_base =
+        auto_base_bundle<TIMEMORY_API, component_tuple<>, auto_tuple<Types...>>;
 
 public:
-    template <typename T, typename... U>
-    using quirk_config = mpl::impl::quirk_config<T, type_list<Types...>, U...>;
+    using this_type      = auto_tuple<Types...>;
+    using base_type      = component_tuple<Types...>;
+    using auto_type      = this_type;
+    using component_type = typename base_type::component_type;
+    using type           = convert_t<available_t<concat<Types...>>, auto_tuple<>>;
 
-public:
-    //
-    //----------------------------------------------------------------------------------//
-    //
-    static void init_storage() { component_type::init_storage(); }
-    //
-    //----------------------------------------------------------------------------------//
-    //
-    static initializer_type& get_initializer()
-    {
-        static initializer_type _instance = [](this_type&) {};
-        return _instance;
-    }
-    //
-    //----------------------------------------------------------------------------------//
-    //
-    static initializer_type& get_finalizer()
-    {
-        static initializer_type _instance = [](this_type&) {};
-        return _instance;
-    }
-
-public:
-    template <typename... T, typename Init = initializer_type>
-    explicit auto_tuple(const string_t&, quirk::config<T...>,
-                        const Init& = this_type::get_initializer());
-
-    template <typename... T, typename Init = initializer_type>
-    explicit auto_tuple(const captured_location_t&, quirk::config<T...>,
-                        const Init& = this_type::get_initializer());
-
-    template <typename Init = initializer_type>
-    explicit auto_tuple(const string_t&, scope::config = scope::get_default(),
-                        bool report_at_exit = settings::destructor_report(),
-                        const Init&         = this_type::get_initializer());
-
-    template <typename Init = initializer_type>
-    explicit auto_tuple(const captured_location_t&, scope::config = scope::get_default(),
-                        bool report_at_exit = settings::destructor_report(),
-                        const Init&         = this_type::get_initializer());
-
-    template <typename Init = initializer_type>
-    explicit auto_tuple(size_t, scope::config = scope::get_default(),
-                        bool report_at_exit = settings::destructor_report(),
-                        const Init&         = this_type::get_initializer());
-
-    explicit auto_tuple(component_type& tmp, scope::config = scope::get_default(),
-                        bool            report_at_exit = settings::destructor_report());
-
-    template <typename Init, typename Arg, typename... Args>
-    auto_tuple(const string_t&, bool store, scope::config _scope, const Init&, Arg&&,
-               Args&&...);
-
-    template <typename Init, typename Arg, typename... Args>
-    auto_tuple(const captured_location_t&, bool store, scope::config _scope, const Init&,
-               Arg&&, Args&&...);
-
-    template <typename Init, typename Arg, typename... Args>
-    auto_tuple(size_t, bool store, scope::config _scope, const Init&, Arg&&, Args&&...);
-
-    ~auto_tuple();
+    template <typename Tp, typename... Args>
+    explicit auto_tuple(Tp&&, Args&&... args);
 
     // copy and move
+    ~auto_tuple()                     = default;
     auto_tuple(const auto_tuple&)     = default;
     auto_tuple(auto_tuple&&) noexcept = default;
     auto_tuple& operator=(const auto_tuple&) = default;
     auto_tuple& operator=(auto_tuple&&) noexcept = default;
 
-    static constexpr std::size_t size() { return component_type::size(); }
+    static constexpr std::size_t size() { return poly_base::size(); }
 
 public:
-    // public member functions
-    component_type&       get_component() { return m_temporary; }
-    const component_type& get_component() const { return m_temporary; }
-
-    operator component_type&() { return m_temporary; }
-    operator const component_type&() const { return m_temporary; }
-
-    // partial interface to underlying component_tuple
-    void push()
-    {
-        if(m_enabled)
-            m_temporary.push();
-    }
-    void pop()
-    {
-        if(m_enabled)
-            m_temporary.pop();
-    }
-    template <typename... Args>
-    void measure(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.measure(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void sample(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.sample(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void start(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.start(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void stop(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.stop(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void assemble(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.assemble(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void derive(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.derive(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void mark(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.mark(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void mark_begin(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.mark_begin(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void mark_end(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.mark_end(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void store(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.store(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void audit(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.audit(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    void add_secondary(Args&&... args)
-    {
-        if(m_enabled)
-            m_temporary.add_secondary(std::forward<Args>(args)...);
-    }
-    template <template <typename> class OpT, typename... Args>
-    void invoke(Args&&... _args)
-    {
-        if(m_enabled)
-            m_temporary.template invoke<OpT>(std::forward<Args>(_args)...);
-    }
-    template <typename... Args>
-    auto get(Args&&... args) const
-    {
-        return m_temporary.get(std::forward<Args>(args)...);
-    }
-    template <typename... Args>
-    auto get_labeled(Args&&... args) const
-    {
-        return m_temporary.get_labeled(std::forward<Args>(args)...);
-    }
-
-    TIMEMORY_NODISCARD bool enabled() const { return m_enabled; }
-    void                    report_at_exit(bool val) { m_report_at_exit = val; }
-    TIMEMORY_NODISCARD bool report_at_exit() const { return m_report_at_exit; }
-
-    TIMEMORY_NODISCARD bool store() const { return m_temporary.store(); }
-    data_type&              data() { return m_temporary.data(); }
-    const data_type&        data() const { return m_temporary.data(); }
-    TIMEMORY_NODISCARD int64_t laps() const { return m_temporary.laps(); }
-    auto                       key() const { return m_temporary.key(); }
-    TIMEMORY_NODISCARD uint64_t hash() const { return m_temporary.hash(); }
-    void                        rekey(const string_t& _key) { m_temporary.rekey(_key); }
-
-public:
-    template <typename Tp>
-    decltype(auto) get()
-    {
-        return m_temporary.template get<Tp>();
-    }
-
-    template <typename Tp>
-    decltype(auto) get() const
-    {
-        return m_temporary.template get<Tp>();
-    }
-
-    void get(void*& ptr, size_t hash) { m_temporary.get(ptr, hash); }
-
-    template <typename T>
-    auto get_component()
-        -> decltype(std::declval<component_type>().template get_component<T>())
-    {
-        return m_temporary.template get_component<T>();
-    }
-
-protected:
-    template <typename Func>
-    void init(Func&& _init)
-    {
-        if(m_enabled)
-            _init(*this);
-    }
-
-    template <typename Func, typename Arg, typename... Args>
-    void init(Func&& _init, Arg&& _arg, Args&&... _args)
-    {
-        if(m_enabled)
-        {
-            _init(*this);
-            m_temporary.construct(std::forward<Arg>(_arg), std::forward<Args>(_args)...);
-        }
-    }
-
-public:
+    this_type&           print(std::ostream& os, bool _endl = false) const;
     friend std::ostream& operator<<(std::ostream& os, const this_type& obj)
     {
-        os << obj.m_temporary;
+        obj.print(os, false);
         return os;
     }
-
-protected:
-    bool            m_enabled          = true;
-    bool            m_report_at_exit   = false;
-    component_type* m_reference_object = nullptr;
-    component_type  m_temporary;
 };
-
-//--------------------------------------------------------------------------------------//
-
+//
 template <typename... Types>
-template <typename... T, typename Init>
-auto_tuple<Types...>::auto_tuple(const string_t& _key, quirk::config<T...> _config,
-                                 const Init& init_func)
-: m_enabled(settings::enabled())
-, m_report_at_exit(quirk_config<quirk::exit_report, T...>::value)
-, m_reference_object(nullptr)
-, m_temporary(_key, m_enabled, _config)
-{
-    if(m_enabled)
-    {
-        init(init_func);
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start, T...>::value)
-        {
-            m_temporary.start();
-        }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
+template <typename Tp, typename... Args>
+auto_tuple<Types...>::auto_tuple(Tp&& inp, Args&&... args)
+: poly_base{ std::forward<Tp>(inp), std::forward<Args>(args)... }
+{}
+//
 template <typename... Types>
-template <typename... T, typename Init>
-auto_tuple<Types...>::auto_tuple(const captured_location_t& loc,
-                                 quirk::config<T...> _config, const Init& init_func)
-: m_enabled(settings::enabled())
-, m_report_at_exit(quirk_config<quirk::exit_report, T...>::value)
-, m_reference_object(nullptr)
-, m_temporary(loc, m_enabled, _config)
+auto_tuple<Types...>&
+auto_tuple<Types...>::print(std::ostream& os, bool _endl) const
 {
-    if(m_enabled)
-    {
-        init(init_func);
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start, T...>::value)
-        {
-            m_temporary.start();
-        }
-    }
+    os << poly_base::m_temporary;
+    if(_endl)
+        os << '\n';
+    return const_cast<this_type&>(*this);
 }
-
-//--------------------------------------------------------------------------------------//
-
-template <typename... Types>
-template <typename Init>
-auto_tuple<Types...>::auto_tuple(const string_t& _key, scope::config _scope,
-                                 bool report_at_exit, const Init& init_func)
-: m_enabled(settings::enabled())
-, m_report_at_exit(report_at_exit || quirk_config<quirk::exit_report>::value)
-, m_reference_object(nullptr)
-, m_temporary(_key, m_enabled, _scope)
-{
-    if(m_enabled)
-    {
-        init(init_func);
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename... Types>
-template <typename Init>
-auto_tuple<Types...>::auto_tuple(const captured_location_t& loc, scope::config _scope,
-                                 bool report_at_exit, const Init& init_func)
-: m_enabled(settings::enabled())
-, m_report_at_exit(report_at_exit || quirk_config<quirk::exit_report>::value)
-, m_reference_object(nullptr)
-, m_temporary(loc, m_enabled, _scope)
-{
-    if(m_enabled)
-    {
-        init(init_func);
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename... Types>
-template <typename Init>
-auto_tuple<Types...>::auto_tuple(size_t hash, scope::config _scope, bool report_at_exit,
-                                 const Init& init_func)
-: m_enabled(settings::enabled())
-, m_report_at_exit(report_at_exit || quirk_config<quirk::exit_report>::value)
-, m_reference_object(nullptr)
-, m_temporary(hash, m_enabled, _scope)
-{
-    if(m_enabled)
-    {
-        init(init_func);
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename... Types>
-auto_tuple<Types...>::auto_tuple(component_type& tmp, scope::config _scope,
-                                 bool report_at_exit)
-: m_report_at_exit(report_at_exit || quirk_config<quirk::exit_report>::value)
-, m_reference_object(&tmp)
-, m_temporary(tmp.clone(true, _scope))
-{
-    if(m_enabled)
-    {
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename... Types>
-template <typename Init, typename Arg, typename... Args>
-auto_tuple<Types...>::auto_tuple(const string_t& _key, bool store, scope::config _scope,
-                                 const Init& init_func, Arg&& arg, Args&&... args)
-: m_enabled(store && settings::enabled())
-, m_report_at_exit(settings::destructor_report() ||
-                   quirk_config<quirk::exit_report>::value)
-, m_reference_object(nullptr)
-, m_temporary(_key, m_enabled, _scope)
-{
-    if(m_enabled)
-    {
-        init(init_func, std::forward<Arg>(arg), std::forward<Args>(args)...);
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename... Types>
-template <typename Init, typename Arg, typename... Args>
-auto_tuple<Types...>::auto_tuple(const captured_location_t& loc, bool store,
-                                 scope::config _scope, const Init& init_func, Arg&& arg,
-                                 Args&&... args)
-: m_enabled(store && settings::enabled())
-, m_report_at_exit(settings::destructor_report() ||
-                   quirk_config<quirk::exit_report>::value)
-, m_reference_object(nullptr)
-, m_temporary(loc, m_enabled, _scope)
-{
-    if(m_enabled)
-    {
-        init(init_func, std::forward<Arg>(arg), std::forward<Args>(args)...);
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename... Types>
-template <typename Init, typename Arg, typename... Args>
-auto_tuple<Types...>::auto_tuple(size_t hash, bool store, scope::config _scope,
-                                 const Init& init_func, Arg&& arg, Args&&... args)
-: m_enabled(store && settings::enabled())
-, m_report_at_exit(settings::destructor_report() ||
-                   quirk_config<quirk::exit_report>::value)
-, m_reference_object(nullptr)
-, m_temporary(hash, m_enabled, _scope)
-{
-    if(m_enabled)
-    {
-        init(init_func, std::forward<Arg>(arg), std::forward<Args>(args)...);
-        IF_CONSTEXPR(!quirk_config<quirk::explicit_start>::value) { m_temporary.start(); }
-    }
-}
-
-//--------------------------------------------------------------------------------------//
-
-template <typename... Types>
-auto_tuple<Types...>::~auto_tuple()
-{
-    IF_CONSTEXPR(!quirk_config<quirk::explicit_stop>::value)
-    {
-        if(m_enabled)
-        {
-            // stop the timer
-            m_temporary.stop();
-
-            // report timer at exit
-            if(m_report_at_exit)
-            {
-                std::stringstream ss;
-                ss << m_temporary;
-                if(ss.str().length() > 0)
-                    std::cout << ss.str() << std::endl;
-            }
-
-            if(m_reference_object)
-            {
-                *m_reference_object += m_temporary;
-            }
-        }
-    }
-}
-
+//
 //======================================================================================//
-
+//
 template <typename... Types>
 auto
 get(const auto_tuple<Types...>& _obj)
 {
     return get(_obj.get_component());
 }
-
-//--------------------------------------------------------------------------------------//
-
+//
 template <typename... Types>
 auto
 get_labeled(const auto_tuple<Types...>& _obj)
 {
     return get_labeled(_obj.get_component());
 }
-
-//======================================================================================//
-
+//
 }  // namespace tim
 
 //======================================================================================//
@@ -621,5 +191,3 @@ get(tim::auto_tuple<Types...>&& obj)
 //--------------------------------------------------------------------------------------//
 //
 }  // namespace std
-//
-//======================================================================================//

--- a/source/timemory/variadic/bundle_execute.hpp
+++ b/source/timemory/variadic/bundle_execute.hpp
@@ -1,0 +1,369 @@
+// MIT License
+//
+// Copyright (c) 2020, The Regents of the University of California,
+// through Lawrence Berkeley National Laboratory (subject to receipt of any
+// required approvals from the U.S. Dept. of Energy).  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#pragma once
+
+#include "timemory/macros/attributes.hpp"
+#include "timemory/variadic/types.hpp"
+
+#include <type_traits>
+#include <utility>
+
+namespace tim
+{
+namespace bundle
+{
+//
+template <typename BundleT, typename FuncT, typename... Args>
+auto
+execute(BundleT&& _bundle, FuncT&& _func, Args&&... _args,
+        enable_if_t<is_invocable<FuncT, Args...>::value &&
+                        !std::is_void<std::result_of_t<FuncT(Args...)>>::value,
+                    int>)
+{
+    using result_type  = std::result_of_t<FuncT(Args...)>;
+    using handler_type = execution_handler<decay_t<BundleT>, result_type>;
+    return handler_type{ std::forward<BundleT>(_bundle),
+                         std::forward<FuncT>(_func)(std::forward<Args>(_args)...) };
+}
+//
+template <typename BundleT, typename FuncT, typename... Args>
+auto
+execute(BundleT&& _bundle, FuncT&& _func, Args&&... _args,
+        enable_if_t<is_invocable<FuncT, Args...>::value &&
+                        std::is_void<std::result_of_t<FuncT(Args...)>>::value,
+                    int>)
+{
+    _func(std::forward<Args>(_args)...);
+    return std::forward<BundleT>(_bundle);
+}
+//
+//
+template <typename BundleT, typename ValueT>
+auto
+execute(BundleT&& _bundle, ValueT&& _value,
+        enable_if_t<!is_invocable<ValueT>::value, long>)
+{
+    using handler_type = execution_handler<decay_t<BundleT>, ValueT>;
+    return handler_type{ std::forward<BundleT>(_bundle), std::forward<ValueT>(_value) };
+}
+//
+template <typename BundleT, typename DataT>
+class execution_handler
+{
+public:
+    static_assert(!std::is_function<DataT>::value,
+                  "Error! should be result, not function!");
+
+    using this_type = execution_handler<BundleT, DataT>;
+
+    execution_handler()                         = delete;
+    execution_handler(const execution_handler&) = delete;
+    execution_handler& operator=(const execution_handler&) = delete;
+
+    execution_handler(execution_handler&&) noexcept = default;
+    execution_handler& operator=(execution_handler&&) noexcept = default;
+
+    execution_handler(BundleT& _bundle, DataT&& _data) noexcept
+    : m_bundle(_bundle)
+    , m_data(std::move(_data))
+    {}
+
+    operator BundleT() const { return m_bundle; }
+    operator DataT() const { return m_data; }
+    operator std::pair<BundleT, DataT>() const
+    {
+        return std::pair<BundleT, DataT>{ m_bundle, m_data };
+    }
+    operator std::tuple<BundleT, DataT>() const
+    {
+        return std::tuple<BundleT, DataT>{ m_bundle, m_data };
+    }
+
+    auto get_bundle_and_result() { return std::pair<BundleT, DataT>{ m_bundle, m_data }; }
+
+    TIMEMORY_NODISCARD auto get_bundle() noexcept { return BundleT{ m_bundle }; }
+    TIMEMORY_NODISCARD auto get_result() noexcept { return DataT{ m_data }; }
+
+    TIMEMORY_NODISCARD auto& return_bundle() noexcept { return m_bundle; }
+    TIMEMORY_NODISCARD auto  return_result() noexcept { return std::move(m_data); }
+
+    // NOTE: since inheriting from BundleT would result in subsequent functions returning
+    // the this pointer of BundleT, we would discard DataT
+    template <typename... Args>
+    this_type& push(Args&&... args)
+    {
+        m_bundle.push(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& pop(Args&&... args)
+    {
+        m_bundle.pop(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& measure(Args&&... args)
+    {
+        m_bundle.measure(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& sample(Args&&... args)
+    {
+        m_bundle.sample(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& start(Args&&... args)
+    {
+        m_bundle.start(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& stop(Args&&... args)
+    {
+        m_bundle.stop(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& assemble(Args&&... args)
+    {
+        m_bundle.assemble(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& derive(Args&&... args)
+    {
+        m_bundle.derive(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& mark(Args&&... args)
+    {
+        m_bundle.mark(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& mark_begin(Args&&... args)
+    {
+        m_bundle.mark_begin(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& mark_end(Args&&... args)
+    {
+        m_bundle.mark_end(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& store(Args&&... args)
+    {
+        m_bundle.store(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& audit(Args&&... args)
+    {
+        m_bundle.audit(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& add_secondary(Args&&... args)
+    {
+        m_bundle.add_secondary(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <template <typename> class OpT, typename... Args>
+    this_type& invoke(Args&&... _args)
+    {
+        m_bundle.template invoke<OpT>(std::forward<Args>(_args)...);
+        return *this;
+    }
+    template <typename... Args>
+    decltype(auto) get(Args&&... args)
+    {
+        return execute(*this, m_bundle.get(std::forward<Args>(args)...));
+    }
+    template <typename... Args>
+    decltype(auto) get_labeled(Args&&... args)
+    {
+        return execute(*this, m_bundle.get_labeled(std::forward<Args>(args)...));
+        return m_bundle.get_labeled(std::forward<Args>(args)...);
+    }
+
+private:
+    BundleT& m_bundle;
+    DataT    m_data;
+};
+//
+//
+template <typename BundleT>
+class execution_handler<BundleT, void>
+{
+public:
+    using DataT     = void;
+    using this_type = execution_handler<BundleT, DataT>;
+
+    execution_handler()                         = delete;
+    execution_handler(const execution_handler&) = delete;
+    execution_handler& operator=(const execution_handler&) = delete;
+
+    execution_handler(execution_handler&&) noexcept = default;
+    execution_handler& operator=(execution_handler&&) noexcept = default;
+
+    execution_handler(BundleT& _bundle) noexcept
+    : m_bundle(_bundle)
+    {}
+
+    operator BundleT() const { return m_bundle; }
+
+    operator std::pair<BundleT, null_type>() const
+    {
+        return std::pair<BundleT, DataT>{ m_bundle, null_type{} };
+    }
+
+    operator std::tuple<BundleT, null_type>() const
+    {
+        return std::tuple<BundleT, DataT>{ m_bundle, null_type{} };
+    }
+
+    auto get_bundle_and_result()
+    {
+        return std::pair<BundleT, DataT>{ m_bundle, null_type{} };
+    }
+
+    TIMEMORY_NODISCARD auto& return_bundle() noexcept { return m_bundle; }
+    void                     return_result() noexcept {}
+
+    // NOTE: since inheriting from BundleT would result in subsequent functions returning
+    // the this pointer of BundleT, we would discard DataT
+    template <typename... Args>
+    this_type& push(Args&&... args)
+    {
+        m_bundle.push(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& pop(Args&&... args)
+    {
+        m_bundle.pop(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& measure(Args&&... args)
+    {
+        m_bundle.measure(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& sample(Args&&... args)
+    {
+        m_bundle.sample(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& start(Args&&... args)
+    {
+        m_bundle.start(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& stop(Args&&... args)
+    {
+        m_bundle.stop(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& assemble(Args&&... args)
+    {
+        m_bundle.assemble(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& derive(Args&&... args)
+    {
+        m_bundle.derive(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& mark(Args&&... args)
+    {
+        m_bundle.mark(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& mark_begin(Args&&... args)
+    {
+        m_bundle.mark_begin(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& mark_end(Args&&... args)
+    {
+        m_bundle.mark_end(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& store(Args&&... args)
+    {
+        m_bundle.store(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& audit(Args&&... args)
+    {
+        m_bundle.audit(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <typename... Args>
+    this_type& add_secondary(Args&&... args)
+    {
+        m_bundle.add_secondary(std::forward<Args>(args)...);
+        return *this;
+    }
+    template <template <typename> class OpT, typename... Args>
+    this_type& invoke(Args&&... _args)
+    {
+        m_bundle.template invoke<OpT>(std::forward<Args>(_args)...);
+        return *this;
+    }
+    template <typename... Args>
+    decltype(auto) get(Args&&... args)
+    {
+        return execute(*this, m_bundle.get(std::forward<Args>(args)...));
+    }
+    template <typename... Args>
+    decltype(auto) get_labeled(Args&&... args)
+    {
+        return execute(*this, m_bundle.get_labeled(std::forward<Args>(args)...));
+        return m_bundle.get_labeled(std::forward<Args>(args)...);
+    }
+
+private:
+    BundleT& m_bundle;
+};
+//
+}  // namespace bundle
+}  // namespace tim

--- a/source/timemory/variadic/component_bundle.cpp
+++ b/source/timemory/variadic/component_bundle.cpp
@@ -53,102 +53,96 @@ component_bundle<Tag, Types...>::component_bundle()
 //--------------------------------------------------------------------------------------//
 //
 template <typename Tag, typename... Types>
-template <typename... T, typename Func>
+template <typename... T>
 component_bundle<Tag, Types...>::component_bundle(const string_t&     _key,
                                                   quirk::config<T...> _config,
-                                                  const Func&         _init_func)
+                                                  transient_func_t    _init_func)
 : bundle_type(bundle_type::handle(type_list_type{}, _key, true_type{}, _config))
 , m_data(invoke::construct<data_type, Tag>(_key, _config))
 {
     apply_v::set_value(m_data, nullptr);
-    bundle_type::init(type_list_type{}, *this, m_data, _init_func, _config);
+    bundle_type::init(type_list_type{}, *this, m_data, std::move(_init_func), _config);
 }
 
 //--------------------------------------------------------------------------------------//
 //
 template <typename Tag, typename... Types>
-template <typename... T, typename Func>
+template <typename... T>
 component_bundle<Tag, Types...>::component_bundle(const captured_location_t& _loc,
                                                   quirk::config<T...>        _config,
-                                                  const Func&                _init_func)
+                                                  transient_func_t           _init_func)
 : bundle_type(bundle_type::handle(type_list_type{}, _loc, true_type{}, _config))
 , m_data(invoke::construct<data_type, Tag>(_loc, _config))
 {
     apply_v::set_value(m_data, nullptr);
-    bundle_type::init(type_list_type{}, *this, m_data, _init_func, _config);
+    bundle_type::init(type_list_type{}, *this, m_data, std::move(_init_func), _config);
 }
 
 //--------------------------------------------------------------------------------------//
 //
 template <typename Tag, typename... Types>
-template <typename Func>
 component_bundle<Tag, Types...>::component_bundle(size_t _hash, bool _store,
-                                                  scope::config _scope,
-                                                  const Func&   _init_func)
+                                                  scope::config    _scope,
+                                                  transient_func_t _init_func)
 : bundle_type(bundle_type::handle(type_list_type{}, _hash, _store, _scope))
 , m_data(invoke::construct<data_type, Tag>(_hash, m_scope))
 {
     // apply_v::set_value(m_data, nullptr);
-    bundle_type::init(type_list_type{}, *this, m_data, _init_func);
+    bundle_type::init(type_list_type{}, *this, m_data, std::move(_init_func));
 }
 
 //--------------------------------------------------------------------------------------//
 //
 template <typename Tag, typename... Types>
-template <typename Func>
 component_bundle<Tag, Types...>::component_bundle(const string_t& _key, bool _store,
-                                                  scope::config _scope,
-                                                  const Func&   _init_func)
+                                                  scope::config    _scope,
+                                                  transient_func_t _init_func)
 : bundle_type(bundle_type::handle(type_list_type{}, _key, _store, _scope))
 {
-    bundle_type::init(type_list_type{}, *this, m_data, _init_func);
+    bundle_type::init(type_list_type{}, *this, m_data, std::move(_init_func));
 }
 
 //--------------------------------------------------------------------------------------//
 //
 template <typename Tag, typename... Types>
-template <typename Func>
 component_bundle<Tag, Types...>::component_bundle(const captured_location_t& _loc,
                                                   bool _store, scope::config _scope,
-                                                  const Func& _init_func)
+                                                  transient_func_t _init_func)
 : bundle_type(bundle_type::handle(type_list_type{}, _loc, _store, _scope))
 {
-    bundle_type::init(type_list_type{}, *this, m_data, _init_func);
+    bundle_type::init(type_list_type{}, *this, m_data, std::move(_init_func));
 }
 
 //--------------------------------------------------------------------------------------//
 //
 template <typename Tag, typename... Types>
-template <typename Func>
 component_bundle<Tag, Types...>::component_bundle(size_t _hash, scope::config _scope,
-                                                  const Func& _init_func)
+                                                  transient_func_t _init_func)
 : bundle_type(bundle_type::handle(type_list_type{}, _hash, true_type{}, _scope))
 {
-    bundle_type::init(type_list_type{}, *this, m_data, _init_func);
+    bundle_type::init(type_list_type{}, *this, m_data, std::move(_init_func));
 }
 
 //--------------------------------------------------------------------------------------//
 //
 template <typename Tag, typename... Types>
-template <typename Func>
-component_bundle<Tag, Types...>::component_bundle(const string_t& _key,
-                                                  scope::config   _scope,
-                                                  const Func&     _init_func)
+component_bundle<Tag, Types...>::component_bundle(const string_t&  _key,
+                                                  scope::config    _scope,
+                                                  transient_func_t _init_func)
 : bundle_type(bundle_type::handle(type_list_type{}, _key, true_type{}, _scope))
 {
-    bundle_type::init(type_list_type{}, *this, m_data, _init_func);
+    bundle_type::init(type_list_type{}, *this, m_data, std::move(_init_func));
 }
 
 //--------------------------------------------------------------------------------------//
 //
 template <typename Tag, typename... Types>
-template <typename Func>
 component_bundle<Tag, Types...>::component_bundle(const captured_location_t& _loc,
                                                   scope::config              _scope,
-                                                  const Func&                _init_func)
+                                                  transient_func_t           _init_func)
 : bundle_type(bundle_type::handle(type_list_type{}, _loc, true_type{}, _scope))
 {
-    bundle_type::init(type_list_type{}, *this, m_data, _init_func);
+    bundle_type::init(type_list_type{}, *this, m_data, std::move(_init_func));
 }
 
 //--------------------------------------------------------------------------------------//
@@ -206,7 +200,7 @@ component_bundle<Tag, Types...>::clone(bool _store, scope::config _scope)
 // insert into graph
 //
 template <typename Tag, typename... Types>
-void
+component_bundle<Tag, Types...>&
 component_bundle<Tag, Types...>::push()
 {
     if(!m_is_pushed())
@@ -218,13 +212,46 @@ component_bundle<Tag, Types...>::push()
         // insert node or find existing node
         invoke::push<Tag>(m_data, m_scope, m_hash);
     }
+    return *this;
+}
+
+//--------------------------------------------------------------------------------------//
+// insert into graph
+//
+template <typename Tag, typename... Types>
+template <typename... Tp>
+component_bundle<Tag, Types...>&
+component_bundle<Tag, Types...>::push(mpl::piecewise_select<Tp...>)
+{
+    using pw_type = convert_t<implemented_t<Tp...>, mpl::piecewise_select<>>;
+    // reset the data
+    invoke::invoke<operation::reset, Tag>(pw_type{}, m_data);
+    // insert node or find existing node
+    invoke::invoke<operation::push_node, Tag>(pw_type{}, m_data, m_scope, m_hash);
+    return *this;
+}
+
+//--------------------------------------------------------------------------------------//
+// insert into graph
+//
+template <typename Tag, typename... Types>
+template <typename... Tp>
+component_bundle<Tag, Types...>&
+component_bundle<Tag, Types...>::push(mpl::piecewise_select<Tp...>, scope::config _scope)
+{
+    using pw_type = convert_t<implemented_t<Tp...>, mpl::piecewise_select<>>;
+    // reset the data
+    invoke::invoke<operation::reset, Tag>(pw_type{}, m_data);
+    // insert node or find existing node
+    invoke::invoke<operation::push_node, Tag>(pw_type{}, m_data, _scope, m_hash);
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
 // pop out of graph
 //
 template <typename Tag, typename... Types>
-void
+component_bundle<Tag, Types...>&
 component_bundle<Tag, Types...>::pop()
 {
     if(m_is_pushed())
@@ -234,6 +261,21 @@ component_bundle<Tag, Types...>::pop()
         // avoid pushing/popping when already pushed/popped
         m_is_pushed(false);
     }
+    return *this;
+}
+
+//--------------------------------------------------------------------------------------//
+// pop out of graph
+//
+template <typename Tag, typename... Types>
+template <typename... Tp>
+component_bundle<Tag, Types...>&
+component_bundle<Tag, Types...>::pop(mpl::piecewise_select<Tp...>)
+{
+    using pw_type = convert_t<implemented_t<Tp...>, mpl::piecewise_select<>>;
+    // set the current node to the parent node
+    invoke::invoke<operation::pop_node, Tag>(pw_type{}, m_data);
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
@@ -241,12 +283,13 @@ component_bundle<Tag, Types...>::pop()
 //
 template <typename Tag, typename... Types>
 template <typename... Args>
-void
+component_bundle<Tag, Types...>&
 component_bundle<Tag, Types...>::measure(Args&&... args)
 {
     if(!trait::runtime_enabled<Tag>::get())
-        return;
+        return *this;
     invoke::measure<Tag>(m_data, std::forward<Args>(args)...);
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
@@ -254,10 +297,11 @@ component_bundle<Tag, Types...>::measure(Args&&... args)
 //
 template <typename Tag, typename... Types>
 template <typename... Args>
-void
+component_bundle<Tag, Types...>&
 component_bundle<Tag, Types...>::sample(Args&&... args)
 {
     invoke::invoke<operation::sample, Tag>(m_data, std::forward<Args>(args)...);
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
@@ -265,29 +309,31 @@ component_bundle<Tag, Types...>::sample(Args&&... args)
 //
 template <typename Tag, typename... Types>
 template <typename... Args>
-void
+component_bundle<Tag, Types...>&
 component_bundle<Tag, Types...>::start(mpl::lightweight, Args&&... args)
 {
     if(!trait::runtime_enabled<Tag>::get())
-        return;
+        return *this;
     assemble(*this);
     invoke::start<Tag>(m_data, std::forward<Args>(args)...);
     m_is_active(true);
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
 //
 template <typename Tag, typename... Types>
 template <typename... Args>
-void
+component_bundle<Tag, Types...>&
 component_bundle<Tag, Types...>::stop(mpl::lightweight, Args&&... args)
 {
     if(!trait::runtime_enabled<Tag>::get())
-        return;
+        return *this;
     invoke::stop<Tag>(m_data, std::forward<Args>(args)...);
     ++m_laps;
     derive(*this);
     m_is_active(false);
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
@@ -295,7 +341,7 @@ component_bundle<Tag, Types...>::stop(mpl::lightweight, Args&&... args)
 //
 template <typename Tag, typename... Types>
 template <typename... Tp, typename... Args>
-void
+component_bundle<Tag, Types...>&
 component_bundle<Tag, Types...>::start(mpl::piecewise_select<Tp...>, Args&&... args)
 {
     using select_tuple_t = mpl::sort<trait::start_priority, std::tuple<Tp...>>;
@@ -311,13 +357,14 @@ component_bundle<Tag, Types...>::start(mpl::piecewise_select<Tp...>, Args&&... a
     // start components
     auto&& _data = mpl::get_reference_tuple<select_tuple_t>(m_data);
     invoke::invoke<operation::standard_start, Tag>(_data, std::forward<Args>(args)...);
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
 //
 template <typename Tag, typename... Types>
 template <typename... Tp, typename... Args>
-void
+component_bundle<Tag, Types...>&
 component_bundle<Tag, Types...>::stop(mpl::piecewise_select<Tp...>, Args&&... args)
 {
     using select_tuple_t = mpl::sort<trait::stop_priority, std::tuple<Tp...>>;
@@ -331,6 +378,7 @@ component_bundle<Tag, Types...>::stop(mpl::piecewise_select<Tp...>, Args&&... ar
         TIMEMORY_FOLD_EXPRESSION(
             operation::pop_node<Tp>(std::get<index_of<Tp, data_type>::value>(m_data)));
     }
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
@@ -338,11 +386,11 @@ component_bundle<Tag, Types...>::stop(mpl::piecewise_select<Tp...>, Args&&... ar
 //
 template <typename Tag, typename... Types>
 template <typename... Args>
-void
+component_bundle<Tag, Types...>&
 component_bundle<Tag, Types...>::start(Args&&... args)
 {
     if(!trait::runtime_enabled<Tag>::get())
-        return;
+        return *this;
 
     // push components into the call-stack
     IF_CONSTEXPR(!quirk_config<quirk::explicit_push>::value)
@@ -353,17 +401,18 @@ component_bundle<Tag, Types...>::start(Args&&... args)
 
     // start components
     start(mpl::lightweight{}, std::forward<Args>(args)...);
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
 //
 template <typename Tag, typename... Types>
 template <typename... Args>
-void
+component_bundle<Tag, Types...>&
 component_bundle<Tag, Types...>::stop(Args&&... args)
 {
     if(!trait::runtime_enabled<Tag>::get())
-        return;
+        return *this;
 
     // stop components
     stop(mpl::lightweight{}, std::forward<Args>(args)...);
@@ -374,6 +423,7 @@ component_bundle<Tag, Types...>::stop(Args&&... args)
         if(m_store())
             pop();
     }
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
@@ -397,11 +447,12 @@ component_bundle<Tag, Types...>::record(Args&&... args)
 //
 template <typename Tag, typename... Types>
 template <typename... Args>
-void
+component_bundle<Tag, Types...>&
 component_bundle<Tag, Types...>::reset(Args&&... args)
 {
     invoke::reset<Tag>(m_data, std::forward<Args>(args)...);
     m_laps = 0;
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/variadic/component_list.cpp
+++ b/source/timemory/variadic/component_list.cpp
@@ -158,7 +158,7 @@ component_list<Types...>::clone(bool _store, scope::config _scope)
 // insert into graph
 //
 template <typename... Types>
-void
+component_list<Types...>&
 component_list<Types...>::push()
 {
     uint64_t count = 0;
@@ -172,13 +172,14 @@ component_list<Types...>::push()
         // insert node or find existing node
         invoke::push(m_data, m_scope, m_hash);
     }
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
 // pop out of grapsh
 //
 template <typename... Types>
-void
+component_list<Types...>&
 component_list<Types...>::pop()
 {
     if(m_is_pushed())
@@ -188,6 +189,7 @@ component_list<Types...>::pop()
         // avoid pushing/popping when already pushed/popped
         m_is_pushed(false);
     }
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
@@ -195,10 +197,11 @@ component_list<Types...>::pop()
 //
 template <typename... Types>
 template <typename... Args>
-void
+component_list<Types...>&
 component_list<Types...>::measure(Args&&... args)
 {
     invoke::measure(m_data, std::forward<Args>(args)...);
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
@@ -206,10 +209,11 @@ component_list<Types...>::measure(Args&&... args)
 //
 template <typename... Types>
 template <typename... Args>
-void
+component_list<Types...>&
 component_list<Types...>::sample(Args&&... args)
 {
     invoke::invoke<operation::sample, TIMEMORY_API>(m_data, std::forward<Args>(args)...);
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
@@ -217,7 +221,7 @@ component_list<Types...>::sample(Args&&... args)
 //
 template <typename... Types>
 template <typename... Args>
-void
+component_list<Types...>&
 component_list<Types...>::start(Args&&... args)
 {
     // push components into the call-stack
@@ -229,13 +233,14 @@ component_list<Types...>::start(Args&&... args)
     assemble(*this);
     invoke::start(m_data, std::forward<Args>(args)...);
     m_is_active(true);
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
 //
 template <typename... Types>
 template <typename... Args>
-void
+component_list<Types...>&
 component_list<Types...>::stop(Args&&... args)
 {
     invoke::stop(m_data, std::forward<Args>(args)...);
@@ -247,6 +252,7 @@ component_list<Types...>::stop(Args&&... args)
             pop();
     }
     m_is_active(false);
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
@@ -267,11 +273,12 @@ component_list<Types...>::record(Args&&... args)
 //
 template <typename... Types>
 template <typename... Args>
-void
+component_list<Types...>&
 component_list<Types...>::reset(Args&&... args)
 {
     invoke::reset(m_data, std::forward<Args>(args)...);
     m_laps = 0;
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
@@ -383,13 +390,13 @@ component_list<Types...>::set_scope(scope::config val)
 template <typename... Types>
 template <typename T>
 void
-component_list<Types...>::set_prefix(T* obj) const
+component_list<Types...>::set_prefix(T* obj, internal_tag) const
 {
     using PrefixOpT =
         operation::generic_operator<T, operation::set_prefix<T>, TIMEMORY_API>;
     auto itr = get_hash_ids()->find(m_hash);
     if(itr != get_hash_ids()->end())
-        PrefixOpT(obj, m_hash, itr->second);
+        PrefixOpT{ obj, m_hash, itr->second };
 }
 
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/variadic/component_tuple.cpp
+++ b/source/timemory/variadic/component_tuple.cpp
@@ -140,7 +140,7 @@ component_tuple<Types...>::clone(bool _store, scope::config _scope)
 // insert into graph
 //
 template <typename... Types>
-void
+component_tuple<Types...>&
 component_tuple<Types...>::push()
 {
     if(!m_is_pushed())
@@ -152,13 +152,14 @@ component_tuple<Types...>::push()
         // insert node or find existing node
         invoke::push(m_data, m_scope, m_hash);
     }
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
 // pop out of graph
 //
 template <typename... Types>
-void
+component_tuple<Types...>&
 component_tuple<Types...>::pop()
 {
     if(m_is_pushed())
@@ -168,6 +169,7 @@ component_tuple<Types...>::pop()
         // avoid pushing/popping when already pushed/popped
         m_is_pushed(false);
     }
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
@@ -175,10 +177,11 @@ component_tuple<Types...>::pop()
 //
 template <typename... Types>
 template <typename... Args>
-void
+component_tuple<Types...>&
 component_tuple<Types...>::measure(Args&&... args)
 {
     invoke::measure(m_data, std::forward<Args>(args)...);
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
@@ -186,10 +189,11 @@ component_tuple<Types...>::measure(Args&&... args)
 //
 template <typename... Types>
 template <typename... Args>
-void
+component_tuple<Types...>&
 component_tuple<Types...>::sample(Args&&... args)
 {
     invoke::invoke<operation::sample, TIMEMORY_API>(m_data, std::forward<Args>(args)...);
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
@@ -197,25 +201,27 @@ component_tuple<Types...>::sample(Args&&... args)
 //
 template <typename... Types>
 template <typename... Args>
-void
+component_tuple<Types...>&
 component_tuple<Types...>::start(mpl::lightweight, Args&&... args)
 {
     assemble(*this);
     invoke::start(m_data, std::forward<Args>(args)...);
     m_is_active(true);
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
 //
 template <typename... Types>
 template <typename... Args>
-void
+component_tuple<Types...>&
 component_tuple<Types...>::stop(mpl::lightweight, Args&&... args)
 {
     invoke::stop(m_data, std::forward<Args>(args)...);
     ++m_laps;
     derive(*this);
     m_is_active(false);
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
@@ -223,7 +229,7 @@ component_tuple<Types...>::stop(mpl::lightweight, Args&&... args)
 //
 template <typename... Types>
 template <typename... Args>
-void
+component_tuple<Types...>&
 component_tuple<Types...>::start(Args&&... args)
 {
     // push components into the call-stack
@@ -235,13 +241,14 @@ component_tuple<Types...>::start(Args&&... args)
 
     // start components
     start(mpl::lightweight{}, std::forward<Args>(args)...);
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
 //
 template <typename... Types>
 template <typename... Args>
-void
+component_tuple<Types...>&
 component_tuple<Types...>::stop(Args&&... args)
 {
     // stop components
@@ -253,6 +260,7 @@ component_tuple<Types...>::stop(Args&&... args)
         if(m_store())
             pop();
     }
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//
@@ -273,11 +281,12 @@ component_tuple<Types...>::record(Args&&... args)
 //
 template <typename... Types>
 template <typename... Args>
-void
+component_tuple<Types...>&
 component_tuple<Types...>::reset(Args&&... args)
 {
     invoke::reset(m_data, std::forward<Args>(args)...);
     m_laps = 0;
+    return *this;
 }
 
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/variadic/definition.hpp
+++ b/source/timemory/variadic/definition.hpp
@@ -24,9 +24,11 @@
 
 #pragma once
 
+#include "timemory/variadic/bundle_execute.hpp"
 #include "timemory/variadic/macros.hpp"
 #include "timemory/variadic/types.hpp"
 //
+#include "timemory/variadic/auto_base_bundle.hpp"
 #include "timemory/variadic/auto_bundle.hpp"
 #include "timemory/variadic/auto_list.hpp"
 #include "timemory/variadic/auto_tuple.hpp"
@@ -44,9 +46,11 @@
 //
 //  Implementations
 //
+#include "timemory/variadic/auto_base_bundle.cpp"
 #include "timemory/variadic/component_bundle.cpp"
 #include "timemory/variadic/component_list.cpp"
 #include "timemory/variadic/component_tuple.cpp"
+#include "timemory/variadic/functional.cpp"
 #include "timemory/variadic/lightweight_tuple.cpp"
 //
 #if defined(TIMEMORY_USE_DEPRECATED)

--- a/source/timemory/variadic/functional.cpp
+++ b/source/timemory/variadic/functional.cpp
@@ -1,0 +1,1167 @@
+// MIT License
+//
+// Copyright (c) 2020, The Regents of the University of California,
+// through Lawrence Berkeley National Laboratory (subject to receipt of any
+// required approvals from the U.S. Dept. of Energy).  All rights reserved.
+//
+// Permission is hereby granted, free of charge, to any person obtaining a copy
+// of this software and associated documentation files (the "Software"), to deal
+// in the Software without restriction, including without limitation the rights
+// to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+// copies of the Software, and to permit persons to whom the Software is
+// furnished to do so, subject to the following conditions:
+//
+// The above copyright notice and this permission notice shall be included in all
+// copies or substantial portions of the Software.
+//
+// THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+// IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+// FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+// AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+// LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+// OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+// SOFTWARE.
+
+#ifndef TIMEMORY_VARIADIC_FUNCTIONAL_CPP_
+#define TIMEMORY_VARIADIC_FUNCTIONAL_CPP_ 1
+
+// #include "timemory/variadic/functional.hpp"
+
+#include "timemory/api.hpp"
+#include "timemory/macros/language.hpp"
+#include "timemory/mpl/apply.hpp"
+#include "timemory/mpl/available.hpp"
+#include "timemory/operations/types/cache.hpp"
+#include "timemory/operations/types/generic.hpp"
+#include "timemory/utility/types.hpp"
+
+#include <type_traits>
+
+namespace tim
+{
+namespace invoke
+{
+namespace invoke_impl
+{
+//
+//--------------------------------------------------------------------------------------//
+//
+template <template <typename> class OpT, typename Tag,
+          template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+invoke(TupleT<Tp...>& _obj, Args&&... _args)
+{
+    using data_type = std::tuple<Tp...>;
+    TIMEMORY_FOLD_EXPRESSION(
+        operation::generic_operator<std::remove_pointer_t<decay_t<Tp>>,
+                                    OpT<std::remove_pointer_t<decay_t<Tp>>>, Tag>(
+            std::get<index_of<Tp, data_type>::value>(_obj),
+            std::forward<Args>(_args)...));
+}
+//
+//--------------------------------------------------------------------------------------//
+//
+template <template <typename, typename> class OpT, typename Tag,
+          template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+invoke(TupleT<Tp...>& _obj, Args&&... _args)
+{
+    using data_type = std::tuple<Tp...>;
+    TIMEMORY_FOLD_EXPRESSION(
+        operation::generic_operator<std::remove_pointer_t<decay_t<Tp>>,
+                                    OpT<std::remove_pointer_t<decay_t<Tp>>, Tag>, Tag>(
+            std::get<index_of<Tp, data_type>::value>(_obj),
+            std::forward<Args>(_args)...));
+}
+//
+//--------------------------------------------------------------------------------------//
+//
+template <template <typename> class OpT, typename Tag,
+          template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+invoke(TupleT<Tp&...>&& _obj, Args&&... _args)
+{
+    using data_type = std::tuple<Tp...>;
+    TIMEMORY_FOLD_EXPRESSION(
+        operation::generic_operator<std::remove_pointer_t<decay_t<Tp>>,
+                                    OpT<std::remove_pointer_t<decay_t<Tp>>>, Tag>(
+            std::get<index_of<Tp, data_type>::value>(_obj),
+            std::forward<Args>(_args)...));
+}
+//
+//--------------------------------------------------------------------------------------//
+//
+template <template <typename, typename> class OpT, typename Tag,
+          template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+invoke(TupleT<Tp&...>&& _obj, Args&&... _args)
+{
+    using data_type = std::tuple<Tp...>;
+    TIMEMORY_FOLD_EXPRESSION(
+        operation::generic_operator<std::remove_pointer_t<decay_t<Tp>>,
+                                    OpT<std::remove_pointer_t<decay_t<Tp>>, Tag>, Tag>(
+            std::get<index_of<Tp, data_type>::value>(_obj),
+            std::forward<Args>(_args)...));
+}
+//
+//--------------------------------------------------------------------------------------//
+//
+template <template <typename> class OpT, typename Tag,
+          template <typename...> class TupleT, typename... Tp,
+          template <typename...> class ValueT, typename... Vp, typename... Args>
+void
+invoke_data(TupleT<Tp...>& _obj, ValueT<Vp...>& _val, Args&&... _args)
+{
+    using data_type = std::tuple<Tp...>;
+    TIMEMORY_FOLD_EXPRESSION(
+        operation::generic_operator<std::remove_pointer_t<decay_t<Tp>>,
+                                    OpT<std::remove_pointer_t<decay_t<Tp>>>, Tag>(
+            std::get<index_of<Tp, data_type>::value>(_obj),
+            std::get<index_of<Tp, data_type>::value>(_val),
+            std::forward<Args>(_args)...));
+}
+//
+//--------------------------------------------------------------------------------------//
+//
+template <template <typename> class OpT, typename Tag,
+          template <typename...> class TupleT, typename... Tp,
+          template <typename...> class ValueT, typename... Vp, typename... Args>
+void
+invoke_data(TupleT<Tp&...>&& _obj, ValueT<Vp...>& _val, Args&&... _args)
+{
+    using data_type = std::tuple<Tp...>;
+    TIMEMORY_FOLD_EXPRESSION(
+        operation::generic_operator<std::remove_pointer_t<decay_t<Tp>>,
+                                    OpT<std::remove_pointer_t<decay_t<Tp>>>, Tag>(
+            std::get<index_of<Tp, data_type>::value>(_obj),
+            std::get<index_of<Tp, data_type>::value>(_val),
+            std::forward<Args>(_args)...));
+}
+//
+//--------------------------------------------------------------------------------------//
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+construct(TupleT<Tp...>& _obj, Args&&... _args)
+{
+    using data_type = std::tuple<Tp...>;
+    TIMEMORY_FOLD_EXPRESSION(
+        std::get<index_of<Tp, data_type>::value>(_obj) =
+            operation::construct<Tp>::get(std::forward<Args>(_args)...));
+}
+//
+}  // namespace invoke_impl
+//
+//======================================================================================//
+//
+template <typename... Args>
+void
+print(std::ostream& os, Args&&... args)
+{
+    TIMEMORY_FOLD_EXPRESSION(os << args << "\n");
+}
+//
+template <typename... Args>
+void
+print(std::ostream& os, const std::string& delim, Args&&... args)
+{
+    TIMEMORY_FOLD_EXPRESSION(os << args << delim);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  invoke
+//--------------------------------------------------------------------------------------//
+//
+template <template <typename...> class OpT, typename ApiT,
+          template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+invoke(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke_impl::invoke<OpT, ApiT>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class OpT, template <typename...> class TupleT,
+          typename... Tp, typename... Args>
+void
+invoke(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke<OpT, TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class OpT, typename ApiT,
+          template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+invoke(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    invoke_impl::invoke<OpT, ApiT>(std::forward<TupleT<Tp&...>>(obj),
+                                   std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class OpT, template <typename...> class TupleT,
+          typename... Tp, typename... Args>
+void
+invoke(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    invoke<OpT, TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj),
+                              std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class OpT, typename ApiT, typename... Up,
+          template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+invoke(mpl::piecewise_select<Up...>, TupleT<Tp...>& obj, Args&&... args)
+{
+    using data_type = TupleT<Tp...>;
+    invoke_impl::invoke<OpT, ApiT>(
+        std::forward_as_tuple(std::get<index_of<Up, data_type>::value>(obj)...),
+        std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class OpT, typename ApiT, typename... Up,
+          template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+invoke(mpl::piecewise_select<Up...>, TupleT<Tp&...>& obj, Args&&... args)
+{
+    using data_type = TupleT<Tp...>;
+    invoke_impl::invoke<OpT, ApiT>(
+        std::tie(std::get<index_of<Up, data_type>::value>(obj)...),
+        std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  construct
+//--------------------------------------------------------------------------------------//
+//
+template <typename TupleT, typename ApiT, typename... Args>
+auto
+construct(Args&&... args)
+{
+    IF_CONSTEXPR(trait::is_available<ApiT>::value)
+    {
+        {
+            TupleT obj{};
+            invoke_impl::construct(std::ref(obj).get(), std::forward<Args>(args)...);
+            return obj;
+        }
+    }
+    return TupleT{};
+}
+//
+//
+template <typename TupleT, typename... Args>
+auto
+construct(Args&&... args)
+{
+    return construct<TupleT, TIMEMORY_API>(std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  destroy
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp>
+auto
+destroy(TupleT<Tp...>& obj)
+{
+    invoke_impl::invoke<operation::generic_deleter, ApiT>(obj);
+}
+//
+template <template <typename...> class TupleT, typename... Tp>
+auto
+destroy(TupleT<Tp...>& obj)
+{
+    destroy<TIMEMORY_API>(obj);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp>
+auto
+destroy(TupleT<Tp&...>&& obj)
+{
+    invoke_impl::invoke<operation::generic_deleter, ApiT>(
+        std::forward<TupleT<Tp&...>>(obj));
+}
+//
+template <template <typename...> class TupleT, typename... Tp>
+auto
+destroy(TupleT<Tp&...>&& obj)
+{
+    destroy<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj));
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  start
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+start(TupleT<Tp...>& obj, Args&&... args)
+{
+    using data_type        = std::tuple<remove_pointer_t<decay_t<Tp>>...>;
+    using priority_types_t = filter_false_t<negative_start_priority, data_type>;
+    using priority_tuple_t = mpl::sort<trait::start_priority, priority_types_t>;
+    using delayed_types_t  = filter_false_t<positive_start_priority, data_type>;
+    using delayed_tuple_t  = mpl::sort<trait::start_priority, delayed_types_t>;
+
+    // start high priority components
+    auto&& _priority_start = mpl::get_reference_tuple<priority_tuple_t>(obj);
+    invoke_impl::invoke<operation::priority_start, ApiT>(_priority_start,
+                                                         std::forward<Args>(args)...);
+    // start non-prioritized components
+    invoke_impl::invoke<operation::standard_start, ApiT>(obj,
+                                                         std::forward<Args>(args)...);
+    // start low prioritized components
+    auto&& _delayed_start = mpl::get_reference_tuple<delayed_tuple_t>(obj);
+    invoke_impl::invoke<operation::delayed_start, ApiT>(_delayed_start,
+                                                        std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+start(TupleT<Tp...>& obj, Args&&... args)
+{
+    start<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+start(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    using data_type        = std::tuple<remove_pointer_t<decay_t<Tp>>...>;
+    using priority_types_t = filter_false_t<negative_start_priority, data_type>;
+    using priority_tuple_t = mpl::sort<trait::start_priority, priority_types_t>;
+    using delayed_types_t  = filter_false_t<positive_start_priority, data_type>;
+    using delayed_tuple_t  = mpl::sort<trait::start_priority, delayed_types_t>;
+
+    // start high priority components
+    auto&& _priority_start =
+        mpl::get_reference_tuple<priority_tuple_t>(std::forward<TupleT<Tp&...>>(obj));
+    invoke_impl::invoke<operation::priority_start, ApiT>(_priority_start,
+                                                         std::forward<Args>(args)...);
+
+    // start non-prioritized components
+    invoke_impl::invoke<operation::standard_start, ApiT>(
+        std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
+
+    // start low prioritized components
+    auto&& _delayed_start =
+        mpl::get_reference_tuple<delayed_tuple_t>(std::forward<TupleT<Tp&...>>(obj));
+    invoke_impl::invoke<operation::delayed_start, ApiT>(_delayed_start,
+                                                        std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+start(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    start<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  stop
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+stop(TupleT<Tp...>& obj, Args&&... args)
+{
+    using data_type        = std::tuple<remove_pointer_t<decay_t<Tp>>...>;
+    using priority_types_t = filter_false_t<negative_stop_priority, data_type>;
+    using priority_tuple_t = mpl::sort<trait::stop_priority, priority_types_t>;
+    using delayed_types_t  = filter_false_t<positive_stop_priority, data_type>;
+    using delayed_tuple_t  = mpl::sort<trait::stop_priority, delayed_types_t>;
+
+    // stop high priority components
+    auto&& _priority_stop = mpl::get_reference_tuple<priority_tuple_t>(obj);
+    invoke_impl::invoke<operation::priority_stop, ApiT>(_priority_stop,
+                                                        std::forward<Args>(args)...);
+
+    // stop non-prioritized components
+    invoke_impl::invoke<operation::standard_stop, ApiT>(obj, std::forward<Args>(args)...);
+
+    // stop low prioritized components
+    auto&& _delayed_stop = mpl::get_reference_tuple<delayed_tuple_t>(obj);
+    invoke_impl::invoke<operation::delayed_stop, ApiT>(_delayed_stop,
+                                                       std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+stop(TupleT<Tp...>& obj, Args&&... args)
+{
+    stop<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+stop(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    using data_type        = std::tuple<remove_pointer_t<decay_t<Tp>>...>;
+    using priority_types_t = filter_false_t<negative_stop_priority, data_type>;
+    using priority_tuple_t = mpl::sort<trait::stop_priority, priority_types_t>;
+    using delayed_types_t  = filter_false_t<positive_stop_priority, data_type>;
+    using delayed_tuple_t  = mpl::sort<trait::stop_priority, delayed_types_t>;
+
+    // stop high priority components
+    auto&& _priority_stop =
+        mpl::get_reference_tuple<priority_tuple_t>(std::forward<TupleT<Tp&...>>(obj));
+    invoke_impl::invoke<operation::priority_stop, ApiT>(_priority_stop,
+                                                        std::forward<Args>(args)...);
+
+    // stop non-prioritized components
+    invoke_impl::invoke<operation::standard_stop, ApiT>(std::forward<TupleT<Tp&...>>(obj),
+                                                        std::forward<Args>(args)...);
+
+    // stop low prioritized components
+    auto&& _delayed_stop =
+        mpl::get_reference_tuple<delayed_tuple_t>(std::forward<TupleT<Tp&...>>(obj));
+    invoke_impl::invoke<operation::delayed_stop, ApiT>(_delayed_stop,
+                                                       std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+stop(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    stop<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  mark
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+mark(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::mark, ApiT>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+mark(TupleT<Tp...>& obj, Args&&... args)
+{
+    mark<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+mark(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::mark, ApiT>(std::forward<TupleT<Tp&...>>(obj),
+                                               std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+mark(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    mark<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  mark_begin
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+mark_begin(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::mark_begin, ApiT>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+mark_begin(TupleT<Tp...>& obj, Args&&... args)
+{
+    mark_begin<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+mark_begin(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::mark_begin, ApiT>(std::forward<TupleT<Tp&...>>(obj),
+                                                     std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+mark_begin(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    mark_begin<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj),
+                             std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  mark_end
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+mark_end(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::mark_end, ApiT>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+mark_end(TupleT<Tp...>& obj, Args&&... args)
+{
+    mark_end<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+mark_end(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::mark_end, ApiT>(std::forward<TupleT<Tp&...>>(obj),
+                                                   std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+mark_end(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    mark_end<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj),
+                           std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  store
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+store(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::store, ApiT>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+store(TupleT<Tp...>& obj, Args&&... args)
+{
+    store<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+store(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::store, ApiT>(std::forward<TupleT<Tp&...>>(obj),
+                                                std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+store(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    store<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  reset
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+reset(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::reset, ApiT>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+reset(TupleT<Tp...>& obj, Args&&... args)
+{
+    reset<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+reset(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::reset, ApiT>(std::forward<TupleT<Tp&...>>(obj),
+                                                std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+reset(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    reset<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  record
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+record(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::record, ApiT>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+record(TupleT<Tp...>& obj, Args&&... args)
+{
+    record<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+record(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::record, ApiT>(std::forward<TupleT<Tp&...>>(obj),
+                                                 std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+record(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    record<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  measure
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+measure(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::measure, ApiT>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+measure(TupleT<Tp...>& obj, Args&&... args)
+{
+    measure<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+measure(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::measure, ApiT>(std::forward<TupleT<Tp&...>>(obj),
+                                                  std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+measure(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    measure<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  push
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+push(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::push_node, ApiT>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+push(TupleT<Tp...>& obj, Args&&... args)
+{
+    push<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+push(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::push_node, ApiT>(std::forward<TupleT<Tp&...>>(obj),
+                                                    std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+push(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    push<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  pop
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+pop(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::pop_node, ApiT>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+pop(TupleT<Tp...>& obj, Args&&... args)
+{
+    pop<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+pop(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::pop_node, ApiT>(std::forward<TupleT<Tp&...>>(obj),
+                                                   std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+pop(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    pop<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  set_prefix
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+set_prefix(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::set_prefix, ApiT>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+set_prefix(TupleT<Tp...>& obj, Args&&... args)
+{
+    set_prefix<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+set_prefix(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::set_prefix, ApiT>(std::forward<TupleT<Tp&...>>(obj),
+                                                     std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+set_prefix(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    set_prefix<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj),
+                             std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  set_scope
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+set_scope(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::set_scope, ApiT>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+set_scope(TupleT<Tp...>& obj, Args&&... args)
+{
+    set_scope<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+set_scope(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::set_scope, ApiT>(std::forward<TupleT<Tp&...>>(obj),
+                                                    std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+set_scope(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    set_scope<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj),
+                            std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  assemble
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+assemble(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::assemble, ApiT>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+assemble(TupleT<Tp...>& obj, Args&&... args)
+{
+    assemble<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+assemble(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::assemble, ApiT>(std::forward<TupleT<Tp&...>>(obj),
+                                                   std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+assemble(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    assemble<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj),
+                           std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  derive
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+derive(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::derive, ApiT>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+derive(TupleT<Tp...>& obj, Args&&... args)
+{
+    derive<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+derive(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::derive, ApiT>(std::forward<TupleT<Tp&...>>(obj),
+                                                 std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+derive(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    derive<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  audit
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+audit(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::audit, ApiT>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+audit(TupleT<Tp...>& obj, Args&&... args)
+{
+    audit<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+audit(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::audit, ApiT>(std::forward<TupleT<Tp&...>>(obj),
+                                                std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+audit(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    audit<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  add_secondary
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+add_secondary(TupleT<Tp...>& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::add_secondary, ApiT>(obj, std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+add_secondary(TupleT<Tp...>& obj, Args&&... args)
+{
+    add_secondary<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+void
+add_secondary(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    invoke_impl::invoke<operation::add_secondary, ApiT>(std::forward<TupleT<Tp&...>>(obj),
+                                                        std::forward<Args>(args)...);
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+add_secondary(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    add_secondary<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj),
+                                std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  get
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+auto
+get(TupleT<Tp...>& obj, Args&&... args)
+{
+    using data_type         = TupleT<std::remove_pointer_t<Tp>...>;
+    using data_collect_type = get_data_type_t<data_type>;
+    using data_value_type   = get_data_value_t<data_type>;
+
+    data_value_type _data{};
+    auto&&          _obj = mpl::get_reference_tuple<data_collect_type>(obj);
+    invoke_impl::invoke_data<operation::get_data, ApiT>(_obj, _data,
+                                                        std::forward<Args>(args)...);
+    return _data;
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+auto
+get(TupleT<Tp...>& obj, Args&&... args)
+{
+    return ::tim::invoke::get<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+auto
+get(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    using data_type         = TupleT<std::remove_pointer_t<Tp>...>;
+    using data_collect_type = get_data_type_t<data_type>;
+    using data_value_type   = get_data_value_t<data_type>;
+
+    data_value_type _data{};
+    auto&&          _obj = mpl::get_reference_tuple<data_collect_type>(obj);
+    invoke_impl::invoke_data<operation::get_data, ApiT>(_obj, _data,
+                                                        std::forward<Args>(args)...);
+    return _data;
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+auto
+get(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    return ::tim::invoke::get<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj),
+                                            std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp>
+auto
+get(TupleT<Tp...>& obj, void*& _ptr, size_t _hash)
+{
+    invoke_impl::invoke<operation::get, ApiT>(obj, _ptr, _hash);
+}
+//
+template <template <typename...> class TupleT, typename... Tp>
+auto
+get(TupleT<Tp...>& obj, void*& _ptr, size_t _hash)
+{
+    return ::tim::invoke::get<TIMEMORY_API>(obj, _ptr, _hash);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  get_labeled
+//--------------------------------------------------------------------------------------//
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+auto
+get_labeled(TupleT<Tp...>& obj, Args&&... args)
+{
+    using data_type         = TupleT<std::remove_pointer_t<Tp>...>;
+    using data_collect_type = get_data_type_t<data_type>;
+    using data_label_type   = get_data_label_t<data_type>;
+
+    data_label_type _data{};
+    auto&&          _obj = mpl::get_reference_tuple<data_collect_type>(obj);
+    invoke_impl::invoke_data<operation::get_labeled_data, ApiT>(
+        _obj, _data, std::forward<Args>(args)...);
+    return _data;
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+auto
+get_labeled(TupleT<Tp...>& obj, Args&&... args)
+{
+    return get_labeled<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+template <typename ApiT, template <typename...> class TupleT, typename... Tp,
+          typename... Args>
+auto
+get_labeled(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    using data_type         = TupleT<std::remove_pointer_t<Tp>...>;
+    using data_collect_type = get_data_type_t<data_type>;
+    using data_label_type   = get_data_label_t<data_type>;
+
+    data_label_type _data{};
+    auto&&          _obj = mpl::get_reference_tuple<data_collect_type>(obj);
+    invoke_impl::invoke_data<operation::get_labeled_data, ApiT>(
+        _obj, _data, std::forward<Args>(args)...);
+    return _data;
+}
+//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+auto
+get_labeled(TupleT<Tp&...>&& obj, Args&&... args)
+{
+    return get_labeled<TIMEMORY_API>(obj, std::forward<Args>(args)...);
+}
+//
+//--------------------------------------------------------------------------------------//
+//                                  get_cache
+//--------------------------------------------------------------------------------------//
+//
+template <typename... BundleT>
+auto
+get_cache()
+{
+    return operation::construct_cache<std::tuple<BundleT...>>{}();
+}
+//
+//--------------------------------------------------------------------------------------//
+//
+//      This is for multiple component bundlers, e.g.
+//          start(comp_tuple<A...>, comp_tuple<B...>)
+//
+//      MUST USE INDEX SEQUENCE. W/o index sequence multiple instances of same bundle
+//      will give weird results
+//
+//--------------------------------------------------------------------------------------//
+//
+namespace disjoint
+{
+//
+#define TIMEMORY_DEFINE_DISJOINT_FUNCTION(FUNC)                                          \
+    namespace disjoint_impl                                                              \
+    {                                                                                    \
+    template <template <typename...> class TupleT, typename... Tp, size_t... Idx,        \
+              typename... Args>                                                          \
+    void FUNC(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)               \
+    {                                                                                    \
+        TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).FUNC(std::forward<Args>(args)...));  \
+    }                                                                                    \
+    }                                                                                    \
+                                                                                         \
+    template <template <typename...> class TupleT, typename... Tp, typename... Args>     \
+    void FUNC(TupleT<Tp...>&& obj, Args&&... args)                                       \
+    {                                                                                    \
+        disjoint_impl::FUNC(std::forward<TupleT<Tp...>>(obj),                            \
+                            make_index_sequence<sizeof...(Tp)>{},                        \
+                            std::forward<Args>(args)...);                                \
+    }
+
+TIMEMORY_DEFINE_DISJOINT_FUNCTION(push)
+TIMEMORY_DEFINE_DISJOINT_FUNCTION(pop)
+TIMEMORY_DEFINE_DISJOINT_FUNCTION(start)
+TIMEMORY_DEFINE_DISJOINT_FUNCTION(stop)
+TIMEMORY_DEFINE_DISJOINT_FUNCTION(mark)
+TIMEMORY_DEFINE_DISJOINT_FUNCTION(mark_begin)
+TIMEMORY_DEFINE_DISJOINT_FUNCTION(mark_end)
+TIMEMORY_DEFINE_DISJOINT_FUNCTION(store)
+TIMEMORY_DEFINE_DISJOINT_FUNCTION(reset)
+TIMEMORY_DEFINE_DISJOINT_FUNCTION(record)
+TIMEMORY_DEFINE_DISJOINT_FUNCTION(measure)
+TIMEMORY_DEFINE_DISJOINT_FUNCTION(set_prefix)
+TIMEMORY_DEFINE_DISJOINT_FUNCTION(set_scope)
+TIMEMORY_DEFINE_DISJOINT_FUNCTION(assemble)
+TIMEMORY_DEFINE_DISJOINT_FUNCTION(derive)
+TIMEMORY_DEFINE_DISJOINT_FUNCTION(audit)
+TIMEMORY_DEFINE_DISJOINT_FUNCTION(add_secondary)
+
+#undef TIMEMORY_DEFINE_DISJOINT_FUNCTION
+
+// invoke is slightly different than the others
+namespace disjoint_impl
+{
+template <template <typename...> class TupleT, typename... Tp, typename FuncT,
+          size_t... Idx, typename... Args>
+void
+invoke(TupleT<Tp...>&& obj, FuncT&& func, index_sequence<Idx...>, Args&&... args)
+{
+    TIMEMORY_FOLD_EXPRESSION(
+        std::forward<FuncT>(func)(std::get<Idx>(obj), std::forward<Args>(args)...));
+}
+}  // namespace disjoint_impl
+//
+template <template <typename...> class TupleT, typename... Tp, typename FuncT,
+          typename... Args>
+void
+invoke(TupleT<Tp...>&& obj, FuncT&& func, Args&&... args)
+{
+    disjoint_impl::invoke(std::forward<TupleT<Tp...>>(obj), std::forward<FuncT>(func),
+                          make_index_sequence<sizeof...(Tp)>{},
+                          std::forward<Args>(args)...);
+}
+}  // namespace disjoint
+}  // namespace invoke
+}  // namespace tim
+
+#endif

--- a/source/timemory/variadic/functional.hpp
+++ b/source/timemory/variadic/functional.hpp
@@ -24,11 +24,6 @@
 
 #pragma once
 
-/** \file "timemory/variadic/functional.hpp"
- * This provides function-based forms of the variadic bundlers
- *
- */
-
 #include "timemory/api.hpp"
 #include "timemory/macros/language.hpp"
 #include "timemory/mpl/apply.hpp"
@@ -43,132 +38,14 @@ namespace tim
 {
 namespace invoke
 {
-namespace invoke_impl
-{
-//
-//--------------------------------------------------------------------------------------//
-//
-template <template <typename> class OpT, typename Tag,
-          template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_INLINE void
-invoke(TupleT<Tp...>& _obj, Args&&... _args)
-{
-    using data_type = std::tuple<Tp...>;
-    TIMEMORY_FOLD_EXPRESSION(
-        operation::generic_operator<std::remove_pointer_t<decay_t<Tp>>,
-                                    OpT<std::remove_pointer_t<decay_t<Tp>>>, Tag>(
-            std::get<index_of<Tp, data_type>::value>(_obj),
-            std::forward<Args>(_args)...));
-}
-//
-//--------------------------------------------------------------------------------------//
-//
-template <template <typename, typename> class OpT, typename Tag,
-          template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_INLINE void
-invoke(TupleT<Tp...>& _obj, Args&&... _args)
-{
-    using data_type = std::tuple<Tp...>;
-    TIMEMORY_FOLD_EXPRESSION(
-        operation::generic_operator<std::remove_pointer_t<decay_t<Tp>>,
-                                    OpT<std::remove_pointer_t<decay_t<Tp>>, Tag>, Tag>(
-            std::get<index_of<Tp, data_type>::value>(_obj),
-            std::forward<Args>(_args)...));
-}
-//
-//--------------------------------------------------------------------------------------//
-//
-template <template <typename> class OpT, typename Tag,
-          template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_INLINE void
-invoke(TupleT<Tp&...>&& _obj, Args&&... _args)
-{
-    using data_type = std::tuple<Tp...>;
-    TIMEMORY_FOLD_EXPRESSION(
-        operation::generic_operator<std::remove_pointer_t<decay_t<Tp>>,
-                                    OpT<std::remove_pointer_t<decay_t<Tp>>>, Tag>(
-            std::get<index_of<Tp, data_type>::value>(_obj),
-            std::forward<Args>(_args)...));
-}
-//
-//--------------------------------------------------------------------------------------//
-//
-template <template <typename, typename> class OpT, typename Tag,
-          template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_INLINE void
-invoke(TupleT<Tp&...>&& _obj, Args&&... _args)
-{
-    using data_type = std::tuple<Tp...>;
-    TIMEMORY_FOLD_EXPRESSION(
-        operation::generic_operator<std::remove_pointer_t<decay_t<Tp>>,
-                                    OpT<std::remove_pointer_t<decay_t<Tp>>, Tag>, Tag>(
-            std::get<index_of<Tp, data_type>::value>(_obj),
-            std::forward<Args>(_args)...));
-}
-//
-//--------------------------------------------------------------------------------------//
-//
-template <template <typename> class OpT, typename Tag,
-          template <typename...> class TupleT, typename... Tp,
-          template <typename...> class ValueT, typename... Vp, typename... Args>
-TIMEMORY_INLINE void
-invoke_data(TupleT<Tp...>& _obj, ValueT<Vp...>& _val, Args&&... _args)
-{
-    using data_type = std::tuple<Tp...>;
-    TIMEMORY_FOLD_EXPRESSION(
-        operation::generic_operator<std::remove_pointer_t<decay_t<Tp>>,
-                                    OpT<std::remove_pointer_t<decay_t<Tp>>>, Tag>(
-            std::get<index_of<Tp, data_type>::value>(_obj),
-            std::get<index_of<Tp, data_type>::value>(_val),
-            std::forward<Args>(_args)...));
-}
-//
-//--------------------------------------------------------------------------------------//
-//
-template <template <typename> class OpT, typename Tag,
-          template <typename...> class TupleT, typename... Tp,
-          template <typename...> class ValueT, typename... Vp, typename... Args>
-TIMEMORY_INLINE void
-invoke_data(TupleT<Tp&...>&& _obj, ValueT<Vp...>& _val, Args&&... _args)
-{
-    using data_type = std::tuple<Tp...>;
-    TIMEMORY_FOLD_EXPRESSION(
-        operation::generic_operator<std::remove_pointer_t<decay_t<Tp>>,
-                                    OpT<std::remove_pointer_t<decay_t<Tp>>>, Tag>(
-            std::get<index_of<Tp, data_type>::value>(_obj),
-            std::get<index_of<Tp, data_type>::value>(_val),
-            std::forward<Args>(_args)...));
-}
-//
-//--------------------------------------------------------------------------------------//
-//
-template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_INLINE void
-construct(TupleT<Tp...>& _obj, Args&&... _args)
-{
-    using data_type = std::tuple<Tp...>;
-    TIMEMORY_FOLD_EXPRESSION(
-        std::get<index_of<Tp, data_type>::value>(_obj) =
-            operation::construct<Tp>::get(std::forward<Args>(_args)...));
-}
-//
-}  // namespace invoke_impl
-//
-//======================================================================================//
 //
 template <typename... Args>
 TIMEMORY_INLINE void
-print(std::ostream& os, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(os << args << "\n");
-}
+print(std::ostream& os, Args&&... args);
 //
 template <typename... Args>
 TIMEMORY_INLINE void
-print(std::ostream& os, const std::string& delim, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(os << args << delim);
-}
+print(std::ostream& os, const std::string& delim, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  invoke
@@ -177,36 +54,32 @@ print(std::ostream& os, const std::string& delim, Args&&... args)
 template <template <typename...> class OpT, typename ApiT,
           template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-invoke(TupleT<Tp...>& obj, Args&&... args)
-{
-    invoke_impl::invoke<OpT, ApiT>(obj, std::forward<Args>(args)...);
-}
+invoke(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class OpT, template <typename...> class TupleT,
           typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-invoke(TupleT<Tp...>& obj, Args&&... args)
-{
-    invoke<OpT, TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+invoke(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class OpT, typename ApiT,
           template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-invoke(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    invoke_impl::invoke<OpT, ApiT>(std::forward<TupleT<Tp&...>>(obj),
-                                   std::forward<Args>(args)...);
-}
+invoke(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class OpT, template <typename...> class TupleT,
           typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-invoke(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    invoke<OpT, TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj),
-                              std::forward<Args>(args)...);
-}
+invoke(TupleT<Tp&...>&& obj, Args&&... args);
+//
+template <template <typename...> class OpT, typename ApiT = TIMEMORY_API, typename... Up,
+          template <typename...> class TupleT, typename... Tp, typename... Args>
+TIMEMORY_HOT_INLINE void
+invoke(mpl::piecewise_select<Up...>, TupleT<Tp...>& obj, Args&&... args);
+//
+template <template <typename...> class OpT, typename ApiT = TIMEMORY_API, typename... Up,
+          template <typename...> class TupleT, typename... Tp, typename... Args>
+TIMEMORY_HOT_INLINE void
+invoke(mpl::piecewise_select<Up...>, TupleT<Tp&...>& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  construct
@@ -214,26 +87,12 @@ invoke(TupleT<Tp&...>&& obj, Args&&... args)
 //
 template <typename TupleT, typename ApiT, typename... Args>
 TIMEMORY_HOT_INLINE auto
-construct(Args&&... args)
-{
-    IF_CONSTEXPR(trait::is_available<ApiT>::value)
-    {
-        {
-            TupleT obj{};
-            invoke_impl::construct(std::ref(obj).get(), std::forward<Args>(args)...);
-            return obj;
-        }
-    }
-    return TupleT{};
-}
+construct(Args&&... args);
 //
 //
 template <typename TupleT, typename... Args>
 TIMEMORY_HOT_INLINE auto
-construct(Args&&... args)
-{
-    return construct<TupleT, TIMEMORY_API>(std::forward<Args>(args)...);
-}
+construct(Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  destroy
@@ -241,32 +100,19 @@ construct(Args&&... args)
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp>
 TIMEMORY_HOT_INLINE auto
-destroy(TupleT<Tp...>& obj)
-{
-    invoke_impl::invoke<operation::generic_deleter, ApiT>(obj);
-}
+destroy(TupleT<Tp...>& obj);
 //
 template <template <typename...> class TupleT, typename... Tp>
 TIMEMORY_HOT_INLINE auto
-destroy(TupleT<Tp...>& obj)
-{
-    destroy<TIMEMORY_API>(obj);
-}
+destroy(TupleT<Tp...>& obj);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp>
 TIMEMORY_HOT_INLINE auto
-destroy(TupleT<Tp&...>&& obj)
-{
-    invoke_impl::invoke<operation::generic_deleter, ApiT>(
-        std::forward<TupleT<Tp&...>>(obj));
-}
+destroy(TupleT<Tp&...>&& obj);
 //
 template <template <typename...> class TupleT, typename... Tp>
 TIMEMORY_HOT_INLINE auto
-destroy(TupleT<Tp&...>&& obj)
-{
-    destroy<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj));
-}
+destroy(TupleT<Tp&...>&& obj);
 //
 //--------------------------------------------------------------------------------------//
 //                                  start
@@ -275,68 +121,20 @@ destroy(TupleT<Tp&...>&& obj)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-start(TupleT<Tp...>& obj, Args&&... args)
-{
-    using data_type        = std::tuple<remove_pointer_t<decay_t<Tp>>...>;
-    using priority_types_t = filter_false_t<negative_start_priority, data_type>;
-    using priority_tuple_t = mpl::sort<trait::start_priority, priority_types_t>;
-    using delayed_types_t  = filter_false_t<positive_start_priority, data_type>;
-    using delayed_tuple_t  = mpl::sort<trait::start_priority, delayed_types_t>;
-
-    // start high priority components
-    auto&& _priority_start = mpl::get_reference_tuple<priority_tuple_t>(obj);
-    invoke_impl::invoke<operation::priority_start, ApiT>(_priority_start,
-                                                         std::forward<Args>(args)...);
-    // start non-prioritized components
-    invoke_impl::invoke<operation::standard_start, ApiT>(obj,
-                                                         std::forward<Args>(args)...);
-    // start low prioritized components
-    auto&& _delayed_start = mpl::get_reference_tuple<delayed_tuple_t>(obj);
-    invoke_impl::invoke<operation::delayed_start, ApiT>(_delayed_start,
-                                                        std::forward<Args>(args)...);
-}
+start(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-start(TupleT<Tp...>& obj, Args&&... args)
-{
-    start<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+start(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-start(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    using data_type        = std::tuple<remove_pointer_t<decay_t<Tp>>...>;
-    using priority_types_t = filter_false_t<negative_start_priority, data_type>;
-    using priority_tuple_t = mpl::sort<trait::start_priority, priority_types_t>;
-    using delayed_types_t  = filter_false_t<positive_start_priority, data_type>;
-    using delayed_tuple_t  = mpl::sort<trait::start_priority, delayed_types_t>;
-
-    // start high priority components
-    auto&& _priority_start =
-        mpl::get_reference_tuple<priority_tuple_t>(std::forward<TupleT<Tp&...>>(obj));
-    invoke_impl::invoke<operation::priority_start, ApiT>(_priority_start,
-                                                         std::forward<Args>(args)...);
-
-    // start non-prioritized components
-    invoke_impl::invoke<operation::standard_start, ApiT>(
-        std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
-
-    // start low prioritized components
-    auto&& _delayed_start =
-        mpl::get_reference_tuple<delayed_tuple_t>(std::forward<TupleT<Tp&...>>(obj));
-    invoke_impl::invoke<operation::delayed_start, ApiT>(_delayed_start,
-                                                        std::forward<Args>(args)...);
-}
+start(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-start(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    start<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
-}
+start(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  stop
@@ -345,69 +143,20 @@ start(TupleT<Tp&...>&& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-stop(TupleT<Tp...>& obj, Args&&... args)
-{
-    using data_type        = std::tuple<remove_pointer_t<decay_t<Tp>>...>;
-    using priority_types_t = filter_false_t<negative_stop_priority, data_type>;
-    using priority_tuple_t = mpl::sort<trait::stop_priority, priority_types_t>;
-    using delayed_types_t  = filter_false_t<positive_stop_priority, data_type>;
-    using delayed_tuple_t  = mpl::sort<trait::stop_priority, delayed_types_t>;
-
-    // stop high priority components
-    auto&& _priority_stop = mpl::get_reference_tuple<priority_tuple_t>(obj);
-    invoke_impl::invoke<operation::priority_stop, ApiT>(_priority_stop,
-                                                        std::forward<Args>(args)...);
-
-    // stop non-prioritized components
-    invoke_impl::invoke<operation::standard_stop, ApiT>(obj, std::forward<Args>(args)...);
-
-    // stop low prioritized components
-    auto&& _delayed_stop = mpl::get_reference_tuple<delayed_tuple_t>(obj);
-    invoke_impl::invoke<operation::delayed_stop, ApiT>(_delayed_stop,
-                                                       std::forward<Args>(args)...);
-}
+stop(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-stop(TupleT<Tp...>& obj, Args&&... args)
-{
-    stop<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+stop(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-stop(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    using data_type        = std::tuple<remove_pointer_t<decay_t<Tp>>...>;
-    using priority_types_t = filter_false_t<negative_stop_priority, data_type>;
-    using priority_tuple_t = mpl::sort<trait::stop_priority, priority_types_t>;
-    using delayed_types_t  = filter_false_t<positive_stop_priority, data_type>;
-    using delayed_tuple_t  = mpl::sort<trait::stop_priority, delayed_types_t>;
-
-    // stop high priority components
-    auto&& _priority_stop =
-        mpl::get_reference_tuple<priority_tuple_t>(std::forward<TupleT<Tp&...>>(obj));
-    invoke_impl::invoke<operation::priority_stop, ApiT>(_priority_stop,
-                                                        std::forward<Args>(args)...);
-
-    // stop non-prioritized components
-    invoke_impl::invoke<operation::standard_stop, ApiT>(std::forward<TupleT<Tp&...>>(obj),
-                                                        std::forward<Args>(args)...);
-
-    // stop low prioritized components
-    auto&& _delayed_stop =
-        mpl::get_reference_tuple<delayed_tuple_t>(std::forward<TupleT<Tp&...>>(obj));
-    invoke_impl::invoke<operation::delayed_stop, ApiT>(_delayed_stop,
-                                                       std::forward<Args>(args)...);
-}
+stop(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-stop(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    stop<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
-}
+stop(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  mark
@@ -416,33 +165,20 @@ stop(TupleT<Tp&...>&& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-mark(TupleT<Tp...>& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::mark, ApiT>(obj, std::forward<Args>(args)...);
-}
+mark(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-mark(TupleT<Tp...>& obj, Args&&... args)
-{
-    mark<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+mark(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-mark(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::mark, ApiT>(std::forward<TupleT<Tp&...>>(obj),
-                                               std::forward<Args>(args)...);
-}
+mark(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-mark(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    mark<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
-}
+mark(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  mark_begin
@@ -451,34 +187,20 @@ mark(TupleT<Tp&...>&& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-mark_begin(TupleT<Tp...>& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::mark_begin, ApiT>(obj, std::forward<Args>(args)...);
-}
+mark_begin(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-mark_begin(TupleT<Tp...>& obj, Args&&... args)
-{
-    mark_begin<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+mark_begin(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-mark_begin(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::mark_begin, ApiT>(std::forward<TupleT<Tp&...>>(obj),
-                                                     std::forward<Args>(args)...);
-}
+mark_begin(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-mark_begin(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    mark_begin<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj),
-                             std::forward<Args>(args)...);
-}
+mark_begin(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  mark_end
@@ -487,34 +209,20 @@ mark_begin(TupleT<Tp&...>&& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-mark_end(TupleT<Tp...>& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::mark_end, ApiT>(obj, std::forward<Args>(args)...);
-}
+mark_end(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-mark_end(TupleT<Tp...>& obj, Args&&... args)
-{
-    mark_end<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+mark_end(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-mark_end(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::mark_end, ApiT>(std::forward<TupleT<Tp&...>>(obj),
-                                                   std::forward<Args>(args)...);
-}
+mark_end(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-mark_end(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    mark_end<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj),
-                           std::forward<Args>(args)...);
-}
+mark_end(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  store
@@ -523,33 +231,20 @@ mark_end(TupleT<Tp&...>&& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-store(TupleT<Tp...>& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::store, ApiT>(obj, std::forward<Args>(args)...);
-}
+store(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-store(TupleT<Tp...>& obj, Args&&... args)
-{
-    store<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+store(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-store(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::store, ApiT>(std::forward<TupleT<Tp&...>>(obj),
-                                                std::forward<Args>(args)...);
-}
+store(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-store(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    store<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
-}
+store(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  reset
@@ -558,33 +253,20 @@ store(TupleT<Tp&...>&& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-reset(TupleT<Tp...>& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::reset, ApiT>(obj, std::forward<Args>(args)...);
-}
+reset(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-reset(TupleT<Tp...>& obj, Args&&... args)
-{
-    reset<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+reset(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-reset(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::reset, ApiT>(std::forward<TupleT<Tp&...>>(obj),
-                                                std::forward<Args>(args)...);
-}
+reset(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-reset(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    reset<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
-}
+reset(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  record
@@ -593,33 +275,20 @@ reset(TupleT<Tp&...>&& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-record(TupleT<Tp...>& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::record, ApiT>(obj, std::forward<Args>(args)...);
-}
+record(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-record(TupleT<Tp...>& obj, Args&&... args)
-{
-    record<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+record(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-record(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::record, ApiT>(std::forward<TupleT<Tp&...>>(obj),
-                                                 std::forward<Args>(args)...);
-}
+record(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-record(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    record<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
-}
+record(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  measure
@@ -628,33 +297,20 @@ record(TupleT<Tp&...>&& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-measure(TupleT<Tp...>& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::measure, ApiT>(obj, std::forward<Args>(args)...);
-}
+measure(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-measure(TupleT<Tp...>& obj, Args&&... args)
-{
-    measure<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+measure(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-measure(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::measure, ApiT>(std::forward<TupleT<Tp&...>>(obj),
-                                                  std::forward<Args>(args)...);
-}
+measure(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-measure(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    measure<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
-}
+measure(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  push
@@ -663,33 +319,20 @@ measure(TupleT<Tp&...>&& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-push(TupleT<Tp...>& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::push_node, ApiT>(obj, std::forward<Args>(args)...);
-}
+push(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-push(TupleT<Tp...>& obj, Args&&... args)
-{
-    push<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+push(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-push(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::push_node, ApiT>(std::forward<TupleT<Tp&...>>(obj),
-                                                    std::forward<Args>(args)...);
-}
+push(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-push(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    push<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
-}
+push(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  pop
@@ -698,33 +341,20 @@ push(TupleT<Tp&...>&& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-pop(TupleT<Tp...>& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::pop_node, ApiT>(obj, std::forward<Args>(args)...);
-}
+pop(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-pop(TupleT<Tp...>& obj, Args&&... args)
-{
-    pop<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+pop(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-pop(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::pop_node, ApiT>(std::forward<TupleT<Tp&...>>(obj),
-                                                   std::forward<Args>(args)...);
-}
+pop(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-pop(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    pop<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
-}
+pop(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  set_prefix
@@ -733,34 +363,20 @@ pop(TupleT<Tp&...>&& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-set_prefix(TupleT<Tp...>& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::set_prefix, ApiT>(obj, std::forward<Args>(args)...);
-}
+set_prefix(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-set_prefix(TupleT<Tp...>& obj, Args&&... args)
-{
-    set_prefix<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+set_prefix(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-set_prefix(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::set_prefix, ApiT>(std::forward<TupleT<Tp&...>>(obj),
-                                                     std::forward<Args>(args)...);
-}
+set_prefix(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-set_prefix(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    set_prefix<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj),
-                             std::forward<Args>(args)...);
-}
+set_prefix(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  set_scope
@@ -769,34 +385,20 @@ set_prefix(TupleT<Tp&...>&& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-set_scope(TupleT<Tp...>& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::set_scope, ApiT>(obj, std::forward<Args>(args)...);
-}
+set_scope(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-set_scope(TupleT<Tp...>& obj, Args&&... args)
-{
-    set_scope<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+set_scope(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-set_scope(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::set_scope, ApiT>(std::forward<TupleT<Tp&...>>(obj),
-                                                    std::forward<Args>(args)...);
-}
+set_scope(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-set_scope(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    set_scope<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj),
-                            std::forward<Args>(args)...);
-}
+set_scope(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  assemble
@@ -805,34 +407,20 @@ set_scope(TupleT<Tp&...>&& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-assemble(TupleT<Tp...>& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::assemble, ApiT>(obj, std::forward<Args>(args)...);
-}
+assemble(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-assemble(TupleT<Tp...>& obj, Args&&... args)
-{
-    assemble<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+assemble(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-assemble(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::assemble, ApiT>(std::forward<TupleT<Tp&...>>(obj),
-                                                   std::forward<Args>(args)...);
-}
+assemble(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-assemble(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    assemble<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj),
-                           std::forward<Args>(args)...);
-}
+assemble(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  derive
@@ -841,33 +429,20 @@ assemble(TupleT<Tp&...>&& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-derive(TupleT<Tp...>& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::derive, ApiT>(obj, std::forward<Args>(args)...);
-}
+derive(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-derive(TupleT<Tp...>& obj, Args&&... args)
-{
-    derive<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+derive(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-derive(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::derive, ApiT>(std::forward<TupleT<Tp&...>>(obj),
-                                                 std::forward<Args>(args)...);
-}
+derive(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-derive(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    derive<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
-}
+derive(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  audit
@@ -876,33 +451,20 @@ derive(TupleT<Tp&...>&& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-audit(TupleT<Tp...>& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::audit, ApiT>(obj, std::forward<Args>(args)...);
-}
+audit(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-audit(TupleT<Tp...>& obj, Args&&... args)
-{
-    audit<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+audit(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-audit(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::audit, ApiT>(std::forward<TupleT<Tp&...>>(obj),
-                                                std::forward<Args>(args)...);
-}
+audit(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-audit(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    audit<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj), std::forward<Args>(args)...);
-}
+audit(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  add_secondary
@@ -911,34 +473,20 @@ audit(TupleT<Tp&...>&& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-add_secondary(TupleT<Tp...>& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::add_secondary, ApiT>(obj, std::forward<Args>(args)...);
-}
+add_secondary(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-add_secondary(TupleT<Tp...>& obj, Args&&... args)
-{
-    add_secondary<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+add_secondary(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE void
-add_secondary(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    invoke_impl::invoke<operation::add_secondary, ApiT>(std::forward<TupleT<Tp&...>>(obj),
-                                                        std::forward<Args>(args)...);
-}
+add_secondary(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE void
-add_secondary(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    add_secondary<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj),
-                                std::forward<Args>(args)...);
-}
+add_secondary(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  get
@@ -947,63 +495,28 @@ add_secondary(TupleT<Tp&...>&& obj, Args&&... args)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE auto
-get(TupleT<Tp...>& obj, Args&&... args)
-{
-    using data_type         = TupleT<std::remove_pointer_t<Tp>...>;
-    using data_collect_type = get_data_type_t<data_type>;
-    using data_value_type   = get_data_value_t<data_type>;
-
-    data_value_type _data{};
-    auto&&          _obj = mpl::get_reference_tuple<data_collect_type>(obj);
-    invoke_impl::invoke_data<operation::get_data, ApiT>(_obj, _data,
-                                                        std::forward<Args>(args)...);
-    return _data;
-}
+get(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE auto
-get(TupleT<Tp...>& obj, Args&&... args)
-{
-    return ::tim::invoke::get<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+get(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE auto
-get(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    using data_type         = TupleT<std::remove_pointer_t<Tp>...>;
-    using data_collect_type = get_data_type_t<data_type>;
-    using data_value_type   = get_data_value_t<data_type>;
-
-    data_value_type _data{};
-    auto&&          _obj = mpl::get_reference_tuple<data_collect_type>(obj);
-    invoke_impl::invoke_data<operation::get_data, ApiT>(_obj, _data,
-                                                        std::forward<Args>(args)...);
-    return _data;
-}
+get(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE auto
-get(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    return ::tim::invoke::get<TIMEMORY_API>(std::forward<TupleT<Tp&...>>(obj),
-                                            std::forward<Args>(args)...);
-}
+get(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp>
 TIMEMORY_HOT_INLINE auto
-get(TupleT<Tp...>& obj, void*& _ptr, size_t _hash)
-{
-    invoke_impl::invoke<operation::get, ApiT>(obj, _ptr, _hash);
-}
+get(TupleT<Tp...>& obj, void*& _ptr, size_t _hash);
 //
 template <template <typename...> class TupleT, typename... Tp>
 TIMEMORY_HOT_INLINE auto
-get(TupleT<Tp...>& obj, void*& _ptr, size_t _hash)
-{
-    return ::tim::invoke::get<TIMEMORY_API>(obj, _ptr, _hash);
-}
+get(TupleT<Tp...>& obj, void*& _ptr, size_t _hash);
 //
 //--------------------------------------------------------------------------------------//
 //                                  get_labeled
@@ -1012,48 +525,20 @@ get(TupleT<Tp...>& obj, void*& _ptr, size_t _hash)
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE auto
-get_labeled(TupleT<Tp...>& obj, Args&&... args)
-{
-    using data_type         = TupleT<std::remove_pointer_t<Tp>...>;
-    using data_collect_type = get_data_type_t<data_type>;
-    using data_label_type   = get_data_label_t<data_type>;
-
-    data_label_type _data{};
-    auto&&          _obj = mpl::get_reference_tuple<data_collect_type>(obj);
-    invoke_impl::invoke_data<operation::get_labeled_data, ApiT>(
-        _obj, _data, std::forward<Args>(args)...);
-    return _data;
-}
+get_labeled(TupleT<Tp...>& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE auto
-get_labeled(TupleT<Tp...>& obj, Args&&... args)
-{
-    return get_labeled<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+get_labeled(TupleT<Tp...>& obj, Args&&... args);
 //
 template <typename ApiT, template <typename...> class TupleT, typename... Tp,
           typename... Args>
 TIMEMORY_HOT_INLINE auto
-get_labeled(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    using data_type         = TupleT<std::remove_pointer_t<Tp>...>;
-    using data_collect_type = get_data_type_t<data_type>;
-    using data_label_type   = get_data_label_t<data_type>;
-
-    data_label_type _data{};
-    auto&&          _obj = mpl::get_reference_tuple<data_collect_type>(obj);
-    invoke_impl::invoke_data<operation::get_labeled_data, ApiT>(
-        _obj, _data, std::forward<Args>(args)...);
-    return _data;
-}
+get_labeled(TupleT<Tp&...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
 TIMEMORY_HOT_INLINE auto
-get_labeled(TupleT<Tp&...>&& obj, Args&&... args)
-{
-    return get_labeled<TIMEMORY_API>(obj, std::forward<Args>(args)...);
-}
+get_labeled(TupleT<Tp&...>&& obj, Args&&... args);
 //
 //--------------------------------------------------------------------------------------//
 //                                  get_cache
@@ -1061,319 +546,83 @@ get_labeled(TupleT<Tp&...>&& obj, Args&&... args)
 //
 template <typename... BundleT>
 TIMEMORY_HOT_INLINE auto
-get_cache()
-{
-    return operation::construct_cache<std::tuple<BundleT...>>{}();
-}
-//
-//--------------------------------------------------------------------------------------//
-//
-//          Forwarded bundles
+get_cache();
 //
 //--------------------------------------------------------------------------------------//
 //
 namespace disjoint
 {
 //
-namespace invoke_impl
-{
-//
-template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
-          typename... Args>
-TIMEMORY_INLINE void
-start(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).start(std::forward<Args>(args)...));
-}
-//
-template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
-          typename... Args>
-TIMEMORY_INLINE void
-stop(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).stop(std::forward<Args>(args)...));
-}
-//
-template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
-          typename... Args>
-TIMEMORY_INLINE void
-mark(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).mark(std::forward<Args>(args)...));
-}
-//
-template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
-          typename... Args>
-TIMEMORY_INLINE void
-mark_begin(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).mark_begin(std::forward<Args>(args)...));
-}
-//
-template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
-          typename... Args>
-TIMEMORY_INLINE void
-mark_end(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).mark_end(std::forward<Args>(args)...));
-}
-//
-template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
-          typename... Args>
-TIMEMORY_INLINE void
-store(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).store(std::forward<Args>(args)...));
-}
-//
-template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
-          typename... Args>
-TIMEMORY_INLINE void
-reset(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).reset(std::forward<Args>(args)...));
-}
-//
-template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
-          typename... Args>
-TIMEMORY_INLINE void
-record(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).record(std::forward<Args>(args)...));
-}
-//
-template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
-          typename... Args>
-TIMEMORY_INLINE void
-measure(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).measure(std::forward<Args>(args)...));
-}
-//
-template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
-          typename... Args>
-TIMEMORY_INLINE void
-push(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).push(std::forward<Args>(args)...));
-}
-//
-template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
-          typename... Args>
-TIMEMORY_INLINE void
-pop(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).pop(std::forward<Args>(args)...));
-}
-//
-template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
-          typename... Args>
-TIMEMORY_INLINE void
-set_prefix(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).set_prefix(std::forward<Args>(args)...));
-}
-//
-template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
-          typename... Args>
-TIMEMORY_INLINE void
-set_scope(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).set_scope(std::forward<Args>(args)...));
-}
-//
-template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
-          typename... Args>
-TIMEMORY_INLINE void
-assemble(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).assemble(std::forward<Args>(args)...));
-}
-//
-template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
-          typename... Args>
-TIMEMORY_INLINE void
-derive(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).derive(std::forward<Args>(args)...));
-}
-//
-template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
-          typename... Args>
-TIMEMORY_INLINE void
-audit(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(std::get<Idx>(obj).audit(std::forward<Args>(args)...));
-}
-//
-template <template <typename...> class TupleT, typename... Tp, size_t... Idx,
-          typename... Args>
-TIMEMORY_INLINE void
-add_secondary(TupleT<Tp...>&& obj, index_sequence<Idx...>, Args&&... args)
-{
-    TIMEMORY_FOLD_EXPRESSION(
-        std::get<Idx>(obj).add_secondary(std::forward<Args>(args)...));
-}
-//
-}  // namespace invoke_impl
-//
-//--------------------------------------------------------------------------------------//
+template <template <typename...> class TupleT, typename... Tp, typename... Args>
+void
+start(TupleT<Tp...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT_INLINE void
-start(TupleT<Tp...>&& obj, Args&&... args)
-{
-    invoke_impl::start(std::forward<TupleT<Tp...>>(obj),
-                       std::make_index_sequence<sizeof...(Tp)>{},
-                       std::forward<Args>(args)...);
-}
+void
+stop(TupleT<Tp...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT_INLINE void
-stop(TupleT<Tp...>&& obj, Args&&... args)
-{
-    invoke_impl::stop(std::forward<TupleT<Tp...>>(obj),
-                      std::make_index_sequence<sizeof...(Tp)>{},
-                      std::forward<Args>(args)...);
-}
+void
+mark(TupleT<Tp...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT_INLINE void
-mark(TupleT<Tp...>&& obj, Args&&... args)
-{
-    invoke_impl::mark(std::forward<TupleT<Tp...>>(obj),
-                      std::make_index_sequence<sizeof...(Tp)>{},
-                      std::forward<Args>(args)...);
-}
+void
+mark_begin(TupleT<Tp...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT_INLINE void
-mark_begin(TupleT<Tp...>&& obj, Args&&... args)
-{
-    invoke_impl::mark_begin(std::forward<TupleT<Tp...>>(obj),
-                            std::make_index_sequence<sizeof...(Tp)>{},
-                            std::forward<Args>(args)...);
-}
+void
+mark_end(TupleT<Tp...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT_INLINE void
-mark_end(TupleT<Tp...>&& obj, Args&&... args)
-{
-    invoke_impl::mark_end(std::forward<TupleT<Tp...>>(obj),
-                          std::make_index_sequence<sizeof...(Tp)>{},
-                          std::forward<Args>(args)...);
-}
+void
+store(TupleT<Tp...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT_INLINE void
-store(TupleT<Tp...>&& obj, Args&&... args)
-{
-    invoke_impl::store(std::forward<TupleT<Tp...>>(obj),
-                       std::make_index_sequence<sizeof...(Tp)>{},
-                       std::forward<Args>(args)...);
-}
+void
+reset(TupleT<Tp...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT_INLINE void
-reset(TupleT<Tp...>&& obj, Args&&... args)
-{
-    invoke_impl::reset(std::forward<TupleT<Tp...>>(obj),
-                       std::make_index_sequence<sizeof...(Tp)>{},
-                       std::forward<Args>(args)...);
-}
+void
+record(TupleT<Tp...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT_INLINE void
-record(TupleT<Tp...>&& obj, Args&&... args)
-{
-    invoke_impl::record(std::forward<TupleT<Tp...>>(obj),
-                        std::make_index_sequence<sizeof...(Tp)>{},
-                        std::forward<Args>(args)...);
-}
+void
+measure(TupleT<Tp...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT_INLINE void
-measure(TupleT<Tp...>&& obj, Args&&... args)
-{
-    invoke_impl::measure(std::forward<TupleT<Tp...>>(obj),
-                         std::make_index_sequence<sizeof...(Tp)>{},
-                         std::forward<Args>(args)...);
-}
+void
+push(TupleT<Tp...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT_INLINE void
-push(TupleT<Tp...>&& obj, Args&&... args)
-{
-    invoke_impl::push(std::forward<TupleT<Tp...>>(obj),
-                      std::make_index_sequence<sizeof...(Tp)>{},
-                      std::forward<Args>(args)...);
-}
+void
+pop(TupleT<Tp...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT_INLINE void
-pop(TupleT<Tp...>&& obj, Args&&... args)
-{
-    invoke_impl::pop(std::forward<TupleT<Tp...>>(obj),
-                     std::make_index_sequence<sizeof...(Tp)>{},
-                     std::forward<Args>(args)...);
-}
+void
+set_prefix(TupleT<Tp...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT_INLINE void
-set_prefix(TupleT<Tp...>&& obj, Args&&... args)
-{
-    invoke_impl::set_prefix(std::forward<TupleT<Tp...>>(obj),
-                            std::make_index_sequence<sizeof...(Tp)>{},
-                            std::forward<Args>(args)...);
-}
+void
+set_scope(TupleT<Tp...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT_INLINE void
-set_scope(TupleT<Tp...>&& obj, Args&&... args)
-{
-    invoke_impl::set_scope(std::forward<TupleT<Tp...>>(obj),
-                           std::make_index_sequence<sizeof...(Tp)>{},
-                           std::forward<Args>(args)...);
-}
+void
+assemble(TupleT<Tp...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT_INLINE void
-assemble(TupleT<Tp...>&& obj, Args&&... args)
-{
-    invoke_impl::assemble(std::forward<TupleT<Tp...>>(obj),
-                          std::make_index_sequence<sizeof...(Tp)>{},
-                          std::forward<Args>(args)...);
-}
+void
+derive(TupleT<Tp...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT_INLINE void
-derive(TupleT<Tp...>&& obj, Args&&... args)
-{
-    invoke_impl::derive(std::forward<TupleT<Tp...>>(obj),
-                        std::make_index_sequence<sizeof...(Tp)>{},
-                        std::forward<Args>(args)...);
-}
+void
+audit(TupleT<Tp...>&& obj, Args&&... args);
 //
 template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT_INLINE void
-audit(TupleT<Tp...>&& obj, Args&&... args)
-{
-    invoke_impl::audit(std::forward<TupleT<Tp...>>(obj),
-                       std::make_index_sequence<sizeof...(Tp)>{},
-                       std::forward<Args>(args)...);
-}
+void
+add_secondary(TupleT<Tp...>&& obj, Args&&... args);
 //
-template <template <typename...> class TupleT, typename... Tp, typename... Args>
-TIMEMORY_HOT_INLINE void
-add_secondary(TupleT<Tp...>&& obj, Args&&... args)
-{
-    invoke_impl::add_secondary(std::forward<TupleT<Tp...>>(obj),
-                               std::make_index_sequence<sizeof...(Tp)>{},
-                               std::forward<Args>(args)...);
-}
 }  // namespace disjoint
-//
-//--------------------------------------------------------------------------------------//
-//
 }  // namespace invoke
 }  // namespace tim
+
+#include "timemory/variadic/functional.cpp"

--- a/source/tools/timemory-avail/timemory-avail.cpp
+++ b/source/tools/timemory-avail/timemory-avail.cpp
@@ -125,7 +125,7 @@ struct get_availability
             return _type;
         };
 
-        bool has_metadata = metadata_t::value != TIMEMORY_COMPONENTS_END;
+        bool has_metadata = metadata_t::specialized();
         bool is_available = trait::is_available<Type>::value;
         bool file_output  = trait::generates_output<Type>::value;
         auto name         = component::metadata<Type>::name();

--- a/source/tools/timemory-compiler-instrument/compiler-instrument-base.cpp
+++ b/source/tools/timemory-compiler-instrument/compiler-instrument-base.cpp
@@ -498,11 +498,11 @@ finalize()
     {
         wall_clock wc{};
         peak_rss   pr{};
-        tim::invoke::disjoint::start(std::forward_as_tuple(wc, pr));
+        tim::invoke::start(std::tie(wc, pr));
         //
         tim::timemory_finalize();
         //
-        tim::invoke::disjoint::stop(std::forward_as_tuple(wc, pr));
+        tim::invoke::stop(std::tie(wc, pr));
         std::stringstream ss;
         ss << "required " << wc.get() << " " << tim::component::wall_clock::display_unit()
            << " and " << pr.get() << " " << tim::component::peak_rss::display_unit();

--- a/timemory/analyze/analyze.py
+++ b/timemory/analyze/analyze.py
@@ -43,9 +43,12 @@ __all__ = [
     "add",
     "subtract",
     "unify",
+    "dump_entity",
     "dump_tree",
     "dump_dot",
     "dump_flamegraph",
+    "dump_tabulate",
+    "dump_unknown",
     "dump",
 ]
 
@@ -102,6 +105,8 @@ def load(data, *_args, **_kwargs):
     from timemory import hatchet
     import hatchet as ht
 
+    #print("data: {}".format(data))
+    #print("data_type: {}".format(type(data).__name__))
     return ht.GraphFrame.from_timemory(data, *_args, **_kwargs)
 
 
@@ -341,6 +346,8 @@ def dump_entity(data, functor, file=None, fext=None):
             print(f"[{lbl}]|0> Outputting '{_file}'...")
         for itr in data:
             _dump_entity(functor(itr), ofs)
+        if ofs is not None:
+            ofs.close()
         if _file is not None:
             files.append(_file)
     return files

--- a/timemory/test/test_hatchet.py
+++ b/timemory/test/test_hatchet.py
@@ -91,7 +91,7 @@ class TimemoryHatchetTests(unittest.TestCase):
         tim.settings.parse()
 
         # generate data
-        fibonacci(10, False)
+        fibonacci(15, False)
         fibonacci(8)
 
     def setUp(self):
@@ -121,12 +121,6 @@ class TimemoryHatchetTests(unittest.TestCase):
         print(gf.tree("sum"))
         print(gf.tree("sum.inc"))
 
-        fbase = os.path.join(tim.settings.output_prefix, "wall")
-        with open(f"{fbase}.dot", "w") as ofs:
-            ofs.write(gf.to_dot())
-        with open(f"{fbase}.fg", "w") as ofs:
-            ofs.write(gf.to_flamegraph())
-
     # ---------------------------------------------------------------------------------- #
     # test handling multi-dimensional data from hatchet
     def test_hatchet_2D_data(self):
@@ -148,6 +142,34 @@ class TimemoryHatchetTests(unittest.TestCase):
 
         self.assertTrue(gf.tree("sum.start-peak-rss.inc") is not None)
         self.assertTrue(gf.tree("sum.stop-peak-rss") is not None)
+
+    def test_hatchet_analyze(self):
+        """test_hatchet_analyze"""
+
+        try:
+            import hatchet as ht
+        except ImportError:
+            return
+
+        from timemory.analyze import embedded_analyze
+        from timemory import settings
+        import timemory
+
+        outpath = os.path.join(
+            settings.output_path,
+            "analysis",
+        )
+
+        args = ["--expression", "x > 0"] + "-f dot flamegraph tree -o {} --per-thread --per-rank --select peak_rss --search fibonacci -e".format(
+            outpath
+        ).split()
+
+        print(f"arguments: {args}")
+
+        embedded_analyze(
+            args,
+            data=[timemory.get(hierarchy=True)],
+        )
 
 
 # ----------------------------- main test runner ---------------------------------------- #


### PR DESCRIPTION
## Overview

- Bundlers now support chaining together function calls for most functions
- New function for checking whether component properties/metadata has been specialized
  - `component::properties<T>::specialized()`
  - `component::metadata<T>::specialized()`
- improvements to `component::data_tracker` and `data::handler`
- `utility::transient_function`: alternative to `std::function` which never allocates on the heap and takes less time to compile
  - this should only be used in synchronous calls and cannot be referenced
  - future updates will use this more often for initialization functions
- the "auto" bundlers now contain significantly less code thanks to a new `auto_base_bundler` static polymorphic base class
  - SIGNIFICANTLY reduced the amount of auto-bundler code
  - A similar technique will be applied to non-auto component bundlers but this is more complicated for various reasons
- Minor fixes timemory.analysis
- Added `operator()` for various operations
- Added `trait::default_runtime_enabled` trait. This can be specialized to have a component default to being disabled at runtime
- bundlers can now execute functions

## New Features

### Bundler Chaining

The vast majority of bundler member functions return references to itself, thus, you can now chain member function calls like `.start().store(i).audit(i)`. Additionally, there is a `execute(...)` member function which will execute some function and store the result (w/o copying) so you can return the result after the chain completes. Here is an example:

```cpp
using bundler_t = component_tuple<wall_clock, peak_rss, data_tracker_integer>;
int foo(int i)
{
    bundler_t _obj{ "foo" };
    _obj.start().store(std::plus<int>{}, i)

    return ...;
}

int bar(int i)
{
    // returns the result of foo(i)
    return bundle_t{ "bar" }.start().audit(i).execute(foo, i).stop().return_result();
}
```

### Transient Function

```cpp
struct foo
{
    using transient_type = utility::transient_function<void(foo&)>;

    // transient_function replaces std::function usage here
    foo(transient_type _init_func = [](foo&) {})
    {
        _init_func(*this);
    }
};

void bar()
{
    foo _obj{ [](foo& f) { ... } };
}
```

## Bug fixes

- Statistics
  - There was a SFINAE error in `math::compute<T>::min(...)` and `math::compute<T>::max(...)` that was causing min/max to not get computed correctly in statistics
