### PR TITLE
Replace `--flush-on-signal <int>` with `--forward-signal <int>` in timem

### DIFF
--- a/source/tools/timemory-timem/timem.cpp
+++ b/source/tools/timemory-timem/timem.cpp
@@ -386,15 +386,15 @@ main(int argc, char** argv)
     for(auto itr : signal_forward())
     {
         CONDITIONAL_PRINT_HERE((debug() && verbose() > 0),
-                               "timem will stop, dump it's output, and exit if signal %i "
-                               "is sent to this process (PID: %i)",
+                               "timem will forward signal %i to its worker "
+                               "process if it is sent to this process (PID: %i)",
                                itr, (int) tim::process::get_id());
         if(signal_types().count(itr) > 0)
             throw std::runtime_error(TIMEMORY_JOIN(
                 " ", "Error! timem sampler is using signal", itr,
-                "to handle the sampling measurements. Flushing output on this signal "
-                "will cause immediate termination. Re-run timem with the"
-                "'--disable-sampling' option to flush output on this signal"));
+                "to handle the sampling measurements. Cannot forward it. "
+                "Re-run timem with the '--disable-sampling' option to "
+                "forward this signal"));
     }
 
     // set the signal handler on this process if using mpi so that we can read

--- a/source/tools/timemory-timem/timem.cpp
+++ b/source/tools/timemory-timem/timem.cpp
@@ -249,7 +249,8 @@ main(int argc, char** argv)
         .description(
             "If any of these signals are sent to timem, forward them to the process.\n"
             "%{INDENT}% E.g. '--forward-signal 2' (default behavior) will cause timem "
-            "to forward\n%{INDENT}% SIGINT to the process if (Cntl+C) is sent by the user.\n"
+            "to forward\n%{INDENT}% SIGINT to the process if (Cntl+C) is sent by the "
+            "user.\n"
             "%{INDENT}% Use '--forward-signal 0' to disable this behavior.")
         .dtype("int")
         .min_count(1)
@@ -390,11 +391,11 @@ main(int argc, char** argv)
                                "process if it is sent to this process (PID: %i)",
                                itr, (int) tim::process::get_id());
         if(signal_types().count(itr) > 0)
-            throw std::runtime_error(TIMEMORY_JOIN(
-                " ", "Error! timem sampler is using signal", itr,
-                "to handle the sampling measurements. Cannot forward it. "
-                "Re-run timem with the '--disable-sampling' option to "
-                "forward this signal"));
+            throw std::runtime_error(
+                TIMEMORY_JOIN(" ", "Error! timem sampler is using signal", itr,
+                              "to handle the sampling measurements. Cannot forward it. "
+                              "Re-run timem with the '--disable-sampling' option to "
+                              "forward this signal"));
     }
 
     // set the signal handler on this process if using mpi so that we can read

--- a/source/tools/timemory-timem/timem.hpp
+++ b/source/tools/timemory-timem/timem.hpp
@@ -891,7 +891,7 @@ struct timem_config
     size_t        buffer_size  = 0;
     string_t      command      = {};
     std::set<int> signal_types = { SIGALRM };
-    std::set<int> signal_flush = { SIGINT };
+    std::set<int> signal_forward = { SIGINT };
     std::vector<std::string>     argvector     = {};
     std::vector<hist_type>       history       = {};
     std::unique_ptr<std::thread> buffer_thread = {};
@@ -938,7 +938,7 @@ TIMEM_CONFIG_FUNCTION(buffer_size)
 TIMEM_CONFIG_FUNCTION(master_pid)
 TIMEM_CONFIG_FUNCTION(worker_pid)
 TIMEM_CONFIG_FUNCTION(signal_types)
-TIMEM_CONFIG_FUNCTION(signal_flush)
+TIMEM_CONFIG_FUNCTION(signal_forward)
 TIMEM_CONFIG_FUNCTION(argvector)
 TIMEM_CONFIG_FUNCTION(buffer_cv);
 TIMEM_CONFIG_FUNCTION(buffer_thread);

--- a/source/tools/timemory-timem/timem.hpp
+++ b/source/tools/timemory-timem/timem.hpp
@@ -882,15 +882,15 @@ struct timem_config
     int      verbose          = tim::get_env("TIMEM_VERBOSE", 0);
     string_t shell =
         tim::get_env("TIMEM_SHELL", tim::get_env<string_t>("SHELL", getusershell()));
-    string_t      shell_flags  = tim::get_env<string_t>("TIMEM_SHELL_FLAGS", "");
-    string_t      output_file  = tim::get_env<string_t>("TIMEM_OUTPUT", "");
-    double        sample_freq  = tim::get_env<double>("TIMEM_SAMPLE_FREQ", 5.0);
-    double        sample_delay = tim::get_env<double>("TIMEM_SAMPLE_DELAY", 1.0e-6);
-    pid_t         master_pid   = getpid();
-    pid_t         worker_pid   = getpid();
-    size_t        buffer_size  = 0;
-    string_t      command      = {};
-    std::set<int> signal_types = { SIGALRM };
+    string_t      shell_flags    = tim::get_env<string_t>("TIMEM_SHELL_FLAGS", "");
+    string_t      output_file    = tim::get_env<string_t>("TIMEM_OUTPUT", "");
+    double        sample_freq    = tim::get_env<double>("TIMEM_SAMPLE_FREQ", 5.0);
+    double        sample_delay   = tim::get_env<double>("TIMEM_SAMPLE_DELAY", 1.0e-6);
+    pid_t         master_pid     = getpid();
+    pid_t         worker_pid     = getpid();
+    size_t        buffer_size    = 0;
+    string_t      command        = {};
+    std::set<int> signal_types   = { SIGALRM };
     std::set<int> signal_forward = { SIGINT };
     std::vector<std::string>     argvector     = {};
     std::vector<hist_type>       history       = {};


### PR DESCRIPTION
Follow-up to #225. Turns out that:

- on Linux, components such as `cpu_util` (see [`times`](https://man7.org/linux/man-pages/man2/times.2.html) man pages) and `peak_rss` (see [`getrusage`](https://man7.org/linux/man-pages/man2/times.2.html) man pages) depend on children processes being waited on.
- `--flush-on-signal <int>` may result in children processes becoming zombie processes if `timem` gets the signal but its process group does not or children processes do not terminate on that signal.

This patch simply ensures the signal is forwarded. Whether children processes terminate or not it's up to their implementation. When they do, `timem` properly finishes waiting on them.