### PR TITLE
Export -rdynamic for GNU compiler on Linux

### DIFF
--- a/cmake/Modules/BuildSettings.cmake
+++ b/cmake/Modules/BuildSettings.cmake
@@ -90,6 +90,11 @@ target_compile_options(timemory-compile-debuginfo INTERFACE
     $<$<COMPILE_LANGUAGE:C>:$<$<C_COMPILER_ID:GNU>:-rdynamic>>
     $<$<COMPILE_LANGUAGE:CXX>:$<$<CXX_COMPILER_ID:GNU>:-rdynamic>>)
 
+if(NOT APPLE)
+    target_link_options(timemory-compile-debuginfo INTERFACE
+        $<$<CXX_COMPILER_ID:GNU>:-rdynamic>)
+endif()
+
 if(CMAKE_CUDA_COMPILER_IS_NVIDIA)
     target_compile_options(timemory-compile-debuginfo INTERFACE
         $<$<COMPILE_LANGUAGE:CUDA>:$<$<CXX_COMPILER_ID:GNU>:-Xcompiler=-rdynamic>>)

--- a/pyctest-runner.py
+++ b/pyctest-runner.py
@@ -1037,6 +1037,18 @@ def run_pyctest():
 
     if not args.quick and not args.coverage and not args.minimal:
 
+        if "compiler" in args.tools:
+            pyct.test(
+                construct_name("ex-compiler-instrument"),
+                construct_command(["./ex_compiler_instrument"], args),
+                {
+                    "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
+                    "LABELS": pyct.PROJECT_NAME,
+                    "TIMEOUT": "120",
+                    "ENVIRONMENT": test_env,
+                },
+            )
+
         pyct.test(
             construct_name("ex-derived"),
             construct_command(["./ex_derived"], args),


### PR DESCRIPTION
- Fixed `-rdynamic` not appearing on the link line for GNU compilers on Linux
- Added `ex_compiler_instrument` to be run in testing
- Closes #163 