### PR TITLE
Environment parsing fix + compiler instrumentation fix + improved remove_type

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -17,7 +17,7 @@ jobs:
       - run:
           name: build
           command: >
-            cmake -B build-timemory/timem-ci-install -DTIMEMORY_REQUIRE_PACKAGES=OFF -DTIMEMORY_BUILD_TIMEM=ON -DTIMEMORY_USE_PAPI=OFF -DTIMEMORY_INSTALL_ALL=OFF -DTIMEMORY_INSTALL_HEADERS=OFF -DTIMEMORY_INSTALL_CONFIG=OFF -DCMAKE_INSTALL_PREFIX=/opt/user/timemory &&
+            cmake -B build-timemory/timem-ci-install -DTIMEMORY_REQUIRE_PACKAGES=OFF -DTIMEMORY_BUILD_TIMEM=ON -DTIMEMORY_USE_PAPI=ON -DTIMEMORY_INSTALL_ALL=OFF -DTIMEMORY_INSTALL_HEADERS=OFF -DTIMEMORY_INSTALL_CONFIG=OFF -DCMAKE_INSTALL_PREFIX=/opt/user/timemory &&
             cmake --build build-timemory/timem-ci-install --target timem
       - run:
           name: install

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -20,6 +20,7 @@ jobs:
             BUILD_TYPE: 'RelWithDebInfo'
             PACKAGES: 'clang-7 build-essential libmpich-dev mpich ccache'
             BUILD_ARGS: '--minimal --build-libs shared static --python --mpi --gotcha --stats --tools mallocp mpip ompt --cxx-standard=17'
+            CTEST_ARGS: '-VV'
             CONFIG_ARGS: '-DTIMEMORY_CCACHE_BUILD=ON -DTIMEMORY_UNITY_BUILD=OFF -DTIMEMORY_BUILD_PYTHON_UNITY=OFF'
           - CC: clang-8
             CXX: clang++-8
@@ -34,6 +35,7 @@ jobs:
             BUILD_TYPE: 'MinSizeRel'
             PACKAGES: 'clang-9 build-essential libopenmpi-dev openmpi-bin openmpi-common libfabric-dev ccache'
             BUILD_ARGS: '--quick --build-libs shared --mpi --cxx-standard=14'
+            CTEST_ARGS: '-VV'
             CONFIG_ARGS: '-DTIMEMORY_CCACHE_BUILD=ON'
           - CC: gcc-6
             CXX: g++-6
@@ -42,6 +44,7 @@ jobs:
             BUILD_TYPE: 'RelWithDebInfo'
             PACKAGES: 'gcc-6 g++-6 gfortran-6 build-essential libtbb-dev ccache'
             BUILD_ARGS: '--minimal --build-libs shared --python --gotcha --stats --cxx-standard=14'
+            CTEST_ARGS: '-VV'
             CONFIG_ARGS: '-DTIMEMORY_CCACHE_BUILD=ON -DTIMEMORY_BUILD_PYTHON_UNITY=OFF'
           - CC: gcc-7
             CXX: g++-7
@@ -50,6 +53,7 @@ jobs:
             BUILD_TYPE: 'Debug'
             PACKAGES: 'gcc-7 g++-7 gfortran-7 build-essential libmpich-dev mpich libtbb-dev libpapi-dev papi-tools lcov ccache'
             BUILD_ARGS: '--minimal --build-libs shared --mpi --papi --gotcha --tools mpip --stats --cxx-standard=17 --coverage'
+            CTEST_ARGS: '-V --output-on-failure'
             CONFIG_ARGS: ''
           - CC: gcc-8
             CXX: g++-8
@@ -58,6 +62,7 @@ jobs:
             BUILD_TYPE: 'Release'
             PACKAGES: 'gcc-8 g++-8 gfortran-8 build-essential libmpich-dev mpich ccache'
             BUILD_ARGS: '--minimal --build-libs shared --mpi --gotcha --stats --tools compiler --cxx-standard=17'
+            CTEST_ARGS: '-VV'
             CONFIG_ARGS: '-DTIMEMORY_CCACHE_BUILD=ON'
           - CC: gcc-9
             CXX: g++-9
@@ -66,13 +71,14 @@ jobs:
             BUILD_TYPE: 'MinSizeRel'
             PACKAGES: 'gcc-9 g++-9 gfortran-9 build-essential ccache'
             BUILD_ARGS: '--minimal --build-libs shared --gotcha --stats --python --cxx-standard=17'
