### PR TITLE
Respect CMAKE_CUDA_HOST_COMPILER

### DIFF
--- a/cmake/Modules/ConfigCUDA.cmake
+++ b/cmake/Modules/ConfigCUDA.cmake
@@ -154,11 +154,16 @@ if("CUDA" IN_LIST LANGUAGES)
         endif()
 
         if(NOT WIN32)
-            get_filename_component(_COMPILER_DIR "${CMAKE_CXX_COMPILER}" DIRECTORY)
+            if(NOT CMAKE_CUDA_HOST_COMPILER)
+              get_filename_component(_COMPILER_DIR "${CMAKE_CXX_COMPILER}" DIRECTORY)
+              target_compile_options(
+                  ${PROJECT_CUDA_INTERFACE_PREFIX}-cuda-compiler
+                  INTERFACE
+                      $<$<COMPILE_LANGUAGE:CUDA>:$<$<CUDA_COMPILER_ID:NVIDIA>:--compiler-bindir=${_COMPILER_DIR}>>)
+            endif()
             target_compile_options(
                 ${PROJECT_CUDA_INTERFACE_PREFIX}-cuda-compiler
                 INTERFACE
-                    $<$<COMPILE_LANGUAGE:CUDA>:$<$<CUDA_COMPILER_ID:NVIDIA>:--compiler-bindir=${_COMPILER_DIR}>>
                     $<$<COMPILE_LANGUAGE:CUDA>:$<$<CUDA_COMPILER_ID:NVIDIA>:-lineinfo>>)
         endif()
     endif()

--- a/cmake/Modules/ConfigCUDA.cmake
+++ b/cmake/Modules/ConfigCUDA.cmake
@@ -155,11 +155,12 @@ if("CUDA" IN_LIST LANGUAGES)
 
         if(NOT WIN32)
             if(NOT CMAKE_CUDA_HOST_COMPILER)
-              get_filename_component(_COMPILER_DIR "${CMAKE_CXX_COMPILER}" DIRECTORY)
-              target_compile_options(
-                  ${PROJECT_CUDA_INTERFACE_PREFIX}-cuda-compiler
-                  INTERFACE
-                      $<$<COMPILE_LANGUAGE:CUDA>:$<$<CUDA_COMPILER_ID:NVIDIA>:--compiler-bindir=${_COMPILER_DIR}>>)
+                get_filename_component(_COMPILER_DIR "${CMAKE_CXX_COMPILER}" DIRECTORY)
+                target_compile_options(
+                    ${PROJECT_CUDA_INTERFACE_PREFIX}-cuda-compiler
+                    INTERFACE
+                        $<$<COMPILE_LANGUAGE:CUDA>:$<$<CUDA_COMPILER_ID:NVIDIA>:--compiler-bindir=${_COMPILER_DIR}>>
+                    )
             endif()
             target_compile_options(
                 ${PROJECT_CUDA_INTERFACE_PREFIX}-cuda-compiler

--- a/cmake/Modules/ConfigCUDA.cmake
+++ b/cmake/Modules/ConfigCUDA.cmake
@@ -68,6 +68,7 @@ if("CUDA" IN_LIST LANGUAGES)
 
     target_compile_definitions(${PROJECT_CUDA_INTERFACE_PREFIX}-cuda
                                INTERFACE ${PROJECT_USE_CUDA_OPTION})
+
     target_include_directories(
         ${PROJECT_CUDA_INTERFACE_PREFIX}-cuda
         INTERFACE ${CUDA_INCLUDE_DIRS} ${CMAKE_CUDA_TOOLKIT_INCLUDE_DIRECTORIES})
@@ -80,11 +81,14 @@ if("CUDA" IN_LIST LANGUAGES)
                    INTERFACE_CUDA_SEPARABLE_COMPILATION ON)
 
     set(CUDA_AUTO_ARCH "auto")
+
     set(TIMEMORY_CUDA_ARCH
         "${CUDA_AUTO_ARCH}"
         CACHE STRING "CUDA architecture (options: ${TIMEMORY_CUDA_ARCH_LIST})")
+
     add_feature(TIMEMORY_CUDA_ARCH
                 "CUDA architecture (options: ${TIMEMORY_CUDA_ARCH_LIST})")
