### PR TITLE
Update hatchet submodule + various patches

### DIFF
--- a/cmake/Templates/console-script.py.in
+++ b/cmake/Templates/console-script.py.in
@@ -3,5 +3,6 @@
 __requires__ = 'timemory==@TIMEMORY_VERSION_STRING@'
 
 if __name__ == '__main__':
+    @CONSOLE_EXTRA@
     from @SCRIPT_SUBMODULE@.__main__ import @SCRIPT_FUNCTION@
     @SCRIPT_FUNCTION@()

--- a/docs/api/type_traits.md
+++ b/docs/api/type_traits.md
@@ -29,11 +29,6 @@ user code.
    :members:
 ```
 
-## Type Identification
-
-```eval_rst
-```
-
 ## Base Class Modifications
 
 ```eval_rst
@@ -42,6 +37,17 @@ user code.
 .. doxygenstruct:: tim::trait::base_has_last
    :members:
 .. doxygenstruct:: tim::trait::dynamic_base
+   :members:
+```
+
+## Priority Ordering
+
+```eval_rst
+.. doxygenstruct:: tim::trait::start_priority
+   :members:
+.. doxygenstruct:: tim::trait::stop_priority
+   :members:
+.. doxygenstruct:: tim::trait::fini_priority
    :members:
 ```
 

--- a/examples/ex-cpu-roofline/CMakeLists.txt
+++ b/examples/ex-cpu-roofline/CMakeLists.txt
@@ -5,6 +5,17 @@ if("${CMAKE_PROJECT_NAME}" STREQUAL "timemory" AND NOT TIMEMORY_USE_PAPI)
     return()
 endif()
 
+set(VALID_PARANOID OFF)
+set(PARANOID_FILE "/proc/sys/kernel/perf_event_paranoid")
+if(EXISTS "${PARANOID_FILE}")
+    file(READ "${PARANOID_FILE}" PARANOID_VALUE LIMIT_COUNT 1)
+    if(PARANOID_VALUE GREATER 1)
+        message(AUTHOR_WARNING "${PARANOID_FILE} is ${PARANOID_VALUE} and a value <= 1 is required to collect the HW counters.")
+        message(STATUS "Skipping cpu-roofline example because HW counter data cannot be collected")
+        return()
+    endif()
+endif()
+
 project(timemory-CPU-Roofline-Example LANGUAGES C CXX)
 
 set(EXE_NAME ex_cpu_roofline)

--- a/examples/ex-gpu-roofline/ex_gpu_roofline.cpp
+++ b/examples/ex-gpu-roofline/ex_gpu_roofline.cpp
@@ -207,12 +207,12 @@ main(int argc, char** argv)
     tim::timemory_init(argc, argv);
     tim::cuda::device_query();
     tim::cuda::set_device(0);
+    tim::enable_signal_detection();
 
-    int64_t num_threads =
-        tim::threading::affinity::hw_physicalcpu();      // default number of threads
-    int64_t num_streams   = 1;                           // default number of streams
-    int64_t working_size  = 500 * tim::units::megabyte;  // default working set size
-    int64_t memory_factor = 10;                          // default multiple of 500 MB
+    int64_t num_threads   = 1;                           // default number of threads
+    int64_t num_streams   = 8;                           // default number of streams
+    int64_t working_size  = 100 * tim::units::megabyte;  // default working set size
+    int64_t memory_factor = 5;                           // default multiple of 100 MB
     int64_t iterations    = 1000;
     int64_t block_size    = 1024;
     int64_t grid_size     = 0;

--- a/pyctest-runner.py
+++ b/pyctest-runner.py
@@ -943,6 +943,46 @@ def run_pyctest():
         )
 
         pyct.test(
+            "timemory-python-profiler-main-no-opts",
+            [
+                sys.executable,
+                "-m",
+                "timemory.profiler",
+                "./ex_python_external",
+                "5",
+            ],
+            {
+                "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
+                "LABELS": pyct.PROJECT_NAME,
+                "TIMEOUT": "120",
+                "ENVIRONMENT": base_env,
+            },
+        )
+
+        pyct.test(
+            "timemory-python-profiler-main-script",
+            [
+                os.path.join(pyct.BINARY_DIRECTORY, "bin", "timemory-python-profiler"),
+                "--max-stack-depth=10",
+                "-l",
+                "-f",
+                "-F",
+                "-c",
+                "wall_clock",
+                "peak_rss",
+                "--",
+                "./ex_python_external",
+                "12",
+            ],
+            {
+                "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
+                "LABELS": pyct.PROJECT_NAME,
+                "TIMEOUT": "120",
+                "ENVIRONMENT": base_env,
+            },
+        )
+
+        pyct.test(
             "timemory-python-profiler-builtin",
             [
                 sys.executable,
@@ -1008,6 +1048,45 @@ def run_pyctest():
         )
 
         pyct.test(
+            "timemory-python-trace-main-no-opts",
+            [
+                sys.executable,
+                "-m",
+                "timemory.trace",
+                "./ex_python_external",
+                "5",
+            ],
+            {
+                "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
+                "LABELS": pyct.PROJECT_NAME,
+                "TIMEOUT": "120",
+                "ENVIRONMENT": base_env,
+            },
+        )
+
+        pyct.test(
+            "timemory-python-trace-main-script",
+            [
+                os.path.join(pyct.BINARY_DIRECTORY, "bin", "timemory-python-trace"),
+                "-l",
+                "-f",
+                "-F",
+                "-c",
+                "wall_clock",
+                "peak_rss",
+                "--",
+                "./ex_python_external",
+                "12",
+            ],
+            {
+                "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
+                "LABELS": pyct.PROJECT_NAME,
+                "TIMEOUT": "120",
+                "ENVIRONMENT": base_env,
+            },
+        )
+
+        pyct.test(
             "timemory-python-trace-builtin",
             [
                 sys.executable,
@@ -1038,6 +1117,43 @@ def run_pyctest():
                 sys.executable,
                 "-m",
                 "timemory.line_profiler",
+                "-v",
+                "-l",
+                "-c",
+                "peak_rss",
+                "--",
+                "./ex_python_external",
+                "12",
+            ],
+            {
+                "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
+                "LABELS": pyct.PROJECT_NAME,
+                "TIMEOUT": "120",
+                "ENVIRONMENT": base_env,
+            },
+        )
+
+        pyct.test(
+            "timemory-python-line-profiler-no-opts",
+            [
+                sys.executable,
+                "-m",
+                "timemory.line_profiler",
+                "./ex_python_external",
+                "12",
+            ],
+            {
+                "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
+                "LABELS": pyct.PROJECT_NAME,
+                "TIMEOUT": "120",
+                "ENVIRONMENT": base_env,
+            },
+        )
+
+        pyct.test(
+            "timemory-python-line-profiler-script",
+            [
+                os.path.join(pyct.BINARY_DIRECTORY, "bin", "timemory-python-line-profiler"),
                 "-v",
                 "-l",
                 "-c",

--- a/pyctest-runner.py
+++ b/pyctest-runner.py
@@ -1134,43 +1134,6 @@ def run_pyctest():
         )
 
         pyct.test(
-            "timemory-python-line-profiler-no-opts",
-            [
-                sys.executable,
-                "-m",
-                "timemory.line_profiler",
-                "./ex_python_external",
-                "12",
-            ],
-            {
-                "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
-                "LABELS": pyct.PROJECT_NAME,
-                "TIMEOUT": "120",
-                "ENVIRONMENT": base_env,
-            },
-        )
-
-        pyct.test(
-            "timemory-python-line-profiler-script",
-            [
-                os.path.join(pyct.BINARY_DIRECTORY, "bin", "timemory-python-line-profiler"),
-                "-v",
-                "-l",
-                "-c",
-                "peak_rss",
-                "--",
-                "./ex_python_external",
-                "12",
-            ],
-            {
-                "WORKING_DIRECTORY": pyct.BINARY_DIRECTORY,
-                "LABELS": pyct.PROJECT_NAME,
-                "TIMEOUT": "120",
-                "ENVIRONMENT": base_env,
-            },
-        )
-
-        pyct.test(
             "timemory-python-line-profiler-builtin",
             [
                 sys.executable,

--- a/source/python/libpytimemory-component-bundle.hpp
+++ b/source/python/libpytimemory-component-bundle.hpp
@@ -155,7 +155,11 @@ generate(py::module& _pymod, const char* _name, const char* _doc,
         size_t isize = bundle_t::size();
         if(tim::settings::debug() || tim::settings::verbose() > 3)
         {
-            PRINT_HERE("%s", "configuring pybundle");
+            static auto _enum2str = pytim::get_enum_string_map();
+            std::string _slist{};
+            for(auto& itr : components)
+                _slist += ", " + _enum2str[itr];
+            PRINT_HERE("configuring pybundle with [%s]", _slist.substr(2).c_str());
         }
 
         _scope_set(flat_profile, timeline_profile);

--- a/source/tests/api_tests.cpp
+++ b/source/tests/api_tests.cpp
@@ -249,8 +249,8 @@ TEST_F(api_tests, category)
             for(auto& itr : _data)
                 ifs >> itr;
         }
-        for(size_t i = 0; i < _data.size(); ++i)
-            EXPECT_NEAR(_data.at(i), _data_cpy.at(i), 1.0e-3);
+        for(size_t j = 0; j < _data.size(); ++j)
+            EXPECT_NEAR(_data.at(j), _data_cpy.at(j), 1.0e-3);
         auto val = details::random_entry(_data);
         EXPECT_GE(val, 1.0);
         EXPECT_LE(val, 11.0);

--- a/source/timemory/compat/macros.h
+++ b/source/timemory/compat/macros.h
@@ -43,21 +43,15 @@
 #endif
 
 #if defined(DISABLE_TIMEMORY) || defined(TIMEMORY_DISABLED)
-
-#    define TIMEMORY_SPRINTF(...)
-
+#    if !defined(TIMEMORY_SPRINTF)
+#        define TIMEMORY_SPRINTF(...)
+#    endif
 #else
-#    if defined(__cplusplus)
-#        define TIMEMORY_SPRINTF(VAR, LEN, FMT, ...)                                     \
-            std::unique_ptr<char> VAR_PTR = std::unique_ptr<char>(new char[LEN]);        \
-            char*                 VAR     = VAR_PTR.get();                               \
-            sprintf(VAR, FMT, __VA_ARGS__);
-#    else
+#    if !defined(TIMEMORY_SPRINTF)
 #        define TIMEMORY_SPRINTF(VAR, LEN, FMT, ...)                                     \
             char VAR[LEN];                                                               \
             sprintf(VAR, FMT, __VA_ARGS__);
 #    endif
-
 #endif
 
 //======================================================================================//

--- a/source/timemory/compat/macros.h
+++ b/source/timemory/compat/macros.h
@@ -50,7 +50,15 @@
 #    if !defined(TIMEMORY_SPRINTF)
 #        define TIMEMORY_SPRINTF(VAR, LEN, FMT, ...)                                     \
             char VAR[LEN];                                                               \
-            sprintf(VAR, FMT, __VA_ARGS__);
+            snprintf(VAR, LEN, FMT, __VA_ARGS__);
+#    endif
+#endif
+
+#if !defined(TIMEMORY_CODE)
+#    if defined(DISABLE_TIMEMORY) || defined(TIMEMORY_DISABLED)
+#        define TIMEMORY_CODE(...)
+#    else
+#        define TIMEMORY_CODE(...) __VA_ARGS__
 #    endif
 #endif
 

--- a/source/timemory/components/properties.hpp
+++ b/source/timemory/components/properties.hpp
@@ -112,7 +112,7 @@ struct static_properties<void, false>
     static bool matches(const char* _ckey, const char* _enum_str, const idset_t& _ids)
     {
         static bool       _debug       = tim::get_env<bool>("TIMEMORY_DEBUG", false);
-        static const auto regex_consts = std::regex_constants::egrep |
+        static const auto regex_consts = std::regex_constants::ECMAScript |
                                          std::regex_constants::icase |
                                          std::regex_constants::optimize;
         std::string _opts{ _enum_str };
@@ -122,16 +122,14 @@ struct static_properties<void, false>
             if(!itr.empty())
                 _opts += "|" + itr;
         }
-        auto _option = std::string{ "(^|[,;: '\"\t\n\r]?)(" } + _opts +
-                       std::string{ ")([,;: '\"\t\n\r]?|$)" };
+        auto _option = std::string{ "\\b(" } + _opts + std::string{ ")\\b" };
         try
         {
             if(std::regex_search(_ckey, std::regex{ _option, regex_consts }))
             {
                 if(_debug)
                 {
-                    auto _doption = std::string{ "^([,;: '\\\"\\t\\n\\r]?)(" } + _opts +
-                                    std::string{ ")([,;: '\\\"\\t\\n\\r]?|$)" };
+                    auto _doption = std::string{ "\\b(" } + _opts + std::string{ ")\\b" };
                     fprintf(stderr,
                             "[component::static_properties::matches] '%s' matches (%s) "
                             "[regex: '%s']\n",
@@ -142,11 +140,10 @@ struct static_properties<void, false>
             }
         } catch(std::regex_error& err)
         {
-            auto _doption = std::string{ "^([,;: '\\\"\\t\\n\\r]?)(" } + _opts +
-                            std::string{ ")([,;: '\\\"\\t\\n\\r]?|$)" };
+            auto _doption = std::string{ "\\b(" } + _opts + std::string{ ")\\b" };
             PRINT_HERE("regex error in regex_match(\"%s\", regex{ \"%s\", egrep | icase "
-                       "| optimize }): %s",
-                       _ckey, _doption.c_str(), err.what());
+                       "| optimize }): %s [real: %s]",
+                       _ckey, _doption.c_str(), err.what(), _option.c_str());
             TIMEMORY_TESTING_EXCEPTION("regex error in: \"" << _doption << "\" for "
                                                             << _ckey)
         }

--- a/source/timemory/components/roofline/types.hpp
+++ b/source/timemory/components/roofline/types.hpp
@@ -175,7 +175,6 @@ TIMEMORY_DEFINE_VARIADIC_TRAIT(custom_label_printing, component::gpu_roofline, t
 
 TIMEMORY_DEFINE_VARIADIC_TRAIT(array_serialization, component::cpu_roofline, true_type,
                                typename)
-//                                typename)
 
 //--------------------------------------------------------------------------------------//
 //
@@ -233,6 +232,19 @@ TIMEMORY_DEFINE_VARIADIC_TRAIT(custom_serialization, component::gpu_roofline, tr
 
 TIMEMORY_DEFINE_VARIADIC_TRAIT(secondary_data, component::gpu_roofline, true_type,
                                typename)
+
+//--------------------------------------------------------------------------------------//
+//
+//                              FINALIZATION PRIORITY
+//
+//--------------------------------------------------------------------------------------//
+
+// finalize early
+TIMEMORY_DEFINE_VARIADIC_TRAIT(fini_priority, component::cpu_roofline,
+                               priority_constant<-4>, typename)
+
+TIMEMORY_DEFINE_VARIADIC_TRAIT(fini_priority, component::gpu_roofline,
+                               priority_constant<-4>, typename)
 
 //--------------------------------------------------------------------------------------//
 //

--- a/source/timemory/components/timing/types.hpp
+++ b/source/timemory/components/timing/types.hpp
@@ -237,15 +237,19 @@ TIMEMORY_PROPERTY_SPECIALIZATION(monotonic_clock, TIMEMORY_MONOTONIC_CLOCK,
 TIMEMORY_PROPERTY_SPECIALIZATION(monotonic_raw_clock, TIMEMORY_MONOTONIC_RAW_CLOCK,
                                  "monotonic_raw_clock", "")
 
-TIMEMORY_PROPERTY_SPECIALIZATION(thread_cpu_clock, TIMEMORY_THREAD_CPU_CLOCK,
-                                 "thread_cpu_clock", "")
 TIMEMORY_PROPERTY_SPECIALIZATION(process_cpu_clock, TIMEMORY_PROCESS_CPU_CLOCK,
-                                 "process_cpu_clock", "")
+                                 "process_cpu_clock", "cpu_process_clock")
 
-TIMEMORY_PROPERTY_SPECIALIZATION(cpu_util, TIMEMORY_CPU_UTIL, "cpu_util", "")
+TIMEMORY_PROPERTY_SPECIALIZATION(thread_cpu_clock, TIMEMORY_THREAD_CPU_CLOCK,
+                                 "thread_cpu_clock", "cpu_thread_clock")
+
+TIMEMORY_PROPERTY_SPECIALIZATION(cpu_util, TIMEMORY_CPU_UTIL, "cpu_util",
+                                 "cpu_utilization")
 
 TIMEMORY_PROPERTY_SPECIALIZATION(process_cpu_util, TIMEMORY_PROCESS_CPU_UTIL,
-                                 "process_cpu_util", "")
+                                 "process_cpu_util", "process_cpu_utilization",
+                                 "cpu_process_util", "cpu_process_utilization")
 
 TIMEMORY_PROPERTY_SPECIALIZATION(thread_cpu_util, TIMEMORY_THREAD_CPU_UTIL,
-                                 "thread_cpu_util", "")
+                                 "thread_cpu_util", "thread_cpu_utilization",
+                                 "cpu_thread_util", "cpu_thread_utilization")

--- a/source/timemory/mpl/type_traits.hpp
+++ b/source/timemory/mpl/type_traits.hpp
@@ -283,7 +283,7 @@ struct custom_unit_printing : false_type
 //--------------------------------------------------------------------------------------//
 /// \struct tim::trait::start_priority
 /// \brief trait that designates whether there is a priority when starting the type w.r.t.
-/// other types.
+/// other types. Lower values indicate higher priority.
 ///
 template <typename T>
 struct start_priority : std::integral_constant<int, 0>
@@ -292,10 +292,20 @@ struct start_priority : std::integral_constant<int, 0>
 //--------------------------------------------------------------------------------------//
 /// \struct tim::trait::stop_priority
 /// \brief trait that designates whether there is a priority when stopping the type w.r.t.
-/// other types.
+/// other types. Lower values indicate higher priority.
 ///
 template <typename T>
 struct stop_priority : std::integral_constant<int, 0>
+{};
+
+//--------------------------------------------------------------------------------------//
+/// \struct tim::trait::fini_priority
+/// \brief trait that designates whether there is a priority when finalizing the type
+/// w.r.t. other types. Recommended for component which hold instances of other
+/// components. Lower values indicate higher priority.
+///
+template <typename T>
+struct fini_priority : std::integral_constant<int, 0>
 {};
 
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/mpl/types.hpp
+++ b/source/timemory/mpl/types.hpp
@@ -156,6 +156,9 @@ template <typename T>
 struct stop_priority;
 
 template <typename T>
+struct fini_priority;
+
+template <typename T>
 struct is_timing_category;
 
 template <typename T>

--- a/source/timemory/operations/types/fini.hpp
+++ b/source/timemory/operations/types/fini.hpp
@@ -62,7 +62,7 @@ struct fini
               enable_if_t<trait::is_available<Up>::value, char> = 0>
     explicit TIMEMORY_COLD fini(mode_constant<StateT>)
     {
-        auto _storage = storage<Tp>::instance();
+        auto _storage = storage<Tp>::noninit_instance();
         if(_storage)
             sfinae<type, StateT>(_storage, 0, 0);
     }
@@ -83,7 +83,7 @@ struct fini
               enable_if_t<trait::is_available<Up>::value, char> = 0>
     TIMEMORY_COLD auto operator()(mode_constant<StateT>)
     {
-        auto _storage = storage<Tp>::instance();
+        auto _storage = storage<Tp>::noninit_instance();
         if(_storage)
             return sfinae<type, StateT>(_storage, 0, 0);
         return false;

--- a/source/timemory/storage/definition.hpp
+++ b/source/timemory/storage/definition.hpp
@@ -1068,8 +1068,10 @@ storage<Type, true>::get_shared_manager()
             m_manager->add_synchronization(demangle<Type>(), m_instance_id,
                                            std::move(_sync));
         }
+
         m_manager->add_finalizer(demangle<Type>(), std::move(_cleanup),
-                                 std::move(_finalize), _is_master);
+                                 std::move(_finalize), _is_master,
+                                 trait::fini_priority<Type>::value);
     }
 }
 //
@@ -1284,7 +1286,8 @@ storage<Type, false>::get_shared_manager()
         };
 
         m_manager->add_finalizer(demangle<Type>(), std::move(_cleanup),
-                                 std::move(_finalize), _is_master);
+                                 std::move(_finalize), _is_master,
+                                 trait::fini_priority<Type>::value);
     }
 }
 //

--- a/timemory/CMakeLists.txt
+++ b/timemory/CMakeLists.txt
@@ -138,6 +138,8 @@ if(SKBUILD)
 endif()
 
 function(TIMEMORY_PYTHON_CONSOLE_SCRIPT SCRIPT_NAME SCRIPT_SUBMODULE SCRIPT_FUNCTION)
+    set(CONSOLE_EXTRA "${ARGN}")
+
     configure_file(${PROJECT_SOURCE_DIR}/cmake/Templates/console-script.py.in
         ${PROJECT_BINARY_DIR}/bin/${SCRIPT_NAME} @ONLY)
 
@@ -149,7 +151,8 @@ function(TIMEMORY_PYTHON_CONSOLE_SCRIPT SCRIPT_NAME SCRIPT_SUBMODULE SCRIPT_FUNC
 endfunction()
 
 timemory_python_console_script("timemory-plotter" "timemory.plotting" "try_plot")
-timemory_python_console_script("timemory-roofline" "timemory.roofline" "try_plot")
+timemory_python_console_script("timemory-roofline" "timemory.roofline" "try_plot"
+	"import os\n    os.environ[\"TIMEMORY_CXX_PLOT_MODE\"] = \"ON\"")
 timemory_python_console_script("timemory-analyze" "timemory.analyze" "try_analyze")
 
 timemory_python_console_script("timemory-python-profiler" "timemory.profiler" "main")

--- a/timemory/__init__.py.in
+++ b/timemory/__init__.py.in
@@ -40,6 +40,7 @@ import os
 
 os.environ.setdefault("TIMEMORY_BANNER", "OFF")
 os.environ.setdefault("PROFILESELECTED", "1")
+
 """
 Setting PROFILESELECTED=1 attempts to ensure that when gperftools is linked,
 cpu profiler, heap checker, and heap profiler lie dormant until activated.
@@ -242,19 +243,43 @@ else:
 
         args = sys.argv[:]
         try:
+            # when executing something like "python -m timemory.{profiler,trace,etc.} ..."
+            # or the scripts "timemory-{python-profiler,plotter,etc.} ..." or a help
+            # flag is in the arguments, disable initialization by default to avoid
+            # creating a directory like "timemory-cpu-clock-output" for commands like
+            # "python -m timemory.trace -c cpu_clock -- <cmd>" and disable finalization
+            # via the atexit since these scripts should call finalize themselves.
+            if len(args) > 0 and (
+                args[0] == "-m"
+                or os.path.basename(args[0]).startswith("timemory-")
+                or "-h" in args
+                or "--help" in args
+                or "-?" in args
+            ):
+                os.environ.setdefault("TIMEMORY_LIBRARY_CTOR", "0")
+                os.environ.setdefault("TIMEMORY_LIBRARY_DTOR", "0")
+
+            # if "--" is present, discard everything before the "--"
+            if len(args) > 0 and "--" in args:
+                idx = args.index("--")
+                args = args[(idx + 1) :]
+
             while len(args) > 0 and len(args[0]) > 0 and args[0][0] == "-":
                 args.pop(0)
+
         except Exception:
-            args = []
-            pass
+            args = ["python"]
 
         if len(args) == 0:
             args.append("python")
 
-        if os.environ.get("TIMEMORY_LIBRARY_CTOR", True):
+        def str2bool(v):
+            return v.lower() in ("yes", "y", "true", "t", "1", "on")
+
+        if str2bool(os.environ.get("TIMEMORY_LIBRARY_CTOR", "yes")):
             initialize(args)
 
-        if os.environ.get("TIMEMORY_LIBRARY_DTOR", True):
+        if str2bool(os.environ.get("TIMEMORY_LIBRARY_DTOR", "yes")):
             import atexit
 
             atexit.register(finalize)

--- a/timemory/__init__.py.in
+++ b/timemory/__init__.py.in
@@ -76,6 +76,10 @@ before BEFORE running Python
 """
 
 
+def __str2bool(v):
+    return v.lower() in ("yes", "y", "true", "t", "1", "on")
+
+
 def __load_component_libs():
     """Loads the timemory library"""
     relative_lib_path = "@LIB_RELPATH@"
@@ -113,7 +117,10 @@ except ImportError:
     import pickle
 
 
-if os.environ.get("TIMEMORY_CXX_PLOT_MODE", None) is not None:
+_no_bindings = __str2bool(
+    os.environ.get("TIMEMORY_CXX_PLOT_MODE", "0")
+) or not __str2bool(os.environ.get("TIMEMORY_PYTHON_BINDINGS", "1"))
+if _no_bindings:
 
     from . import mpi_support
     from . import mpi
@@ -272,13 +279,10 @@ else:
         if len(args) == 0:
             args.append("python")
 
-        def str2bool(v):
-            return v.lower() in ("yes", "y", "true", "t", "1", "on")
-
-        if str2bool(os.environ.get("TIMEMORY_LIBRARY_CTOR", "yes")):
+        if __str2bool(os.environ.get("TIMEMORY_LIBRARY_CTOR", "yes")):
             initialize(args)
 
-        if str2bool(os.environ.get("TIMEMORY_LIBRARY_DTOR", "yes")):
+        if __str2bool(os.environ.get("TIMEMORY_LIBRARY_DTOR", "yes")):
             import atexit
 
             atexit.register(finalize)

--- a/timemory/__init__.py.in
+++ b/timemory/__init__.py.in
@@ -257,7 +257,6 @@ else:
                 or "-?" in args
             ):
                 os.environ.setdefault("TIMEMORY_LIBRARY_CTOR", "0")
-                os.environ.setdefault("TIMEMORY_LIBRARY_DTOR", "0")
 
             # if "--" is present, discard everything before the "--"
             if len(args) > 0 and "--" in args:

--- a/timemory/analyze/__init__.py
+++ b/timemory/analyze/__init__.py
@@ -41,6 +41,15 @@ __maintainer__ = "Jonathan Madsen"
 __email__ = "jrmadsen@lbl.gov"
 __status__ = "Development"
 
+rank = 0
+try:
+    import mpi4py
+    from mpi4py import MPI
+
+    rank = MPI.COMM_WORLD.Get_rank()
+except ImportError:
+    pass
+
 from .analyze import (
     load,
     match,
@@ -60,8 +69,12 @@ def embedded_analyze(
     data=[],
     call_exit=False,
     verbose=os.environ.get("TIMEMORY_VERBOSE", 0),
+    ranks=[0],
 ):
     """This is intended to be called from the embedded python interpreter"""
+    if len(ranks) > 0 and rank not in ranks:
+        return
+
     call_exit = False
     cmd_line = False
     if args is None:

--- a/timemory/analyze/analyze.py
+++ b/timemory/analyze/analyze.py
@@ -406,7 +406,7 @@ def dump_flamegraph(data, metric, file=None, echo_dart=False):
                         os.path.basename(itr), itr, format="string", type="text"
                     )
             else:
-                (outs, errs) = popen(
+                (retc, outs, errs) = popen(
                     [
                         flamegrapher,
                         "--hash",

--- a/timemory/api/gperftools/__main__.py
+++ b/timemory/api/gperftools/__main__.py
@@ -214,15 +214,8 @@ if __name__ == "__main__":
         _separator = "--"
 
         for _arg in sys.argv[1:]:
-            if _arg == _separator:
+            if _arg == _separator and _i < len(_argsets):
                 _i += 1
-                if _i >= len(_argsets):
-                    sys.exit(
-                        'ERROR: Too many "{}" separators provided '
-                        "(expected at most {}).".format(
-                            _separator, len(_argsets) - 1
-                        )
-                    )
             else:
                 _argsets[_i].append(_arg)
 

--- a/timemory/common.py
+++ b/timemory/common.py
@@ -196,6 +196,7 @@ def popen(cmd, outf=None, keep_going=True, timeout=None, shell=False):
     p = None
     outs = None
     errs = None
+    retc = 0
     if shell:
         p = sp.run(
             " ".join(cmd),
@@ -213,13 +214,14 @@ def popen(cmd, outf=None, keep_going=True, timeout=None, shell=False):
         except sp.TimeoutExpired:
             p.kill()
 
-    if p.returncode != 0:
+    retc = p.returncode
+    if retc != 0:
         if errs is not None:
             print("{}".format(errs.decode("utf-8")))
         elif p.stderr is not None:
             print("{}".format(p.stderr.decode("utf-8")))
 
-    handle_error(p.returncode, cmd, keep_going)
+    handle_error(retc, cmd, keep_going)
 
     if outf is not None:
         with open(outf, "w") as f:
@@ -234,7 +236,7 @@ def popen(cmd, outf=None, keep_going=True, timeout=None, shell=False):
     if errs is None and p.stderr is not None:
         errs = "{}".format(p.stderr.decode("utf-8"))
 
-    return (outs, errs)
+    return (retc, outs, errs)
 
 
 def dart_measurement(name, value):

--- a/timemory/profiler/__main__.py
+++ b/timemory/profiler/__main__.py
@@ -176,28 +176,28 @@ def parse_args(args=None):
     parser.add_argument(
         "--skip-funcs",
         type=str,
-        nargs="?",
+        nargs="+",
         default=_profiler_config.skip_functions,
         help="Filter out any entries with these function names",
     )
     parser.add_argument(
         "--skip-files",
         type=str,
-        nargs="?",
+        nargs="+",
         default=_profiler_config.skip_filenames,
         help="Filter out any entries from these files",
     )
     parser.add_argument(
         "--only-funcs",
         type=str,
-        nargs="?",
+        nargs="+",
         default=_profiler_config.only_functions,
         help="Select only entries with these function names",
     )
     parser.add_argument(
         "--only-files",
         type=str,
-        nargs="?",
+        nargs="+",
         default=_profiler_config.only_filenames,
         help="Select only entries from these files",
     )

--- a/timemory/profiler/__main__.py
+++ b/timemory/profiler/__main__.py
@@ -259,7 +259,17 @@ def main():
         opts, argv = parse_args(sys.argv[:_idx])
         argv = _argv
     else:
-        opts, argv = parse_args()
+        if "-h" in sys.argv or "--help" in sys.argv:
+            opts, argv = parse_args()
+        else:
+            argv = sys.argv[1:]
+            opts, discard = parse_args()
+            if len(argv) == 0 or not os.path.isfile(argv[0]):
+                raise RuntimeError(
+                    "Could not determine input script. Use '--' before "
+                    "the script and its arguments to ensure correct parsing. \nE.g. "
+                    "python -m timemory.profiler -- ./script.py"
+                )
 
     from ..libpytimemory import initialize
     from ..libpytimemory import settings

--- a/timemory/profiler/profiler.py
+++ b/timemory/profiler/profiler.py
@@ -128,6 +128,7 @@ class Profiler:
         self.components = list(dict.fromkeys(self.components))
         if len(self.components) == 0:
             self.components += ["wall_clock"]
+        self.components.remove("")
         if _profl is None:
             settings.profiler_components = ",".join(self.components)
         settings.profiler_components = ",".join(self.components)
@@ -146,6 +147,12 @@ class Profiler:
         """Initialize, configure the bundle, store original profiler function"""
 
         _profiler_init()
+        if settings.debug:
+            print(
+                "configuring Profiler with components: {}".format(
+                    self.components
+                )
+            )
         _profiler_bundle.configure(
             self.components, self._flat_profile, self._timeline_profile
         )

--- a/timemory/roofline/__main__.py
+++ b/timemory/roofline/__main__.py
@@ -37,10 +37,6 @@ import warnings
 import traceback
 import multiprocessing as mp
 
-import timemory
-import timemory.roofline as _roofline
-
-
 # error code
 _errc = 0
 
@@ -287,6 +283,8 @@ def plot_impl(args, ai_data, op_data, rank=None, label=None):
         fname = "{}_{}".format(fname, rank)
         title = "{} (MPI rank: {})".format(args.title, rank)
 
+    import timemory.roofline as _roofline
+
     _roofline.plot_roofline(
         ai_data,
         op_data,
@@ -462,6 +460,8 @@ def try_plot():
         args = parse_args(len(_cmd) != 0)
         run(args, _cmd)
         if args.verbose is not None:
+            import timemory.roofline as _roofline
+
             _roofline.VERBOSE = args.verbose
         plot(args)
 

--- a/timemory/roofline/__main__.py
+++ b/timemory/roofline/__main__.py
@@ -311,6 +311,8 @@ def run(args, cmd):
     if len(cmd) == 0:
         return
 
+    os.environ["TIMEMORY_PYTHON_BINDINGS"] = "0"
+
     def get_environ(env_var, default_value, dtype):
         val = os.environ.get(env_var)
         if val is None:
@@ -443,15 +445,8 @@ def try_plot():
         _separator = "--"
 
         for _arg in sys.argv[1:]:
-            if _arg == _separator:
+            if _arg == _separator and _i < len(_argsets):
                 _i += 1
-                if _i >= len(_argsets):
-                    sys.exit(
-                        'ERROR: Too many "{}" separators provided '
-                        "(expected at most {}).".format(
-                            _separator, len(_argsets) - 1
-                        )
-                    )
             else:
                 _argsets[_i].append(_arg)
 

--- a/timemory/test/test_hatchet.py
+++ b/timemory/test/test_hatchet.py
@@ -35,9 +35,12 @@ __maintainer__ = "Jonathan Madsen"
 __email__ = "jrmadsen@lbl.gov"
 __status__ = "Development"
 
+rank = 0
 try:
     import mpi4py
     from mpi4py import MPI
+
+    rank = MPI.COMM_WORLD.Get_rank()
 except ImportError:
     pass
 
@@ -64,6 +67,7 @@ def fibonacci(n, with_arg=True):
         "fib({})".format(n) if with_arg else "",
         mode=mode,
     ):
+        arr = np.ones([100, 100], dtype=float)
         return (
             n
             if n < 2
@@ -117,9 +121,10 @@ class TimemoryHatchetTests(unittest.TestCase):
         data = tim.get(hierarchy=True, components=["wall_clock"])
         gf = ht.GraphFrame.from_timemory(data)
 
-        print(gf.dataframe)
-        print(gf.tree("sum"))
-        print(gf.tree("sum.inc"))
+        if rank == 0:
+            print(gf.dataframe)
+            print(gf.tree("sum"))
+            print(gf.tree("sum.inc"))
 
     # ---------------------------------------------------------------------------------- #
     # test handling multi-dimensional data from hatchet
@@ -136,9 +141,10 @@ class TimemoryHatchetTests(unittest.TestCase):
         data = tim.get(hierarchy=True, components=[CurrentPeakRss.id()])
         gf = ht.GraphFrame.from_timemory(data)
 
-        print(gf.dataframe)
-        print(gf.tree("sum.start-peak-rss"))
-        print(gf.tree("sum.stop-peak-rss.inc"))
+        if rank == 0:
+            print(gf.dataframe)
+            print(gf.tree("sum.start-peak-rss"))
+            print(gf.tree("sum.stop-peak-rss.inc"))
 
         self.assertTrue(gf.tree("sum.start-peak-rss.inc") is not None)
         self.assertTrue(gf.tree("sum.stop-peak-rss") is not None)
@@ -167,7 +173,8 @@ class TimemoryHatchetTests(unittest.TestCase):
             ).split()
         )
 
-        print(f"arguments: {args}")
+        if rank == 0:
+            print(f"arguments: {args}")
 
         embedded_analyze(
             args,

--- a/timemory/trace/__main__.py
+++ b/timemory/trace/__main__.py
@@ -161,28 +161,28 @@ def parse_args(args=None):
     parser.add_argument(
         "--skip-funcs",
         type=str,
-        nargs="?",
+        nargs="+",
         default=_tracer_config.skip_functions,
         help="Filter out any entries with these function names",
     )
     parser.add_argument(
         "--skip-files",
         type=str,
-        nargs="?",
+        nargs="+",
         default=_tracer_config.skip_filenames,
         help="Filter out any entries from these files",
     )
     parser.add_argument(
         "--only-funcs",
         type=str,
-        nargs="?",
+        nargs="+",
         default=_tracer_config.only_functions,
         help="Select only entries with these function names",
     )
     parser.add_argument(
         "--only-files",
         type=str,
-        nargs="?",
+        nargs="+",
         default=_tracer_config.only_filenames,
         help="Select only entries from these files",
     )

--- a/timemory/trace/__main__.py
+++ b/timemory/trace/__main__.py
@@ -244,7 +244,17 @@ def main():
         opts, argv = parse_args(sys.argv[:_idx])
         argv = _argv
     else:
-        opts, argv = parse_args()
+        if "-h" in sys.argv or "--help" in sys.argv:
+            opts, argv = parse_args()
+        else:
+            argv = sys.argv[1:]
+            opts, discard = parse_args()
+            if len(argv) == 0 or not os.path.isfile(argv[0]):
+                raise RuntimeError(
+                    "Could not determine input script. Use '--' before "
+                    "the script and its arguments to ensure correct parsing. \nE.g. "
+                    "python -m timemory.trace -- ./script.py"
+                )
 
     from ..libpytimemory import initialize
     from ..libpytimemory import settings

--- a/timemory/trace/tracer.py
+++ b/timemory/trace/tracer.py
@@ -240,7 +240,6 @@ class Tracer:
     def runctx(self, cmd, _globals, _locals):
         """Trace a context"""
 
-        print("cmd: {}".format(cmd))
         try:
             self.start()
             exec_(cmd, _globals, _locals)

--- a/timemory/trace/tracer.py
+++ b/timemory/trace/tracer.py
@@ -121,6 +121,7 @@ class Tracer:
         self.components = list(dict.fromkeys(self.components))
         if len(self.components) == 0:
             self.components += ["wall_clock"]
+        self.components.remove("")
         if _trace is None:
             settings.trace_components = ",".join(self.components)
         settings.trace_components = ",".join(self.components)
@@ -139,6 +140,10 @@ class Tracer:
         """Initialize, configure the bundle, store original tracer function"""
 
         _tracer_init()
+        if settings.debug:
+            print(
+                "configuring Tracer with components: {}".format(self.components)
+            )
         _tracer_bundle.configure(self.components, True, False)
         self._original_function = sys.gettrace()
 


### PR DESCRIPTION
- `TIMEMORY_CODE` macro
  - This can wrap any C/C++ code, e.g.
- Bug fix to `static_properties::matches(...)`
  -  `thread_cpu_clock` fields were activating `cpu_clock` components
- introducing `trait::fini_priority<T>` for ordering the finalization of components
- Bug fix in `operation::fini<T>` which sometimes re-initialized storage after finalization
- Improved finalization of compiler instrumentation
- Bug fixes to python profiler and trace
  - configure args weren't parsed properly
  - fix for when `--` is not provided
- Updated hatchet submodule