+            CTEST_ARGS: '-VV'
             CONFIG_ARGS: '-DTIMEMORY_CCACHE_BUILD=ON -DTIMEMORY_BUILD_PYTHON_UNITY=OFF'
 
     env:
       CC: ${{ matrix.CC }}
       FC: ${{ matrix.FC }}
       CXX: ${{ matrix.CXX }}
-      CTEST_ARGS: "-VV ${{ matrix.CTEST_ARGS }}"
+      CTEST_ARGS: "${{ matrix.CTEST_ARGS }}"
 
     steps:
       - name: Setup Environment
@@ -108,6 +114,26 @@ jobs:
           python -m pip install pytest
           echo -e "Running command:\n$(which python) ./pyctest-runner.py ${PYCTEST_ARGS} -- ${CTEST_ARGS} -- ${CMAKE_ARGS}"
           python ./pyctest-runner.py ${PYCTEST_ARGS} -- ${CTEST_ARGS} -- ${CMAKE_ARGS}
+
+      - name: Update Log
+        working-directory: ${{github.workspace}}/build-timemory/Linux
+        run: |
+          for i in $(find Testing | grep LastUpdate); do echo "##### File: ${i} #####"; cat ${i}; done
+
+      - name: Configure Log
+        working-directory: ${{github.workspace}}/build-timemory/Linux
+        run: |
+          for i in $(find Testing | grep LastConfigure); do echo "##### File: ${i} #####"; cat ${i}; done
+
+      - name: Build Log
+        working-directory: ${{github.workspace}}/build-timemory/Linux
+        run: |
+          for i in $(find Testing | grep LastBuild); do echo "##### File: ${i} #####"; cat ${i}; done
+
+      - name: Test Log
+        working-directory: ${{github.workspace}}/build-timemory/Linux
+        run: |
+          for i in $(find Testing | grep LastTest); do echo "##### File: ${i} #####"; cat ${i}; done
 
       - name: Test Install
         working-directory: ${{github.workspace}}/build-timemory/Linux

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -28,6 +28,13 @@ jobs:
             PACKAGES: 'clang-8 build-essential ccache'
             BUILD_ARGS: '--minimal --build-libs shared static --stats --tools kokkos-config timem --cxx-standard=14'
             CONFIG_ARGS: '-DTIMEMORY_CCACHE_BUILD=ON'
+          - CC: clang-9
+            CXX: clang++-9
+            PYTHON_VERSION: '3.7'
+            BUILD_TYPE: 'MinSizeRel'
+            PACKAGES: 'clang-9 build-essential libopenmpi-dev openmpi-bin openmpi-common libfabric-dev ccache'
+            BUILD_ARGS: '--quick --build-libs shared --mpi --cxx-standard=14'
+            CONFIG_ARGS: '-DTIMEMORY_CCACHE_BUILD=ON'
           - CC: gcc-6
             CXX: g++-6
             FC: gfortran-6
@@ -49,7 +56,7 @@ jobs:
             FC: gfortran-8
             PYTHON_VERSION: '3.7'
             BUILD_TYPE: 'Release'
-            PACKAGES: 'gcc-8 g++-8 gfortran-8 build-essential libopenmpi-dev openmpi-bin openmpi-common libfabric-dev ccache'
+            PACKAGES: 'gcc-8 g++-8 gfortran-8 build-essential libmpich-dev mpich ccache'
             BUILD_ARGS: '--minimal --build-libs shared --mpi --gotcha --stats --tools compiler --cxx-standard=17'
             CONFIG_ARGS: '-DTIMEMORY_CCACHE_BUILD=ON'
           - CC: gcc-9

--- a/.github/workflows/continuous-integration.yml
+++ b/.github/workflows/continuous-integration.yml
@@ -1,6 +1,10 @@
 name: continuous-integration
 
-on: [push, pull_request]
+on:
+  push:
+    branches: [ master, develop ]
+  pull_request:
+    branches: [ master, develop ]
 
 jobs:
   linux-ci:

