### PR TITLE
fortran module + timemory-run path resolution

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -80,12 +80,14 @@ jobs:
           packages:
             - gcc-6
             - g++-6
+            - gfortran-6
             - build-essential
             - libtbb-dev
             - ccache
       env:
         - CC=gcc-6
         - CXX=g++-6
+        - FC=gfortran-6
         - BUILD_TYPE=RelWithDebInfo
         - BUILD_ARGS='--minimal --build-libs shared --python --stats --cxx-standard=14'
         - CONFIG_ARGS='-DTIMEMORY_CCACHE_BUILD=ON'
@@ -100,6 +102,7 @@ jobs:
           packages:
             - gcc-7
             - g++-7
+            - gfortran-7
             - build-essential
             - libmpich-dev
             - mpich
@@ -109,6 +112,7 @@ jobs:
       env:
         - CC=gcc-7
         - CXX=g++-7
+        - FC=gfortran-7
         - BUILD_ARGS='--minimal --build-libs shared --mpi --papi --gotcha --tools mpip --stats --cxx-standard=17 --coverage'
     #
     # GCC 8
@@ -122,6 +126,7 @@ jobs:
           packages:
             - gcc-8
             - g++-8
+            - gfortran-8
             - build-essential
             - libopenmpi-dev
             - openmpi-bin
@@ -131,6 +136,7 @@ jobs:
       env:
         - CC=gcc-8
         - CXX=g++-8
+        - FC=gfortran-8
         - BUILD_TYPE=RelWithDebInfo
         - BUILD_ARGS='--minimal --build-libs shared --mpi --stats --tools compiler --cxx-standard=17'
         - CONFIG_ARGS='-DTIMEMORY_CCACHE_BUILD=ON'

--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -29,6 +29,23 @@ include("${CMAKE_CURRENT_LIST_DIR}/cmake/Modules/ProjectSetup.cmake")
 
 project(timemory LANGUAGES C CXX VERSION ${TIMEMORY_VERSION})
 