+
     set_property(CACHE TIMEMORY_CUDA_ARCH PROPERTY STRINGS ${TIMEMORY_CUDA_ARCH_LIST})
 
     set(_CUDA_ARCHES ${TIMEMORY_CUDA_ARCH})
@@ -154,18 +158,25 @@ if("CUDA" IN_LIST LANGUAGES)
         endif()
 
         if(NOT WIN32)
-            if(NOT CMAKE_CUDA_HOST_COMPILER)
-                get_filename_component(_COMPILER_DIR "${CMAKE_CXX_COMPILER}" DIRECTORY)
-                target_compile_options(
-                    ${PROJECT_CUDA_INTERFACE_PREFIX}-cuda-compiler
-                    INTERFACE
-                        $<$<COMPILE_LANGUAGE:CUDA>:$<$<CUDA_COMPILER_ID:NVIDIA>:--compiler-bindir=${_COMPILER_DIR}>>
-                    )
-            endif()
             target_compile_options(
                 ${PROJECT_CUDA_INTERFACE_PREFIX}-cuda-compiler
                 INTERFACE
                     $<$<COMPILE_LANGUAGE:CUDA>:$<$<CUDA_COMPILER_ID:NVIDIA>:-lineinfo>>)
+        endif()
+
+        # do not specify the --compiler-bindir in portable mode
+        if(NOT WIN32 AND NOT TIMEMORY_BUILD_PORTABLE)
+            # this complicated generator expression basically states: if compile language
+            # is CUDA and CUDA compiler ID is NVIDIA and CMAKE_CUDA_HOST_COMPILER is
+            # empty, then add the compiler flag --compiler-bindir=${CMAKE_CXX_COMPILER}.
+            # According to NVCC docs, despite the flags suggesting it wants a directory,
+            # you can specify the compiler executable to ensure that the correct compiler
+            # is selected
+            target_compile_options(
+                ${PROJECT_CUDA_INTERFACE_PREFIX}-cuda-compiler
+                INTERFACE
+                    $<$<COMPILE_LANGUAGE:CUDA>:$<$<CUDA_COMPILER_ID:NVIDIA>:$<IF:$<STREQUAL:CMAKE_CUDA_HOST_COMPILER,"">,--compiler-bindir=${CMAKE_CXX_COMPILER},>>>
+                )
         endif()
     endif()
 

--- a/cmake/Modules/MacroUtilities.cmake
+++ b/cmake/Modules/MacroUtilities.cmake
@@ -1488,4 +1488,14 @@ function(PRINT_FEATURES)
     print_disabled_interfaces()
 endfunction()
 
+# ----------------------------------------------------------------------------------------#
+# function timemory_get_enabled_languages() Gets the enabled languages property
+#
+function(timemory_get_enabled_languages _VAR)
+    get_property(_ENABLED_LANGUAGES GLOBAL PROPERTY ENABLED_LANGUAGES)
+    set(${_VAR}
+        ${_ENABLED_LANGUAGES}
+        PARENT_SCOPE)
+endfunction()
+
 cmake_policy(POP)

--- a/cmake/Modules/Options.cmake
+++ b/cmake/Modules/Options.cmake
@@ -130,7 +130,16 @@ timemory_test_find_package(libunwind _USE_LIBUNWIND)
 set(_REQUIRE_LIBUNWIND OFF)
 set(_HATCHET ${_UNIX_OS})
 
-# skip check_language if suppose to fail
+# once the cuda language is enabled, the CMAKE_CUDA_HOST_COMPILER variable is read-only
+# and change to it are undefined
+timemory_get_enabled_languages(TIMEMORY_ENABLED_LANGUAGES)
+if(NOT "CUDA" IN_LIST TIMEMORY_ENABLED_LANGUAGES
+   AND "$ENV{CUDAHOSTCXX}" STREQUAL ""
+   AND NOT DEFINED CMAKE_CUDA_HOST_COMPILER)
+    set(CMAKE_CUDA_HOST_COMPILER ${CMAKE_CXX_COMPILER})
+endif()
+
+# skip check_language if supposed to fail
 if(DEFINED TIMEMORY_USE_CUDA
    AND TIMEMORY_USE_CUDA
    AND TIMEMORY_REQUIRE_PACKAGES)


### PR DESCRIPTION
ConfigCUDA.cmake now respects the CMAKE_CUDA_HOST_COMPILER flag which is used to set the host compiler for nvcc (usually gcc or clang).