### PR TITLE
timemory avail fix

### DIFF
--- a/.appveyor.yml
+++ b/.appveyor.yml
@@ -1,7 +1,24 @@
-version: 1.0.{build}
+version: 2.0.{build}
 
-# https://developercommunity.visualstudio.com/content/problem/457095/cannot-bind-temporary-int-object-to-an-rvalue-refe.html
-# ^ this issue has caused support to be dropped for Visual Studio 2017
+skip_commits:
+  files:
+    - docs/*
+    - .github/*
+    - scripts/*
+    - recipe/*
+    - spack/*
+    - docker/*
+    - '**/*.md'
+    - pyproject.toml
+    - pytest.ini
+    - requirements.txt
+    - setup.*
+    - VERSION
+
+skip_tags: true
+skip_branch_with_pr: true
+max_jobs: 2
+
 image:
   - Visual Studio 2019
 

--- a/source/timemory/settings/settings.cpp
+++ b/source/timemory/settings/settings.cpp
@@ -1182,23 +1182,33 @@ settings::read(std::istream& ifs, std::string inp)
     {
         using policy_type = policy::input_archive<cereal::JSONInputArchive, TIMEMORY_API>;
         auto ia           = policy_type::get(ifs);
-        ia->setNextName("timemory");
-        ia->startNode();
+        try
         {
-            try
+            ia->setNextName("timemory");
+            ia->startNode();
             {
-                ia->setNextName("metadata");
-                ia->startNode();
-                // settings
-                (*ia)(cereal::make_nvp("settings", *this));
-                ia->finishNode();
-            } catch(...)
-            {
-                // settings
-                (*ia)(cereal::make_nvp("settings", *this));
+                try
+                {
+                    ia->setNextName("metadata");
+                    ia->startNode();
+                    // settings
+                    (*ia)(cereal::make_nvp("settings", *this));
+                    ia->finishNode();
+                } catch(...)
+                {
+                    // settings
+                    (*ia)(cereal::make_nvp("settings", *this));
+                }
             }
+            ia->finishNode();
+        } catch(tim::cereal::Exception& e)
+        {
+            PRINT_HERE("Exception reading %s :: %s", inp.c_str(), e.what());
+#    if defined(TIMEMORY_INTERNAL_TESTING)
+            TIMEMORY_CONDITIONAL_DEMANGLED_BACKTRACE(true, 8);
+#    endif
+            return false;
         }
-        ia->finishNode();
         return true;
     }
 #    if defined(TIMEMORY_USE_XML)

--- a/source/tools/timemory-avail/timemory-avail.hpp
+++ b/source/tools/timemory-avail/timemory-avail.hpp
@@ -169,8 +169,8 @@ private:
     array_type* output_stream  = nullptr;
     unique_set  exclude_stream = {};
     int_stack   name_counter;
-    unique_set  value_keys = { "name",    "value",     "description", "count",
-                              "environ", "max_count", "cmdline",     "data_type" };
+    unique_set  value_keys = { "name",      "value",   "description", "count",  "environ",
+                              "max_count", "cmdline", "data_type",   "initial" };
 };
 
 //======================================================================================//


### PR DESCRIPTION
- `timemory-avail -S` was not reporting settings correctly due to failure to read the "initial" field
- added some try/catch statements around where JSON input archives are read in
- reduced appveyor workload