+cmake_policy(SET CMP0010 NEW)
+cmake_policy(SET CMP0022 NEW)
+cmake_policy(SET CMP0048 NEW)
+cmake_policy(SET CMP0042 NEW)
+cmake_policy(SET CMP0053 NEW)
+cmake_policy(SET CMP0063 NEW)
+if(NOT CMAKE_VERSION VERSION_LESS 3.13)
+    cmake_policy(SET CMP0077 NEW)
+    cmake_policy(SET CMP0079 NEW)
+endif()
+if(NOT CMAKE_VERSION VERSION_LESS 3.14)
+    cmake_policy(SET CMP0082 NEW)
+endif()
+if(NOT CMAKE_VERSION VERSION_LESS 3.18)
+    cmake_policy(SET CMP0104 OLD)
+endif()
+
 # Check if project is being used directly or via add_subdirectory
 set(${PROJECT_NAME}_MAIN_PROJECT ON)
 if(NOT CMAKE_CURRENT_SOURCE_DIR STREQUAL CMAKE_SOURCE_DIR OR

--- a/cmake/Modules/ProjectSetup.cmake
+++ b/cmake/Modules/ProjectSetup.cmake
@@ -20,27 +20,6 @@ if(TIMEMORY_CCACHE_BUILD)
 endif()
 
 #----------------------------------------------------------------------------------------#
-#   policies
-#----------------------------------------------------------------------------------------#
-
-cmake_policy(SET CMP0010 NEW)
-cmake_policy(SET CMP0022 NEW)
-cmake_policy(SET CMP0048 NEW)
-cmake_policy(SET CMP0042 NEW)
-cmake_policy(SET CMP0053 NEW)
-cmake_policy(SET CMP0063 NEW)
-if(NOT CMAKE_VERSION VERSION_LESS 3.13)
-    cmake_policy(SET CMP0077 NEW)
-    cmake_policy(SET CMP0079 NEW)
-endif()
-if(NOT CMAKE_VERSION VERSION_LESS 3.14)
-    cmake_policy(SET CMP0082 NEW)
-endif()
-if(NOT CMAKE_VERSION VERSION_LESS 3.18)
-    cmake_policy(SET CMP0104 OLD)
-endif()
-
-#----------------------------------------------------------------------------------------#
 #   options
 #----------------------------------------------------------------------------------------#
 

--- a/examples/CMakeLists.txt
+++ b/examples/CMakeLists.txt
@@ -35,6 +35,7 @@ option(TIMEMORY_BUILD_C_EXAMPLES "Enable building these examples" ${DEFAULT_CHOI
 option(TIMEMORY_BUILD_TPL_EXAMPLES "Enable building these examples" ${DEFAULT_CHOICE})
 option(TIMEMORY_BUILD_CUDA_EXAMPLES "Enable building these examples" ${DEFAULT_CHOICE})
 option(TIMEMORY_BUILD_PYTHON_EXAMPLES "Enable building these examples" ${DEFAULT_CHOICE})
+option(TIMEMORY_BUILD_FORTRAN_EXAMPLES "Enable building these examples" ${DEFAULT_CHOICE})
 option(TIMEMORY_BUILD_ROOFLINE_EXAMPLES "Enable building these examples" ${DEFAULT_CHOICE})
 option(TIMEMORY_BUILD_DYNAMIC_INSTRUMENT_EXAMPLES "Enable building these examples" ${DEFAULT_CHOICE})
 option(TIMEMORY_BUILD_COMPILER_INSTRUMENT_EXAMPLES "Enable building these examples" ${DEFAULT_CHOICE})
@@ -42,6 +43,10 @@ option(TIMEMORY_BUILD_COMPILER_INSTRUMENT_EXAMPLES "Enable building these exampl
 # C language related
 if(TIMEMORY_BUILD_C_EXAMPLES)
     add_subdirectory(ex-c)
+endif()
+
+if(TIMEMORY_BUILD_FORTRAN_EXAMPLES)
+    add_subdirectory(ex-fortran)
 endif()
 
 # external package related

--- a/examples/ex-fortran/CMakeLists.txt
+++ b/examples/ex-fortran/CMakeLists.txt
@@ -1,0 +1,18 @@
+cmake_minimum_required(VERSION 3.15 FATAL_ERROR)
+
+# this is for internal use
+if("${CMAKE_PROJECT_NAME}" STREQUAL "timemory" AND NOT TIMEMORY_BUILD_FORTRAN)
+    return()
+endif()
+
+project(timemory-Fortran-Example LANGUAGES Fortran)
+
+set(EXE_NAME ex_fortran_timing)
+set(CMAKE_INTERPROCEDURAL_OPTIMIZATION OFF)
+
+set(timemory_FIND_COMPONENTS_INTERFACE timemory::fortran-example)
+find_package(timemory REQUIRED COMPONENTS fortran)
+
+add_executable(${EXE_NAME} ${EXE_NAME}.f90)
+target_link_libraries(${EXE_NAME} timemory::fortran-example)
+install(TARGETS ${EXE_NAME} DESTINATION bin OPTIONAL)

--- a/examples/ex-fortran/README.md
+++ b/examples/ex-fortran/README.md
@@ -1,0 +1,69 @@
+# ex-fortran
+
+This example demonstrates the use of timemory fortran API
+
+## Build
+
+See [examples](../README.md##Build). This examples requires an additional `-DTIMEMORY_BUILD_FORTRAN=ON` flag to be built.
+
+## Expected Output
+
+```console
+$ ./ex_fortran_timing
+[cpu]|0> Outputting 'timemory-ex-fortran-output/cpu.flamegraph.json'...
+[cpu]|0> Outputting 'timemory-ex-fortran-output/cpu.json'...
+[cpu]|0> Outputting 'timemory-ex-fortran-output/cpu.tree.json'...
+[cpu]|0> Outputting 'timemory-ex-fortran-output/cpu.txt'...
+
+|---------------------------------------------------------------------------------------------------------|
+|                            TOTAL CPU TIME SPENT IN BOTH USER- AND KERNEL-MODE                           |
+|---------------------------------------------------------------------------------------------------------|
+|    LABEL      | COUNT  | DEPTH  | METRIC | UNITS  |  SUM   | MEAN   |  MIN   |  MAX   | STDDEV | % SELF |
+|---------------|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|
+| >>> main      |      1 |      0 | cpu    | sec    |  0.010 |  0.010 |  0.010 |  0.010 |  0.000 |  100.0 |
+| >>> |_inner   |      1 |      1 | cpu    | sec    |  0.000 |  0.000 |  0.000 |  0.000 |  0.000 |    0.0 |
+| >>> |_indexed |      1 |      1 | cpu    | sec    |  0.000 |  0.000 |  0.000 |  0.000 |  0.000 |    0.0 |
+|---------------------------------------------------------------------------------------------------------|
+
+[wall]|0> Outputting 'timemory-ex-fortran-output/wall.flamegraph.json'...
+[wall]|0> Outputting 'timemory-ex-fortran-output/wall.json'...
+[wall]|0> Outputting 'timemory-ex-fortran-output/wall.tree.json'...
+[wall]|0> Outputting 'timemory-ex-fortran-output/wall.txt'...
+
+|---------------------------------------------------------------------------------------------------------|
+|                                 REAL-CLOCK TIMER (I.E. WALL-CLOCK TIMER)                                |
+|---------------------------------------------------------------------------------------------------------|
+|    LABEL      | COUNT  | DEPTH  | METRIC | UNITS  |  SUM   | MEAN   |  MIN   |  MAX   | STDDEV | % SELF |
+|---------------|--------|--------|--------|--------|--------|--------|--------|--------|--------|--------|
+| >>> main      |      1 |      0 | wall   | sec    |  0.001 |  0.001 |  0.001 |  0.001 |  0.000 |   66.6 |
+| >>> |_inner   |      1 |      1 | wall   | sec    |  0.000 |  0.000 |  0.000 |  0.000 |  0.000 |  100.0 |
+| >>> |_indexed |      1 |      1 | wall   | sec    |  0.000 |  0.000 |  0.000 |  0.000 |  0.000 |  100.0 |
+|---------------------------------------------------------------------------------------------------------|
+
+[peak_rss]|0> Outputting 'timemory-ex-fortran-output/peak_rss.json'...
+[peak_rss]|0> Outputting 'timemory-ex-fortran-output/peak_rss.tree.json'...
+[peak_rss]|0> Outputting 'timemory-ex-fortran-output/peak_rss.txt'...
+
+|-------------------------------------------------------------------------------------------------------|
+|   MEASURES CHANGES IN THE HIGH-WATER MARK FOR THE AMOUNT OF MEMORY ALLOCATED IN RAM. MAY FLUCTUATE IF |
+|                                             SWAP IS ENABLED                                           |
+|-------------------------------------------------------------------------------------------------------|
+|  LABEL    | COUNT  | DEPTH  | METRIC   | UNITS  |  SUM   | MEAN   |  MIN   |  MAX   | STDDEV | % SELF |
+|-----------|--------|--------|----------|--------|--------|--------|--------|--------|--------|--------|
+| >>> inner |      1 |      0 | peak_rss | MB     |  0.000 |  0.000 |  0.000 |  0.000 |  0.000 |    0.0 |
+|-------------------------------------------------------------------------------------------------------|
+
+[page_rss]|0> Outputting 'timemory-ex-fortran-output/page_rss.json'...
+[page_rss]|0> Outputting 'timemory-ex-fortran-output/page_rss.tree.json'...
+[page_rss]|0> Outputting 'timemory-ex-fortran-output/page_rss.txt'...
+
+|----------------------------------------------------------------------------------------------------------------|
+|        AMOUNT OF MEMORY ALLOCATED IN PAGES OF MEMORY. UNLIKE PEAK_RSS, VALUE WILL FLUCTUATE AS MEMORY IS       |
+|                                                 FREED/ALLOCATED                                                |
+|----------------------------------------------------------------------------------------------------------------|
+|       LABEL        | COUNT  | DEPTH  | METRIC   | UNITS  |  SUM   | MEAN   |  MIN   |  MAX   | STDDEV | % SELF |
+|--------------------|--------|--------|----------|--------|--------|--------|--------|--------|--------|--------|
+| >>> inner (pushed) |      1 |      0 | page_rss | MB     |  0.004 |  0.004 |  0.004 |  0.004 |  0.000 |  100.0 |
+|----------------------------------------------------------------------------------------------------------------|
+
+```

--- a/examples/ex-fortran/ex_fortran_timing.f90
+++ b/examples/ex-fortran/ex_fortran_timing.f90
@@ -1,0 +1,56 @@
+
+program fortran_example
+    use timemory
+    use iso_c_binding, only : C_INT64_T
+    implicit none
+    integer(C_INT64_T) :: idx
+
+    ! initialize with explicit name
+    call timemory_init_library("ex-fortran")
+
+    ! initialize with name extracted from get_command_argument(0, ...)
+    ! call timemory_init_library("")
+
+    ! define the default set of components
+    call timemory_set_default("wall_clock, cpu_clock")
+
+    ! Start region "main"
+    call timemory_push_region("main")
+
+    ! Add peak_rss to the current set of components
+    call timemory_add_components("peak_rss")
+
+    ! Nested region "inner" nested under "main"
+    call timemory_push_region("inner")
+
+    ! End the "inner" region
+    call timemory_pop_region("inner")
+
+    ! remove peak_rss
+    call timemory_remove_components("peak_rss")
+
+    ! begin a region and get an identifier
+    idx = timemory_get_begin_record("indexed")
+
+    ! replace current set of components
+    call timemory_push_components("page_rss")
+
+    ! Nested region "inner" with only page_rss components
+    call timemory_push_region("inner (pushed)")
+
+    ! Stop "inner" region with only page_rss components
+    call timemory_pop_region("inner (pushed)")
+
+    ! restore previous set of components
+    call timemory_pop_components()
+
+    ! end the "indexed" region
+    call timemory_end_record(idx)
+
+    ! End "main"
+    call timemory_pop_region("main")
+
+    ! Output the results
+    call timemory_finalize_library()
+
+end program fortran_example

--- a/source/CMakeLists.txt
+++ b/source/CMakeLists.txt
@@ -31,6 +31,7 @@ file(GLOB compat_headers            ${CMAKE_CURRENT_LIST_DIR}/timemory/compat/*.
                                     ${CMAKE_CURRENT_LIST_DIR}/timemory/compat/*.hpp)
 file(GLOB c_sources                 ${CMAKE_CURRENT_LIST_DIR}/*.c)
 file(GLOB cxx_sources               ${CMAKE_CURRENT_LIST_DIR}/*.cpp)
+file(GLOB fortran_sources           ${CMAKE_CURRENT_LIST_DIR}/*.f90)
 file(GLOB_RECURSE tpl_headers       ${CMAKE_CURRENT_LIST_DIR}/timemory/tpls/*.hpp
                                     ${CMAKE_CURRENT_LIST_DIR}/timemory/tpls/*.h)
 file(GLOB_RECURSE tpl_licenses      ${CMAKE_CURRENT_LIST_DIR}/timemory/tpls/*license*)
@@ -66,8 +67,9 @@ file(GLOB pysources ${CMAKE_CURRENT_LIST_DIR}/python/*.cpp)
 # build library setup
 #
 # directly compile sources
-set(C_LIBRARY_SOURCES       ${c_sources}   ${c_headers})
-set(CXX_LIBRARY_SOURCES     ${cxx_sources} ${timemory_glob_headers})
+set(C_LIBRARY_SOURCES       ${c_sources}        ${c_headers})
+set(CXX_LIBRARY_SOURCES     ${cxx_sources}      ${timemory_glob_headers})
+set(Fortran_LIBRARY_SOURCES ${fortran_sources}  ${fortran_headers})
 
 #----------------------------------------------------------------------------------------#
 # build the C++ libraries
@@ -293,6 +295,71 @@ if(TIMEMORY_BUILD_C)
     endif()
 endif()
 
+
+#----------------------------------------------------------------------------------------#
+#
+#                       EXTERN C libraries
+#
+#----------------------------------------------------------------------------------------#
+
+if(TIMEMORY_BUILD_FORTRAN)
+
+    if(_BUILD_SHARED_CXX)
+        build_library(
+            PIC
+            TYPE                SHARED
+            TARGET_NAME         timemory-fortran-shared
+            OUTPUT_NAME         ftimemory
+            LANGUAGE            Fortran
+            LINKER_LANGUAGE     ${_LINKER_LANGUAGE}
+            OUTPUT_DIR          ${PROJECT_BINARY_DIR}
+            SOURCES             ${Fortran_LIBRARY_SOURCES}
+            LINK_LIBRARIES      timemory-external-shared
+                                PRIVATE
+                                    timemory-compile-options
+                                    timemory-develop-options
+                                    timemory-analysis-tools
+                                    timemory-cxx-shared)
+
+        set_target_properties(timemory-fortran-shared PROPERTIES
+            INTERPROCEDURAL_OPTIMIZATION OFF)
+
+        if(WIN32)
+            target_compile_definitions(timemory-fortran-shared
+                PRIVATE     TIMEMORY_CDLL_EXPORT
+                INTERFACE   TIMEMORY_CDLL_IMPORT)
+        endif()
+    endif()
+
+    if(_BUILD_STATIC_CXX)
+
+        build_library(
+            TYPE                STATIC
+            TARGET_NAME         timemory-fortran-static
+            OUTPUT_NAME         ftimemory
+            LANGUAGE            Fortran
+            LINKER_LANGUAGE     ${_LINKER_LANGUAGE}
+            OUTPUT_DIR          ${PROJECT_BINARY_DIR}
+            SOURCES             ${Fortran_LIBRARY_SOURCES}
+            LINK_LIBRARIES      timemory-external-static
+                                PRIVATE
+                                    timemory-compile-options
+                                    timemory-develop-options
+                                    timemory-analysis-tools
+                                    timemory-cxx-static)
+
+        target_include_directories(timemory-fortran-static PUBLIC
+            $<BUILD_INTERFACE:${CMAKE_CURRENT_LIST_DIR}>
+            $<INSTALL_INTERFACE:${CMAKE_INSTALL_PREFIX}/${CMAKE_INSTALL_INCLUDEDIR}>)
+
+        set_target_properties(timemory-fortran-static PROPERTIES
+            INTERPROCEDURAL_OPTIMIZATION OFF)
+    endif()
+
+    if(WIN32 AND _BUILD_SHARED_CXX AND _BUILD_STATIC_CXX)
+        add_dependencies(timemory-fortran-shared timemory-fortran-static)
+    endif()
+endif()
 
 #----------------------------------------------------------------------------------------#
 #

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -951,15 +951,20 @@ if(TIMEMORY_USE_DYNINST AND TIMEMORY_BUILD_GOOGLE_TEST AND NOT TIMEMORY_USE_COVE
         "binary-rewrite-stubs")
 
     foreach(_TARGET ${_DYNAMIC_TARGETS})
-        set(COMMAND
-            ${CMAKE_CURRENT_BINARY_DIR}/${_TARGET})
-
         foreach(_FILE ${_scripts})
             # do not run launch-process + timemory
             if("${_TARGET}" STREQUAL "dynamic_instrument_timemory_tests" AND
                "${_FILE}" IN_LIST _SKIP_DYNAMIC_WITH_TIMEMORY)
                 continue()
             endif()
+
+            # set the relative or absolute path
+            if("${_FILE}" STREQUAL "launch-process")
+                set(COMMAND ${_TARGET})
+            else()
+                set(COMMAND ${CMAKE_CURRENT_BINARY_DIR}/${_TARGET})
+            endif()
+
             set(TEST_NAME ${_TARGET}-${_FILE})
             configure_file(
                 ${CMAKE_CURRENT_LIST_DIR}/scripts/${_FILE}.sh.in

--- a/source/tests/mangle_tests.cpp
+++ b/source/tests/mangle_tests.cpp
@@ -84,23 +84,8 @@ TEST_F(mangle_tests, sample)
         "S4_S4_S4_S4_S4_PKiRKNS_6Array4IdEESA_SA_ldRKSt5arrayIdLm3EESC_NS_4Dim3EdlEUllE_"
         "vEEvT_OT0_mEUlvE_EEvSH_";
 
-    using namespace tim::component;
-
-    std::string demangled_name =
-        "void amrex::launch_global<void amrex::For<long, void "
-        "doEsirkepovDepositionShapeN<3>(double const*, double const*, double const*, "
-        "double const*, double const*, double const*, double const*, int const*, "
-        "amrex::Array4<double> const&, amrex::Array4<double> const&, "
-        "amrex::Array4<double> const&, long, double, std::array<double, 3ul> const&, "
-        "std::array<double, 3ul>, amrex::Dim3, double, long)::'lambda'(long), void>(3, "
-        "void doEsirkepovDepositionShapeN<3>(double const*, double const*, double "
-        "const*, double const*, double const*, double const*, double const*, int const*, "
-        "amrex::Array4<double> const&, amrex::Array4<double> const&, "
-        "amrex::Array4<double> const&, long, double, std::array<double, 3ul> const&, "
-        "std::array<double, 3ul>, amrex::Dim3, double, long)::'lambda'(long)&&, unsigned "
-        "long)::'lambda'()>(3)";
-
-    EXPECT_EQ(demangled_name, tim::demangle(function_name))
+    // verify the demangling did not fail
+    EXPECT_NE(function_name, tim::demangle(function_name))
         << details::demangle(function_name);
 }
 
@@ -124,21 +109,8 @@ TEST_F(mangle_tests, cuda_kernel)
         "S4_S4_S4_S4_S4_PKiRKNS_6Array4IdEESA_SA_ldRKSt5arrayIdLm3EESC_NS_4Dim3EdlEUllE_"
         "vEEvT_OT0_mEUlvE_EEvSH_";
 
-    std::string demangled_name =
-        "void amrex::launch_global<void amrex::For<long, void "
-        "doEsirkepovDepositionShapeN<3>(double const*, double const*, double const*, "
-        "double const*, double const*, double const*, double const*, int const*, "
-        "amrex::Array4<double> const&, amrex::Array4<double> const&, "
-        "amrex::Array4<double> const&, long, double, std::array<double, 3ul> const&, "
-        "std::array<double, 3ul>, amrex::Dim3, double, long)::'lambda'(long), void>(3, "
-        "void doEsirkepovDepositionShapeN<3>(double const*, double const*, double "
-        "const*, double const*, double const*, double const*, double const*, int const*, "
-        "amrex::Array4<double> const&, amrex::Array4<double> const&, "
-        "amrex::Array4<double> const&, long, double, std::array<double, 3ul> const&, "
-        "std::array<double, 3ul>, amrex::Dim3, double, long)::'lambda'(long)&&, unsigned "
-        "long)::'lambda'()>(3)";
-
-    EXPECT_EQ(demangled_name, tim::demangle(function_name))
+    // verify the demangling did not fail
+    EXPECT_NE(function_name, tim::demangle(function_name))
         << details::demangle(function_name);
 }
 

--- a/source/tests/scripts/attach-process.sh.in
+++ b/source/tests/scripts/attach-process.sh.in
@@ -18,6 +18,8 @@ export TIMEMORY_FLAMEGRAPH_OUTPUT=OFF
 
 rm -rf ${TIMEMORY_OUTPUT_PATH}
 
+# append directories to path
+export PATH=@CMAKE_CURRENT_BINARY_DIR@:@PROJECT_BINARY_DIR@:${PATH}
 # add path to libtimemory to LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=@PROJECT_BINARY_DIR@:${LD_LIBRARY_PATH}
 

--- a/source/tests/scripts/binary-rewrite-mpip.sh.in
+++ b/source/tests/scripts/binary-rewrite-mpip.sh.in
@@ -19,6 +19,8 @@ rm -rf ${TIMEMORY_OUTPUT_PATH}
 
 export TIMEMORY_OUTPUT_PREFIX="orig"
 
+# append directories to path
+export PATH=@CMAKE_CURRENT_BINARY_DIR@:@PROJECT_BINARY_DIR@:${PATH}
 # add path to libtimemory to LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=@PROJECT_BINARY_DIR@:${LD_LIBRARY_PATH}
 

--- a/source/tests/scripts/binary-rewrite-regex.sh.in
+++ b/source/tests/scripts/binary-rewrite-regex.sh.in
@@ -18,6 +18,8 @@ export TIMEMORY_FLAMEGRAPH_OUTPUT=OFF
 
 rm -rf ${TIMEMORY_OUTPUT_PATH}
 
+# append directories to path
+export PATH=@CMAKE_CURRENT_BINARY_DIR@:@PROJECT_BINARY_DIR@:${PATH}
 # add path to libtimemory to LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=@PROJECT_BINARY_DIR@:${LD_LIBRARY_PATH}
 

--- a/source/tests/scripts/binary-rewrite-stubs.sh.in
+++ b/source/tests/scripts/binary-rewrite-stubs.sh.in
@@ -18,6 +18,8 @@ export TIMEMORY_FLAMEGRAPH_OUTPUT=OFF
 
 rm -rf ${TIMEMORY_OUTPUT_PATH}
 
+# append directories to path
+export PATH=@CMAKE_CURRENT_BINARY_DIR@:@PROJECT_BINARY_DIR@:${PATH}
 # add path to libtimemory to LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=@PROJECT_BINARY_DIR@:${LD_LIBRARY_PATH}
 

--- a/source/tests/scripts/binary-rewrite.sh.in
+++ b/source/tests/scripts/binary-rewrite.sh.in
@@ -18,6 +18,8 @@ export TIMEMORY_FLAMEGRAPH_OUTPUT=OFF
 
 rm -rf ${TIMEMORY_OUTPUT_PATH}
 
+# append directories to path
+export PATH=@CMAKE_CURRENT_BINARY_DIR@:@PROJECT_BINARY_DIR@:${PATH}
 # add path to libtimemory to LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=@PROJECT_BINARY_DIR@:${LD_LIBRARY_PATH}
 

--- a/source/tests/scripts/launch-process.sh.in
+++ b/source/tests/scripts/launch-process.sh.in
@@ -18,13 +18,15 @@ export TIMEMORY_FLAMEGRAPH_OUTPUT=OFF
 
 rm -rf ${TIMEMORY_OUTPUT_PATH}
 
+# append directories to path
+export PATH=@CMAKE_CURRENT_BINARY_DIR@:@PROJECT_BINARY_DIR@:${PATH}
 # add path to libtimemory to LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=@PROJECT_BINARY_DIR@:${LD_LIBRARY_PATH}
 
 emit-separator "Performing runtime instrumentation"
 
 # launch
-@PROJECT_BINARY_DIR@/timemory-run --label args return -v 1 -ME '(^libm|^libc|^libz|^libicu|^liblzma|^libxml|\.c$)' -- @COMMAND@
+timemory-run --label args return -v 1 -ME '(^libm|^libc|^libz|^libicu|^liblzma|^libxml|\.c$)' -- @COMMAND@
 
 emit-separator "Analyzing results in ${TIMEMORY_OUTPUT_PATH}"
 

--- a/source/tests/scripts/region-sync.sh.in
+++ b/source/tests/scripts/region-sync.sh.in
@@ -17,6 +17,8 @@ export TIMEMORY_FLAMEGRAPH_OUTPUT=OFF
 
 rm -rf ${TIMEMORY_OUTPUT_PATH}
 
+# append directories to path
+export PATH=@CMAKE_CURRENT_BINARY_DIR@:@PROJECT_BINARY_DIR@:${PATH}
 # add path to libtimemory to LD_LIBRARY_PATH
 export LD_LIBRARY_PATH=@PROJECT_BINARY_DIR@:${LD_LIBRARY_PATH}
 

--- a/source/timemory/storage/definition.hpp
+++ b/source/timemory/storage/definition.hpp
@@ -367,26 +367,38 @@ storage<Type, true>::~storage()
 
     auto _debug = m_settings->get_debug();
 
-    if(_debug)
-        printf("[%s]> destructing @ %i...\n", m_label.c_str(), __LINE__);
+    CONDITIONAL_PRINT_HERE(_debug, "[%s|%li]> destroying storage", m_label.c_str(),
+                           (long) m_instance_id);
+
+    auto _main_instance = singleton_t::master_instance();
 
     if(!m_is_master)
     {
-        if(singleton_t::master_instance())
+        if(_main_instance)
         {
-            if(_debug)
-                printf("[%s]> merging into master @ %i...\n", m_label.c_str(), __LINE__);
-            singleton_t::master_instance()->merge(this);
+            CONDITIONAL_PRINT_HERE(_debug, "[%s|%li]> merging into primary instance",
+                                   m_label.c_str(), (long) m_instance_id);
+            _main_instance->merge(this);
+        }
+        else
+        {
+            CONDITIONAL_PRINT_HERE(
+                _debug, "[%s|%li]> skipping merge into non-existent primary instance",
+                m_label.c_str(), (long) m_instance_id);
         }
     }
 
-    if(_debug)
-        printf("[%s]> deleting graph data @ %i...\n", m_label.c_str(), __LINE__);
-    delete m_graph_data_instance;
+    if(m_graph_data_instance)
+    {
+        CONDITIONAL_PRINT_HERE(_debug, "[%s|%li]> deleting graph data", m_label.c_str(),
+                               (long) m_instance_id);
+        delete m_graph_data_instance;
+    }
+
     m_graph_data_instance = nullptr;
 
-    if(_debug)
-        printf("[%s]> storage destroyed @ %i...\n", m_label.c_str(), __LINE__);
+    CONDITIONAL_PRINT_HERE(_debug, "[%s|%li]> storage destroyed", m_label.c_str(),
+                           (long) m_instance_id);
 }
 //
 //--------------------------------------------------------------------------------------//

--- a/source/timemory/utility/utility.hpp
+++ b/source/timemory/utility/utility.hpp
@@ -184,37 +184,35 @@ demangle(const std::string& _str)
 
 template <typename Tp>
 inline auto
-demangle()
+try_demangle()
 {
-    // a type demangle will always be the same
-    static auto _value = demangle(typeid(Tp).name());
-    return _value;
+    // static because a type demangle will always be the same
+    static auto _val = []() {
+        // wrap the type in type_list and then extract ... from tim::type_list<...>
+        auto _tmp = ::tim::demangle(typeid(type_list<Tp>).name());
+        auto _key = std::string{ "type_list" };
+        auto _idx = _tmp.find(_key);
+        _idx      = _tmp.find("<", _idx);
+        _tmp      = _tmp.substr(_idx + 1);
+        _idx      = _tmp.find_last_of(">");
+        _tmp      = _tmp.substr(0, _idx);
+        // strip trailing whitespaces
+        while((_idx = _tmp.find_last_of(" ")) == _tmp.length() - 1)
+            _tmp = _tmp.substr(0, _idx);
+        return _tmp;
+    }();
+    return _val;
 }
 
 //--------------------------------------------------------------------------------------//
 
-namespace internal
-{
-template <typename Tp, typename Up = Tp>
-inline auto
-try_demangle(int) -> decltype(demangle<Tp>(), std::string())
-{
-    return demangle<Tp>();
-}
-//
-template <typename Tp, typename Up = Tp>
-inline auto
-try_demangle(long)
-{
-    return "";
-}
-}  // namespace internal
-
 template <typename Tp>
 inline auto
-try_demangle()
+demangle()
 {
-    return internal::try_demangle<Tp>(0);
+    // static because a type demangle will always be the same
+    static auto _val = demangle(typeid(Tp).name());
+    return _val;
 }
 
 //--------------------------------------------------------------------------------------//

--- a/source/timemory_f.f90
+++ b/source/timemory_f.f90
@@ -1,0 +1,201 @@
+! MIT License
+!
+! Copyright (c) 2020, The Regents of the University of California,
+! through Lawrence Berkeley National Laboratory (subject to receipt of any
+! required approvals from the U.S. Dept. of Energy).  All rights reserved.
+!
+! Permission is hereby granted, free of charge, to any person obtaining a copy
+! of this software and associated documentation files (the "Software"), to deal
+! in the Software without restriction, including without limitation the rights
+! to use, copy, modify, merge, publish, distribute, sublicense, and/or sell
+! copies of the Software, and to permit persons to whom the Software is
+! furnished to do so, subject to the following conditions:
+!
+! The above copyright notice and this permission notice shall be included in all
+! copies or substantial portions of the Software.
+!
+! THE SOFTWARE IS PROVIDED "AS IS", WITHOUT WARRANTY OF ANY KIND, EXPRESS OR
+! IMPLIED, INCLUDING BUT NOT LIMITED TO THE WARRANTIES OF MERCHANTABILITY,
+! FITNESS FOR A PARTICULAR PURPOSE AND NONINFRINGEMENT. IN NO EVENT SHALL THE
+! AUTHORS OR COPYRIGHT HOLDERS BE LIABLE FOR ANY CLAIM, DAMAGES OR OTHER
+! LIABILITY, WHETHER IN AN ACTION OF CONTRACT, TORT OR OTHERWISE, ARISING FROM,
+! OUT OF OR IN CONNECTION WITH THE SOFTWARE OR THE USE OR OTHER DEALINGS IN THE
+! SOFTWARE.
+
+module timemory
+    use iso_c_binding, only : C_INT, C_LONG, C_NULL_PTR, C_PTR, C_SIZE_T
+    ! splicer begin module_use
+    ! splicer end module_use
+    implicit none
+
+    !
+    interface
+        !
+        subroutine c_timemory_named_init_library(name) &
+                bind(C, name="timemory_named_init_library")
+            use iso_c_binding, only : C_CHAR
+            implicit none
+            character(kind=C_CHAR), intent(IN) :: name(*)
+        end subroutine c_timemory_named_init_library
+        !
+        subroutine c_timemory_finalize_library() &
+                bind(C, name="timemory_finalize_library")
+        end subroutine c_timemory_finalize_library
+        !
+        subroutine c_timemory_resume() &
+                bind(C, name="timemory_resume")
+        end subroutine c_timemory_resume
+        !
+        subroutine c_timemory_pause() &
+                bind(C, name="timemory_pause")
+        end subroutine c_timemory_pause
+        !
+        subroutine c_timemory_set_default(name) &
+                bind(C, name="timemory_set_default")
+            use iso_c_binding, only : C_CHAR
+            implicit none
+            character(kind=C_CHAR), intent(IN) :: name(*)
+        end subroutine c_timemory_set_default
+        !
+        subroutine c_timemory_add_components(name) &
+                bind(C, name="timemory_add_components")
+            use iso_c_binding, only : C_CHAR
+            implicit none
+            character(kind=C_CHAR), intent(IN) :: name(*)
+        end subroutine c_timemory_add_components
+        !
+        subroutine c_timemory_remove_components(name) &
+                bind(C, name="timemory_remove_components")
+            use iso_c_binding, only : C_CHAR
+            implicit none
+            character(kind=C_CHAR), intent(IN) :: name(*)
+        end subroutine c_timemory_remove_components
+        !
+        subroutine c_timemory_push_components(name) &
+                bind(C, name="timemory_push_components")
+            use iso_c_binding, only : C_CHAR
+            implicit none
+            character(kind=C_CHAR), intent(IN) :: name(*)
+        end subroutine c_timemory_push_components
+        !
+        subroutine c_timemory_pop_components() &
+                bind(C, name="timemory_pop_components")
+        end subroutine c_timemory_pop_components
+        !
+        function c_timemory_get_begin_record(name) &
+                result(idx) &
+                bind(C, name="timemory_get_begin_record")
+            use iso_c_binding, only : C_CHAR, C_INT64_T
+            implicit none
+            character(kind=C_CHAR), intent(IN) :: name(*)
+            integer(C_INT64_T) :: idx
+        end function c_timemory_get_begin_record
+        !
+        subroutine c_timemory_end_record(idx) &
+                bind(C, name="timemory_end_record")
+            use iso_c_binding, only : C_INT64_T
+            implicit none
+            integer(C_INT64_T), intent(IN) :: idx
+        end subroutine c_timemory_end_record
+        !
+        subroutine c_timemory_push_region(name) &
+                bind(C, name="timemory_push_region")
+            use iso_c_binding, only : C_CHAR
+            implicit none
+            character(kind=C_CHAR), intent(IN) :: name(*)
+        end subroutine c_timemory_push_region
+        !
+        subroutine c_timemory_pop_region(name) &
+                bind(C, name="timemory_pop_region")
+            use iso_c_binding, only : C_CHAR
+            implicit none
+            character(kind=C_CHAR), intent(IN) :: name(*)
+        end subroutine c_timemory_pop_region
+
+
+    end interface
+
+contains
+    !
+    subroutine timemory_init_library(name)
+        use iso_c_binding, only : C_NULL_CHAR, C_CHAR
+        character(len=*) :: name
+        character(len=1024) :: farg_name
+        character(len=1024, kind=C_CHAR) :: carg_name
+
+        if (LEN(name) == 0) then
+            call get_command_argument(0, farg_name)
+            carg_name = trim(farg_name)//C_NULL_CHAR
+        else
+            carg_name = trim(name)//C_NULL_CHAR
+        end if
+        call c_timemory_named_init_library(carg_name)
+    end subroutine timemory_init_library
+    !
+    subroutine timemory_finalize_library()
+        call c_timemory_finalize_library()
+    end subroutine timemory_finalize_library
+    !
+    subroutine timemory_pause()
+        call c_timemory_pause()
+    end subroutine timemory_pause
+    !
+    subroutine timemory_resume()
+        call c_timemory_resume()
+    end subroutine timemory_resume
+    !
+    subroutine timemory_set_default(name)
+        use iso_c_binding, only : C_NULL_CHAR
+        character(len=*), intent(IN) :: name
+        call c_timemory_set_default(trim(name)//C_NULL_CHAR)
+    end subroutine timemory_set_default
+    !
+    subroutine timemory_add_components(name)
+        use iso_c_binding, only : C_NULL_CHAR
+        character(len=*), intent(IN) :: name
+        call c_timemory_add_components(trim(name)//C_NULL_CHAR)
+    end subroutine timemory_add_components
+    !
+    subroutine timemory_remove_components(name)
+        use iso_c_binding, only : C_NULL_CHAR
+        character(len=*), intent(IN) :: name
+        call c_timemory_remove_components(trim(name)//C_NULL_CHAR)
+    end subroutine timemory_remove_components
+    !
+    subroutine timemory_push_components(name)
+        use iso_c_binding, only : C_NULL_CHAR
+        character(len=*), intent(IN) :: name
+        call c_timemory_push_components(trim(name)//C_NULL_CHAR)
+    end subroutine timemory_push_components
+    !
+    subroutine timemory_pop_components()
+        call c_timemory_pop_components()
+    end subroutine timemory_pop_components
+    !
+    function timemory_get_begin_record(name) &
+        result(idx)
+        use iso_c_binding, only : C_NULL_CHAR, C_INT64_T
+        character(len=*), intent(IN) :: name
+        integer(C_INT64_T) :: idx
+        idx = c_timemory_get_begin_record(trim(name)//C_NULL_CHAR)
+    end function timemory_get_begin_record
+    !
+    subroutine timemory_end_record(idx)
+        use iso_c_binding, only : C_INT64_T
+        integer(C_INT64_T), intent(IN) :: idx
+        call c_timemory_end_record(idx)
+    end subroutine timemory_end_record
+    !
+    subroutine timemory_push_region(name)
+        use iso_c_binding, only : C_NULL_CHAR
+        character(len=*), intent(IN) :: name
+        call c_timemory_push_region(trim(name)//C_NULL_CHAR)
+    end subroutine timemory_push_region
+    !
+    subroutine timemory_pop_region(name)
+        use iso_c_binding, only : C_NULL_CHAR
+        character(len=*), intent(IN) :: name
+        call c_timemory_pop_region(trim(name)//C_NULL_CHAR)
+    end subroutine timemory_pop_region
+
+end module timemory

--- a/timemory/plotting/table.py
+++ b/timemory/plotting/table.py
@@ -42,6 +42,7 @@ __all__ = [
 ]
 
 import os
+import sys
 from .plotting import make_output_directory, add_plotted_files, plot_parameters
 
 # use the matplotlib import stuff from plotting
@@ -78,6 +79,11 @@ def timem(data, fname, args):
         col_labels.append("Rank {}".format(rank))
         i = 0
         for key, entry in data["timem"][rank].items():
+            if isinstance(entry["value"], (list, dict)):
+                sys.stderr.write(
+                    f"Skipping multi-dimensional entry for {key}\n"
+                )
+                continue
             if rank == 0:
                 unit = entry["unit_repr"]
                 if unit:
@@ -99,7 +105,7 @@ def timem(data, fname, args):
                 int_data[i] = False
             else:
                 table_vals[i].append("{}".format(value))
-                if not i in int_data:
+                if i not in int_data:
                     int_data[i] = True
             i += 1
 


### PR DESCRIPTION
- new timemory-fortran-{shared,static} targets
- new timemory fortran module
- fortran example
- support path resolution in timemory-run
- temporary patch to plotting/table.py for multi-dimensional data
- closes #175 

## Fortran module example

See `examples/ex-fortran`

```fortran
program fortran_example
    use timemory
    use iso_c_binding, only : C_INT64_T
    implicit none
    integer(C_INT64_T) :: idx

    ! initialize with explicit name
    call timemory_init_library("ex-fortran")

    ! initialize with name extracted from get_command_argument(0, ...)
    ! call timemory_init_library("")

    ! define the default set of components
    call timemory_set_default("wall_clock, cpu_clock")

    ! Start region "main"
    call timemory_push_region("main")

    ! Add peak_rss to the current set of components
    call timemory_add_components("peak_rss")

    ! Nested region "inner" nested under "main"
    call timemory_push_region("inner")

    ! End the "inner" region
    call timemory_pop_region("inner")

    ! remove peak_rss
    call timemory_remove_components("peak_rss")

    ! begin a region and get an identifier
    idx = timemory_get_begin_record("indexed")

    ! replace current set of components
    call timemory_push_components("page_rss")

    ! Nested region "inner" with only page_rss components
    call timemory_push_region("inner (pushed)")

    ! Stop "inner" region with only page_rss components
    call timemory_pop_region("inner (pushed)")

    ! restore previous set of components
    call timemory_pop_components()

    ! end the "indexed" region
    call timemory_end_record(idx)

    ! End "main"
    call timemory_pop_region("main")

    ! Output the results
    call timemory_finalize_library()

end program fortran_example
```