--- a/cmake/Modules/ClangFormat.cmake
+++ b/cmake/Modules/ClangFormat.cmake
@@ -46,7 +46,15 @@ if(CLANG_FORMATTER)
         ${PROJECT_SOURCE_DIR}/source/*.c
         ${PROJECT_SOURCE_DIR}/source/*.cu
         ${PROJECT_SOURCE_DIR}/source/*.cpp
-        ${PROJECT_SOURCE_DIR}/source/*.cpp.in)
+        ${PROJECT_SOURCE_DIR}/source/*.cpp.in
+        ${PROJECT_SOURCE_DIR}/source/tools/*.c
+        ${PROJECT_SOURCE_DIR}/source/tools/*.cu
+        ${PROJECT_SOURCE_DIR}/source/tools/*.cpp
+        ${PROJECT_SOURCE_DIR}/source/tools/*.cpp.in
+        ${PROJECT_SOURCE_DIR}/source/tests/*.c
+        ${PROJECT_SOURCE_DIR}/source/tests/*.cu
+        ${PROJECT_SOURCE_DIR}/source/tests/*.cpp
+        ${PROJECT_SOURCE_DIR}/source/tests/*.cpp.in)
     if(TIMEMORY_SOURCE_GROUP)
         source_group(TREE ${PROJECT_SOURCE_DIR}/source FILES ${sources})
     endif()

--- a/cmake/Modules/MacroUtilities.cmake
+++ b/cmake/Modules/MacroUtilities.cmake
@@ -269,6 +269,11 @@ FUNCTION(ADD_TIMEMORY_GOOGLE_TEST TEST_NAME)
         target_compile_definitions(google-test-debug-options INTERFACE
             $<$<CONFIG:Debug>:DEBUG> TIMEMORY_TESTING)
     endif()
+    if("${CMAKE_BUILD_TYPE}" STREQUAL "Debug" OR TIMEMORY_USE_COVERAGE)
+        # create a pre-processor which relaxes pass/fail when converage is enabled
+        target_compile_definitions(google-test-debug-options INTERFACE
+            TIMEMORY_RELAXED_TESTING)
+    endif()
     list(APPEND TEST_LINK_LIBRARIES google-test-debug-options)
 
     if(NOT TEST_TARGET)

--- a/cmake/Modules/Options.cmake
+++ b/cmake/Modules/Options.cmake
@@ -119,7 +119,10 @@ else()
     set(_USE_CUDA OFF)
 endif()
 
-if(TIMEMORY_BUILD_FORTRAN OR NOT DEFINED TIMEMORY_BUILD_FORTRAN)
+# On Windows do not try run check_language because it tends to hang indefinitely
+if(WIN32 AND NOT DEFINED TIMEMORY_BUILD_FORTRAN)
+    set(_BUILD_FORTRAN OFF)
+elseif(TIMEMORY_BUILD_FORTRAN OR NOT DEFINED TIMEMORY_BUILD_FORTRAN)
     check_language(Fortran)
     if(CMAKE_Fortran_COMPILER)
         enable_language(Fortran)

--- a/source/tests/CMakeLists.txt
+++ b/source/tests/CMakeLists.txt
@@ -148,7 +148,7 @@ add_subdirectory(external)
 
 foreach(_LINK_TYPE shared static)
     foreach(_DEPTH_VALUE 0 5)
-        set(compiler_instr_env "TIMEMORY_SUPPRESS_CONFIG=ON;TIMEMORY_COMPILER_COUT_OUTPUT=ON")
+        set(compiler_instr_env "TIMEMORY_SUPPRESS_CONFIG=ON;TIMEMORY_COMPILER_SUPPRESS_CONFIG=ON;TIMEMORY_COMPILER_COUT_OUTPUT=ON")
         if(NOT "${_DEPTH_VALUE}" STREQUAL "0")
             set(_EXTRA "_max_depth_${_DEPTH_VALUE}")
             list(APPEND compiler_instr_env "TIMEMORY_COMPILER_MAX_DEPTH=${_DEPTH_VALUE}")

--- a/source/tests/test_macros.hpp
+++ b/source/tests/test_macros.hpp
@@ -49,6 +49,29 @@ using stringstream_t = std::stringstream;
 
 namespace
 {
+#if !defined(DISABLE_TIMEMORY)
+template <typename Tp>
+inline std::string
+as_string(const tim::node::result<Tp>& _obj)
+{
+    std::ostringstream _oss{};
+    _oss << "tid=" << std::setw(2) << _obj.tid() << ", ";
+    _oss << "pid=" << std::setw(6) << _obj.pid() << ", ";
+    _oss << "depth=" << std::setw(2) << _obj.depth() << ", ";
+    _oss << "hash=" << std::setw(21) << _obj.hash() << ", ";
+    _oss << "prefix=" << _obj.prefix() << ", ";
+    _oss << "data=" << _obj.data();
+    return _oss.str();
+}
+#else
+template <typename Tp>
+inline std::string
+as_string(const Tp&)
+{
+    return std::string{};
+}
+#endif
+//
 #if !defined(TIMEMORY_TEST_NO_METRIC) && !defined(DISABLE_TIMEMORY)
 inline auto&
 metric()

--- a/source/timemory/manager/manager.cpp
+++ b/source/timemory/manager/manager.cpp
@@ -98,13 +98,29 @@ manager::manager()
         auto _cpu_info = cpu::get_info();
         auto _user     = get_env<std::string>("USER", "nobody");
 
+        for(auto&& itr : { "SHELL", "HOME", "PWD" })
+        {
+            auto _var = get_env<std::string>(itr, "");
+            if(!_var.empty())
+                add_metadata(itr, _var);
+        }
+
         add_metadata("USER", _user);
         add_metadata("LAUNCH_DATE", _launch_date);
         add_metadata("LAUNCH_TIME", _launch_time);
         add_metadata("TIMEMORY_API", demangle<TIMEMORY_API>());
+
+#    if defined(TIMEMORY_VERSION_STRING)
         add_metadata("TIMEMORY_VERSION", TIMEMORY_VERSION_STRING);
+#    endif
+
+#    if defined(TIMEMORY_GIT_DESCRIBE)
         add_metadata("TIMEMORY_GIT_DESCRIBE", TIMEMORY_GIT_DESCRIBE);
+#    endif
+
+#    if defined(TIMEMORY_GIT_REVISION)
         add_metadata("TIMEMORY_GIT_REVISION", TIMEMORY_GIT_REVISION);
+#    endif
 
         add_metadata("CPU_MODEL", _cpu_info.model);
         add_metadata("CPU_VENDOR", _cpu_info.vendor);
@@ -434,7 +450,7 @@ manager::write_metadata(const std::string& _output_dir, const char* context)
                                                    _output_dir);
 
     auto _settings = f_settings();
-    bool _banner   = (_settings) ? _settings->get_banner() : false;
+    auto _banner   = (_settings) ? _settings->get_banner() : false;
     if(f_verbose() > 0 || _banner || f_debug())
         printf("\n[metadata::%s]> Outputting '%s' and '%s'...\n", context, fname.c_str(),
                hname.c_str());

--- a/source/timemory/mpl/filters.hpp
+++ b/source/timemory/mpl/filters.hpp
@@ -304,32 +304,6 @@ struct sortT<PrioT, type_list<In, InT...>, type_list<BegTT...>, type_list<Tp, En
                                      type_list<BegTT..., Tp>, type_list<EndTT...>>::type>;
 };
 
-//--------------------------------------------------------------------------------------//
-//  remove a type from a variadic bundle
-//
-namespace internal
-{
-template <typename Tp, typename In, typename Out>
-struct remove_type;
-
-template <typename Tp, template <typename...> class Tuple, typename Out>
-struct remove_type<Tp, Tuple<>, Out>
-{
-    using type = Out;
-};
-
-template <typename Tp, template <typename...> class InTuple,
-          template <typename...> class OutTuple, typename In, typename... InTail,
-          typename... Out>
-struct remove_type<Tp, InTuple<In, InTail...>, OutTuple<Out...>>
-{
-    using type = conditional_t<
-        std::is_same<Tp, In>::value,
-        typename remove_type<Tp, type_list<InTail...>, OutTuple<Out...>>::type,
-        typename remove_type<Tp, type_list<InTail...>, OutTuple<Out..., In>>::type>;
-};
-}  // namespace internal
-
 //======================================================================================//
 
 template <typename Tp, typename OpT>
@@ -389,10 +363,12 @@ template <typename Tp, template <typename...> class Tuple, typename... Types>
 struct remove_type<Tp, Tuple<Types...>>
 {
     static constexpr auto value = is_one_of<Tp, type_list<Types...>>::value;
-    using type =
-        conditional_t<value,
-                      typename internal::remove_type<Tp, Tuple<Types...>, Tuple<>>::type,
-                      Tuple<Types...>>;
+    using type                  = conditional_t<
+        value,
+        convert_t<type_concat_t<std::conditional_t<std::is_same<Tp, Types>::value,
+                                                   type_list<>, type_list<Types>>...>,
+                  Tuple<>>,
+        Tuple<Types...>>;
 };
 
 //======================================================================================//

--- a/source/timemory/operations/types/node.hpp
+++ b/source/timemory/operations/types/node.hpp
@@ -127,6 +127,16 @@ private:
 
             // get the current depth
             auto _beg_depth = operation::get_depth<storage_type>{}(*_storage);
+            // check against max depth when not flat
+            if(!operation::get_is_flat<type, false>{}(_obj))
+            {
+                auto _settings = settings::instance();
+                if(_settings && _beg_depth + 1 > _settings->get_max_depth())
+                {
+                    operation::set_is_on_stack<type>{}(_obj, false);
+                    return nullptr;
+                }
+            }
             // assign iterator to the insertion point in storage
             operation::set_iterator<type>{}(
                 _obj, operation::insert<storage_type>{}(*_storage, _scope, _obj, _hash));

--- a/source/timemory/settings/settings.cpp
+++ b/source/timemory/settings/settings.cpp
@@ -340,10 +340,21 @@ void
 settings::parse(settings* _settings)
 {
     if(!_settings)
+    {
+        PRINT_HERE("%s", "nullptr to tim::settings");
         return;
+    }
 
     if(_settings->get_suppress_parsing())
+    {
+        static auto _once = false;
+        if(!_once)
+        {
+            PRINT_HERE("%s", "settings parsing has been suppressed");
+            _once = true;
+        }
         return;
+    }
 
     for(const auto& itr : *_settings)
     {

--- a/source/timemory/settings/vsettings.cpp
+++ b/source/timemory/settings/vsettings.cpp
@@ -30,6 +30,53 @@
 namespace tim
 {
 //
+TIMEMORY_SETTINGS_INLINE
+vsettings::vsettings(std::string _name, std::string _env_name, std::string _descript,
+                     std::vector<std::string> _cmdline, int32_t _count,
+                     int32_t _max_count, std::vector<std::string> _choices)
+: m_count(_count)
+, m_max_count(_max_count)
+, m_name(std::move(_name))
+, m_env_name(std::move(_env_name))
+, m_description(std::move(_descript))
+, m_cmdline(std::move(_cmdline))
+, m_choices(std::move(_choices))
+{}
+//
+TIMEMORY_SETTINGS_LINKAGE(vsettings::display_map_t)
+vsettings::get_display(std::ios::fmtflags fmt, int _w, int _p)
+{
+    display_map_t _data;
+    auto          _as_str = [&](auto _val) {
+        std::stringstream _ss;
+        _ss.setf(fmt);
+        if(_w > -1)
+            _ss << std::setw(_w);
+        if(_p > -1)
+            _ss << std::setprecision(_p);
+        _ss << std::boolalpha << _val;
+        return _ss.str();
+    };
+
+    auto _arr_as_str = [&](auto _val) -> std::string {
+        if(_val.empty())
+            return "";
+        std::stringstream _ss;
+        for(size_t i = 0; i < _val.size(); ++i)
+            _ss << ", " << _as_str(_val.at(i));
+        return _ss.str().substr(2);
+    };
+
+    _data["name"]         = _as_str(m_name);
+    _data["count"]        = _as_str(m_count);
+    _data["max_count"]    = _as_str(m_max_count);
+    _data["env_name"]     = _as_str(m_env_name);
+    _data["description"]  = _as_str(m_description);
+    _data["command_line"] = _arr_as_str(m_cmdline);
+    _data["choices"]      = _arr_as_str(m_choices);
+    return _data;
+}
+//
 TIMEMORY_SETTINGS_LINKAGE(bool)
 vsettings::matches(const std::string& inp, bool exact) const
 {

--- a/source/tools/timemory-timem/timem.cpp
+++ b/source/tools/timemory-timem/timem.cpp
@@ -62,6 +62,8 @@ main(int argc, char** argv)
     tim::settings::enabled()     = true;
     // ensure manager never writes metadata
     tim::manager::instance()->set_write_metadata(-1);
+    // disable network stats by default
+    tim::trait::apply<tim::trait::runtime_enabled>::set<network_stats>(false);
 
     auto _mpi_argc = 1;
     auto _mpi_argv = argv;


### PR DESCRIPTION
- `mpl::remove_type` is much more efficient
- Fixed issue with settings not parsing environment
- Fixed MT issue with compiler instrumentation changes to support max-depth 